### PR TITLE
Move serviceAccount config to podTemplate

### DIFF
--- a/src/org/ods/Context.groovy
+++ b/src/org/ods/Context.groovy
@@ -24,6 +24,8 @@ interface Context {
 
     boolean getPodAlwaysPullImage()
 
+    String getPodServiceAccount()
+
     String getGitBranch()
 
     String getCredentialsId()

--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -103,6 +103,9 @@ class OdsContext implements Context {
     if (!config.containsKey('podAlwaysPullImage')) {
       config.podAlwaysPullImage = true
     }
+    if (!config.containsKey('podServiceAccount')) {
+      config.podServiceAccount = 'jenkins'
+    }
     if (!config.containsKey('podContainers')) {
       config.podContainers = [
         script.containerTemplate(
@@ -110,8 +113,7 @@ class OdsContext implements Context {
           image: config.image,
           workingDir: '/tmp',
           alwaysPullImage: config.podAlwaysPullImage,
-          args: '${computer.jnlpmac} ${computer.name}',
-          serviceAccount: 'jenkins'
+          args: '${computer.jnlpmac} ${computer.name}'
         )
       ]
     }
@@ -182,6 +184,10 @@ class OdsContext implements Context {
 
   boolean getPodAlwaysPullImage() {
     config.podAlwaysPullImage
+  }
+
+  String getPodServiceAccount() {
+    config.podServiceAccount
   }
 
   String getGitUrl() {

--- a/src/org/ods/OdsPipeline.groovy
+++ b/src/org/ods/OdsPipeline.groovy
@@ -51,7 +51,8 @@ class OdsPipeline implements Serializable {
       label: context.podLabel,
       cloud: 'openshift',
       containers: context.podContainers,
-      volumes: context.podVolumes
+      volumes: context.podVolumes,
+      serviceAccount: context.podServiceAccount
     ) {
       script.node(context.podLabel) {
         try {


### PR DESCRIPTION
Fixes #78.

I have no idea what I tested in the original PR - I definitely made sure everything still works but I cannot remember how I verified that it was running as Jenkins, and by the looks of it, I either looked at the wrong place or did not look at all. Confused .... sorry!

The change should work - `oc export` of a pod running against the new branch tells me:
```
schedulerName: default-scheduler
  securityContext:
    fsGroup: 1206650000
    seLinuxOptions:
      level: s0:c455,c40
  serviceAccount: jenkins
  serviceAccountName: jenkins
  terminationGracePeriodSeconds: 30
```

Also, build still works so I assume things are fine now.