### PR TITLE
Optionally check for status of quality gate

### DIFF
--- a/vars/stageScanForSonarqube.groovy
+++ b/vars/stageScanForSonarqube.groovy
@@ -1,40 +1,81 @@
-def call(def context) {
+def call(def context, def requireQualityGatePass = false) {
   if (context.sonarQubeBranch == '*' || context.sonarQubeBranch == context.gitBranch) {
     stage('SonarQube Analysis') {
       withSonarQubeEnv('SonarServerConfig') {
-        // debug mode
+
+        // Debug mode
         def debugMode = ""
         if (context.debug) {
           debugMode = "-X"
         }
-        // project version - this could be overwritten later by e.g. the MRO forced version
+
+        // Project version - this could be overwritten later by e.g. the MRO forced version
         def projectVersionParam = ""
         def propertiesContent = readFile('sonar-project.properties')
         if (!propertiesContent.contains('sonar.projectVersion=')) {
           projectVersionParam = "-Dsonar.projectVersion=${context.gitCommit.take(8)}"
         }
-        // scan
+
+        // Scan
         def scannerBinary = "sonar-scanner"
         def status = sh(returnStatus: true, script: "which ${scannerBinary}", label : "finding scanner binary")
         if (status != 0) {
           def scannerHome = tool 'SonarScanner'
           scannerBinary = "${scannerHome}/bin/sonar-scanner"
         }
-        sh (script: "${scannerBinary} ${debugMode} ${projectVersionParam}", label : "SQ scanning")
-		
-		    // generate and archive cnes report
-        // we need to get the SQ project name as people could modify it
-        sqProps = readProperties file: 'sonar-project.properties'
-            sonarProjectKey = sqProps['sonar.projectKey']
-            targetSQreport = "SCRR-" + sonarProjectKey + ".docx"
+        sh (
+          label : "SQ scanning",
+          script: "${scannerBinary} ${debugMode} ${projectVersionParam}"
+        )
+
+        // Generate and archive cnes report.
+        // We need to get the SQ project name as it might have been modified.
+        def sqProps = readProperties file: 'sonar-project.properties'
+        def sonarProjectKey = sqProps['sonar.projectKey']
+        def targetSQreport = "SCRR-" + sonarProjectKey + ".docx"
         withEnv (["SQ_PROJECT=${sonarProjectKey}", "TARGET_SQ_REPORT=${targetSQreport}"]) {
-              sh (script: "java -jar /usr/local/cnes/cnesreport.jar -s $SONAR_HOST_URL -t $SONAR_AUTH_TOKEN -p $SQ_PROJECT", label : "generate SCR Report")
-              sh (script: "mkdir -p artifacts", label : "create artifacts folder")
-              sh (script: "mv *-analysis-report.docx* artifacts/", label : "move SCRR to artifacts dir")
-              sh (script: "mv artifacts/*-analysis-report.docx* artifacts/$TARGET_SQ_REPORT", label : "rename to SCRR")
-              archiveArtifacts "artifacts/SCRR*"
-              stash(name: "scrr-report-${context.componentId}-${context.buildNumber}", includes: 'artifacts/SCRR*', allowEmpty : true)
-              context.addArtifactURI("SCRR", targetSQreport)
+          sh(
+            label : "Generate CNES Report",
+            script: "java -jar /usr/local/cnes/cnesreport.jar -s $SONAR_HOST_URL -t $SONAR_AUTH_TOKEN -p $SQ_PROJECT"
+          )
+          sh(
+            label : "Create artifacts dir",
+            script: "mkdir -p artifacts"
+          )
+          sh(
+            label : "Move report to artifacts dir",
+            script: "mv *-analysis-report.docx* artifacts/"
+          )
+          sh(
+            label : "Rename report to SCRR",
+            script: "mv artifacts/*-analysis-report.docx* artifacts/$TARGET_SQ_REPORT"
+          )
+          archiveArtifacts "artifacts/SCRR*"
+          stash(
+            name: "scrr-report-${context.componentId}-${context.buildNumber}",
+            includes: 'artifacts/SCRR*',
+            allowEmpty : true
+          )
+          context.addArtifactURI("SCRR", targetSQreport)
+        }
+
+        // Check quality gate status
+        if (requireQualityGatePass) {
+          def qualityGateJson = sh(
+            label: "Get status of quality gate",
+            script: "curl -s -u $SONAR_AUTH_TOKEN: $SONAR_HOST_URL/api/qualitygates/project_status?projectKey=$sonarProjectKey",
+            returnStdout: true
+          )
+          try {
+            def qualityGateResult = readJSON text: qualityGateJson
+            if (qualityGateResult["projectStatus"]["projectStatus"] == "ERROR") {
+              error "Quality gate failed!"
+            } else {
+              echo "Quality gate passed."
+            }
+          } catch (Exception ex) {
+            error "Quality gate status could not be retrieved. Status was: '${qualityGateJson}'. Error was: ${ex}"
+          }
         }
       }
     }


### PR DESCRIPTION
Closes #22.

Because any execution of `sonar-scanner` returns with exit code 0, we must explicitly ask for the status of the quality gate. What exactly the quality gate is (the rules/conditions that determine pass/fail) is completely in the hands of SonarQube, so there is no need to configure anything in Jenkins. The feature is opt-in right now.

PR includes some minor code massaging that does not change functionality.