### PR TITLE
Loosen check for branchToEnvironmentMapping

### DIFF
--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -25,7 +25,9 @@ class OdsContext implements Context {
     if (!config.image) {
       logger.error "Param 'image' is required"
     }
-    if (!config.branchToEnvironmentMapping) {
+    // branchToEnvironmentMapping must be given, but it is OK to be empty - e.g.
+    // if the repository should not be deployed to OpenShift at all.
+    if (!config.containsKey('branchToEnvironmentMapping')) {
       logger.error "Param 'branchToEnvironmentMapping' is required"
     }
 


### PR DESCRIPTION
`branchToEnvironmentMapping` must be given, but it is OK to be empty - e.g. if the repository should not be deployed to OpenShift at all.