### PR TITLE
Offer alternative way to build in OpenShift

### DIFF
--- a/vars/stageStartOpenshiftBuild.groovy
+++ b/vars/stageStartOpenshiftBuild.groovy
@@ -1,0 +1,31 @@
+def call(def context) {
+  stage('Build Openshift Image') {
+    if (!context.environment) {
+      println("Skipping for empty environment ...")
+      return
+    }
+
+    timeout(context.openshiftBuildTimeout) {
+      patchBuildConfig(context)
+      sh "oc start-build ${context.componentId} --from-dir docker --follow -n ${context.targetProject}"
+    }
+  }
+}
+
+private void patchBuildConfig(def context) {
+  sh """oc patch bc ${context.componentId} --patch '
+   spec:
+     output:
+       to:
+         kind: ImageStreamTag
+         name: ${context.componentId}:${context.tagversion}
+     runPolicy: Serial
+     source:
+       type: Binary
+     strategy:
+       type: Docker
+       dockerstrategy: {}
+    ' -n ${context.targetProject}"""
+}
+
+return this

--- a/vars/stageUpdateOpenshiftBuild.groovy
+++ b/vars/stageUpdateOpenshiftBuild.groovy
@@ -8,7 +8,7 @@ def call(def context) {
     timeout(context.openshiftBuildTimeout) {
       sh "oc project ${context.targetProject}"
       patchBuildConfig(context)
-      sh "oc start-build ${context.componentId} -e projectId=${context.projectId} -e componentId=${context.componentId} -e tagversion=${context.tagversion} -e nexusHost=${context.nexusHost} -e nexusUsername=${context.nexusUsername} -e nexusPassword=${context.nexusPassword} --wait=true -n ${context.targetProject}"
+      sh "oc start-build ${context.componentId} -e projectId=${context.projectId} -e componentId=${context.componentId} -e tagversion=${context.tagversion} -e nexusHost=${context.nexusHost} -e nexusUsername=${context.nexusUsername} -e nexusPassword=${context.nexusPassword} --follow -n ${context.targetProject}"
     }
   }
 }


### PR DESCRIPTION
See https://github.com/opendevstack/ods-jenkins-shared-library/issues/3.

Instead of moving the artifacts to Docker via Nexus, we upload the
artifact directly. This should be a bit faster (as downloading is not
necessary), it should be less brittle (as paths in Jenkins and
Dockerfile do not need to match), requires less params (e.g. Nexus
credentials) and less code (as archiving is done automatically by OC).

Also, we now follow the build instead of simply waiting for it, removing
the need to go into OpenShift to see what happened with the build.

Addresses #3.

In a next step, all quickstarters should make use of the new stage.