### PR TITLE
Set memory explicitly

### DIFF
--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -115,6 +115,8 @@ class OdsContext implements Context {
           name: 'jnlp',
           image: config.image,
           workingDir: '/tmp',
+          resourceRequestMemory: '1Gi',
+          resourceLimitMemory: '2Gi',
           alwaysPullImage: config.podAlwaysPullImage,
           args: '${computer.jnlpmac} ${computer.name}'
         )


### PR DESCRIPTION
Recent changes on dedicated resulted in 512mb used for the slave pods.
That caused issues with NPM and Scala because they need more memory to
build.

And, to make things really crazy: it resulted in https://github.com/opendevstack/ods-project-quickstarters/pull/308
not actually using Java 8. This is because https://github.com/openshift/jenkins/blob/openshift-3.11/slave-base/contrib/bin/run-jnlp-client#L18-L35
uses the available memory as an input to select the Java version. It
will use i386 if less than 2Gi are available ...

Closes #114.

FYI @ManuelFeller @oalyman 