### PR TITLE
Fix cmd that copy files to default test location

### DIFF
--- a/src/org/ods/OdsPipeline.groovy
+++ b/src/org/ods/OdsPipeline.groovy
@@ -162,7 +162,7 @@ class OdsPipeline implements Serializable {
       } else 
       {
         // copy files to default location 
-        script.sh(script: "cp -rf ${context.getTestResults()}/* ${testLocation}/*", label : "Moving test results to expected location")
+        script.sh(script: "cp -rf ${context.getTestResults()}/* ${testLocation}", label : "Moving test results to expected location")
       }
     } 
     


### PR DESCRIPTION
Fix for https://github.com/opendevstack/ods-jenkins-shared-library/issues/132