### PR TITLE
Remove complicated / broken checkout logic

### DIFF
--- a/src/org/ods/Context.groovy
+++ b/src/org/ods/Context.groovy
@@ -12,8 +12,6 @@ interface Context {
 
     String getBuildUrl()
 
-    boolean getResponsible()
-
     String getImage()
 
     String getPodLabel()
@@ -29,8 +27,6 @@ interface Context {
     String getCredentialsId()
 
     String getGitUrl()
-
-    String getShortBranchName()
 
     String getTagversion()
 

--- a/src/org/ods/OdsPipeline.groovy
+++ b/src/org/ods/OdsPipeline.groovy
@@ -42,12 +42,6 @@ class OdsPipeline implements Serializable {
       }
     }
 
-    if (!context.responsible) {
-      script.currentBuild.result = 'ABORTED'
-      logger.info "***** Skipping ODS Pipeline *****"
-      return
-    }
-
     def msgBasedOn = ''
     if (context.image) {
       msgBasedOn = " based on image '${context.image}'"
@@ -63,8 +57,8 @@ class OdsPipeline implements Serializable {
         try {
           setBitbucketBuildStatus('INPROGRESS')
           script.wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
-            script.git url: context.gitUrl, branch: context.gitBranch, credentialsId: context.credentialsId
-            script.currentBuild.displayName = "${context.shortBranchName}/#${context.tagversion}"
+            script.checkout script.scm
+            script.currentBuild.displayName = "#${context.tagversion}"
             stages(context)
           }
           script.currentBuild.result = 'SUCCESS'


### PR DESCRIPTION
Once the webhook proxy is in place, we can simplify the shared library:

* No more responsibility check needed
* Git branch/commit determination can be easier and should now be actually correct in all cases