### PR TITLE
Improve clone script development

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -216,6 +216,9 @@ When you write stages, you have access to both global variables (defined without
 | targetProject
 | Target project, based on the environment. E.g. "foo-dev".
 
+| cloneProjectScriptBranch
+| Branch on `ods-core` used for the `clone-project.sh` and dependent scripts. Default is `production`.
+
 | groupId
 | Group ID, defaults to: org.opendevstack.+++<projectID>+++.+++</projectID>+++
 

--- a/src/org/ods/Context.groovy
+++ b/src/org/ods/Context.groovy
@@ -80,6 +80,12 @@ interface Context {
     // Set the environment to clone
     void setCloneSourceEnv( String cloneSourceEnv)
 
+    // The branch in which the clone-project.sh script is used
+    String getCloneProjectScriptBranch()
+
+    Map<String, String> getCloneProjectScriptUrls()
+
+
     // The environment which was chosen as the deployment target, e.g. "dev".
     String getEnvironment()
 

--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -83,6 +83,9 @@ class OdsContext implements Context {
     if (!config.containsKey('autoCloneEnvironmentsFromSourceMapping')) {
       config.autoCloneEnvironmentsFromSourceMapping = [:]
     }
+    if (!config.containsKey('cloneProjectScriptBranch')) {
+      config.cloneProjectScriptBranch = 'production'
+    }
     if (!config.containsKey('sonarQubeBranch')) {
       config.sonarQubeBranch = 'master'
     }
@@ -266,6 +269,10 @@ class OdsContext implements Context {
 
   void setCloneSourceEnv(String cloneSourceEnv) {
     config.cloneSourceEnv = cloneSourceEnv
+  }
+
+  String getCloneProjectScriptBranch() {
+    config.cloneProjectScriptBranch
   }
 
   String getEnvironment() {
@@ -556,6 +563,17 @@ class OdsContext implements Context {
       return ""
     }
     return tokens[1]
+  }
+
+  Map<String, String> getCloneProjectScriptUrls() {
+    def scripts = ['clone-project.sh', 'import-project.sh',  'export-project.sh']
+    def m = [:]
+    def branch = getCloneProjectScriptBranch().replace('/','%2F')
+    for (script in scripts) {
+      def url = "https://bitbucket.bix-digital.com/projects/OPENDEVSTACK/repos/ods-core/raw/ocp-scripts/${script}?at=refs%2Fheads%2F${branch}"
+      m.put(script, url)
+    }
+    return m
   }
 
   public Map<String, String> getBuildArtifactURIs() {

--- a/src/org/ods/OdsPipeline.groovy
+++ b/src/org/ods/OdsPipeline.groovy
@@ -268,12 +268,11 @@ class OdsPipeline implements Serializable {
       script.withCredentials([script.usernameColonPassword(credentialsId: context.credentialsId, variable: 'USERPASS')]) {
         def userPass = script.USERPASS.replace('$', '\'$\'')
         def branchName = "${script.env.JOB_NAME}-${script.env.BUILD_NUMBER}-${context.cloneSourceEnv}"
-        logger.info 'Calculated branch name: ${branchName}'
+        logger.info "Calculated branch name: ${branchName}"
         def scriptToUrls = context.getCloneProjectScriptUrls()
-        for ( e in scriptToUrls) {
-          def script = e.key
-          def url = e.value
-          script.sh(script: "curl --fail -s --user ${userPass} -G '${url}' -d raw -o '${script}'")
+        // NOTE: a for loop did not work here due to https://issues.jenkins-ci.org/browse/JENKINS-49732
+        scriptToUrls.each { scriptName, url ->
+          script.sh(script: "curl --fail -s --user ${userPass} -G '${url}' -d raw -o '${scriptName}'")
         }
         def debugMode = ""
         if (context.getDebug()) {

--- a/src/org/ods/OdsPipeline.groovy
+++ b/src/org/ods/OdsPipeline.groovy
@@ -267,10 +267,14 @@ class OdsPipeline implements Serializable {
       logger.info 'Environment does not exist yet. Creating now ...'
       script.withCredentials([script.usernameColonPassword(credentialsId: context.credentialsId, variable: 'USERPASS')]) {
         def userPass = script.USERPASS.replace('$', '\'$\'')
-        def cloneProjectScriptUrl = "https://${context.bitbucketHost}/projects/opendevstack/repos/ods-core/raw/ocp-scripts/clone-project.sh?at=refs%2Fheads%2Fproduction"
         def branchName = "${script.env.JOB_NAME}-${script.env.BUILD_NUMBER}-${context.cloneSourceEnv}"
         logger.info 'Calculated branch name: ${branchName}'
-        script.sh(script: "curl --fail -s --user ${userPass} -G '${cloneProjectScriptUrl}' -d raw -o clone-project.sh")
+        def scriptToUrls = context.getCloneProjectScriptUrls()
+        for ( e in scriptToUrls) {
+          def script = e.key
+          def url = e.value
+          script.sh(script: "curl --fail -s --user ${userPass} -G '${url}' -d raw -o '${script}'")
+        }
         def debugMode = ""
         if (context.getDebug()) {
           debugMode = "--debug"

--- a/test/org/ods/PipelineScript.groovy
+++ b/test/org/ods/PipelineScript.groovy
@@ -5,7 +5,8 @@ class PipelineScript {
 
     def env = [
             'BUILD_ID'   : 15,
-            'BRANCH_NAME': 'PR-10'
+            'BRANCH_NAME': 'PR-10',
+            'JOB_NAME': 'foo-cd/foo-cd-JOB-10',
     ]
 
     def scm


### PR DESCRIPTION
This provides a new configuration entry `cloneProjectScriptBranch` in the odsPipeline which defined the branch to use when assembling the clone script and its dependencies. For example this can look like this:

```groovy
odsPipeline(
  image: "${dockerRegistry}/cd/jenkins-slave-python:1.2.x",
  projectId: projectId,
  componentId: componentId,
  cloneProjectScriptBranch: 'feature/jsl-167-improve-clone-script-dev',
```

The default value of `cloneProjectScriptBranch` is `production`. 

To work this will also require https://github.com/opendevstack/ods-core/pull/348 to be merged.

Note that this still relies on curl to get the scripts. Alternatives for using curl such as git to checkout a subdirectory or using svn export which appears to be available on GitHub have been discussed but appear to be less desirable.

The changes have been tested on our internal cluster.

Closes #167 