### PR TITLE
Allow to pass build args to the BuildConfig

### DIFF
--- a/vars/stageStartOpenshiftBuild.groovy
+++ b/vars/stageStartOpenshiftBuild.groovy
@@ -1,4 +1,4 @@
-def call(def context) {
+def call(def context, def buildArgs = [:]) {
   stage('Build Openshift Image') {
     if (!context.environment) {
       println("Skipping for empty environment ...")
@@ -6,17 +6,29 @@ def call(def context) {
     }
 
     timeout(context.openshiftBuildTimeout) {
-      patchBuildConfig(context)
+      patchBuildConfig(context, buildArgs)
       sh "oc start-build ${context.componentId} --from-dir docker --follow -n ${context.targetProject}"
     }
   }
 }
 
-private void patchBuildConfig(def context) {
-  sh """oc patch bc ${context.componentId} --type=json --patch '[
-    {"op": "replace", "path": "/spec/source", "value":{"type":"Binary"}},
-    {"op": "replace", "path": "/spec/output/to/name", "value":"${context.componentId}:${context.tagversion}"}
-    ]' -n ${context.targetProject}"""
+private void patchBuildConfig(def context, def buildArgs) {
+  def patches = [
+    '{"op": "replace", "path": "/spec/source", "value": {"type":"Binary"}}',
+    """{"op": "replace", "path": "/spec/output/to/name", "value": "${context.componentId}:${context.tagversion}"}"""
+  ]
+
+  def buildArgsItems = []
+  for (def key : buildArgs.keySet()) {
+    def val = buildArgs[key]
+    buildArgsItems.push("{\"name\": \"${key}\", \"value\": \"${val}\"}")
+  }
+  if (buildArgsItems.size() > 0) {
+    def buildArgsPatch = """{"op": "replace", "path": "/spec/strategy/dockerStrategy", "value": {"buildArgs": [${buildArgsItems.join(",")}]}}"""
+    patches.push(buildArgsPatch)
+  }
+
+  sh """oc patch bc ${context.componentId} --type=json --patch '[${patches.join(",")}]' -n ${context.targetProject}"""
 }
 
 return this

--- a/vars/stageStartOpenshiftBuild.txt
+++ b/vars/stageStartOpenshiftBuild.txt
@@ -1,0 +1,7 @@
+stageStartOpenshiftBuild triggers the BuildConfig related to the repository
+being built.
+
+stageStartOpenshiftBuild takes an optional "buildArgs" param, which is a map
+allowing to customise the image build step in OpenShift. For example:
+
+stageStartOpenshiftBuild(context, ["myArg":"val"])


### PR DESCRIPTION
Sometimes, users want to customize what build args are passed to the
BuildConfig, e.g. to set Nexus credentials.

Closes #61.