### PR TITLE
fix: add resource cpu to container template

### DIFF
--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -122,6 +122,8 @@ class OdsContext implements Context {
           name: 'jnlp',
           image: config.image,
           workingDir: '/tmp',
+          resourceRequestCpu: '10m',
+          resourceLimitCpu: '300m',
           resourceRequestMemory: '1Gi',
           resourceLimitMemory: '2Gi',
           alwaysPullImage: config.podAlwaysPullImage,


### PR DESCRIPTION
specify cpu and memory for resource requests, otherwise the slave will try to reserve all available cpu
- set request cpu to 10 millicores
- set limit cpu to 300 millicores