### PR TITLE
Expose bitbucketUrl, taken from BITBUCKET_URL if present

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -276,8 +276,11 @@ When you write stages, you have access to both global variables (defined without
 | odsSharedLibVersion
 | ODS Jenkins shared library version, taken from reference in Jenkinsfile.
 
+| bitbucketUrl
+| BitBucket URL - value taken from BITBUCKET_URL. If BITBUCKET_URL is not present, it will default to https://<BITBUCKET_HOST>.
+
 | bitbucketHost
-| BitBucket host - value taken from BITBUCKET_HOST.
+| BitBucket host - value taken from bitbucketUrl.
 
 | environmentCreated
 | Whether an environment has been created during the build.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -280,7 +280,7 @@ When you write stages, you have access to both global variables (defined without
 | BitBucket URL - value taken from BITBUCKET_URL. If BITBUCKET_URL is not present, it will default to https://<BITBUCKET_HOST>.
 
 | bitbucketHost
-| BitBucket host - value taken from bitbucketUrl.
+| BitBucket host - value derived from bitbucketUrl.
 
 | environmentCreated
 | Whether an environment has been created during the build.

--- a/src/org/ods/Context.groovy
+++ b/src/org/ods/Context.groovy
@@ -148,8 +148,11 @@ interface Context {
     // ODS Jenkins shared library version, taken from reference in Jenkinsfile.
     String getOdsSharedLibVersion()
 
-    // BitBucket host - value taken from BITBUCKET_HOST.
+    // BitBucket host - value taken from BITBUCKET_URL.
     String getBitbucketHost()
+
+    // BitBucket URL - value taken from BITBUCKET_URL.
+    String getBitbucketUrl()
 
     // Timeout for the OpenShift build of the container image in minutes.
     int getOpenshiftBuildTimeout()

--- a/src/org/ods/Context.groovy
+++ b/src/org/ods/Context.groovy
@@ -148,11 +148,11 @@ interface Context {
     // ODS Jenkins shared library version, taken from reference in Jenkinsfile.
     String getOdsSharedLibVersion()
 
-    // BitBucket host - value taken from BITBUCKET_URL.
-    String getBitbucketHost()
-
     // BitBucket URL - value taken from BITBUCKET_URL.
     String getBitbucketUrl()
+
+    // BitBucket host - value derived from getBitbucketUrl.
+    String getBitbucketHost()
 
     // Timeout for the OpenShift build of the container image in minutes.
     int getOpenshiftBuildTimeout()

--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -384,12 +384,12 @@ class OdsContext implements Context {
     config.odsSharedLibVersion
   }
 
-  String getBitbucketHost() {
-    config.bitbucketHost
-  }
-
   String getBitbucketUrl() {
     config.bitbucketUrl
+  }
+
+  String getBitbucketHost() {
+    config.bitbucketHost
   }
 
   int getOpenshiftBuildTimeout() {

--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -44,7 +44,15 @@ class OdsContext implements Context {
     config.nexusUsername = script.env.NEXUS_USERNAME
     config.nexusPassword = script.env.NEXUS_PASSWORD
     config.openshiftHost = script.env.OPENSHIFT_API_URL
-    config.bitbucketHost = script.env.BITBUCKET_HOST
+
+    if (script.env.BITBUCKET_URL) {
+      config.bitbucketUrl = script.env.BITBUCKET_URL
+      config.bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
+    } else if (script.env.BITBUCKET_HOST) {
+      config.bitbucketHost = script.env.BITBUCKET_HOST
+      config.bitbucketUrl = "https://${config.bitbucketHost}"
+    }
+
     config.odsSharedLibVersion = script.sh(script: "env | grep 'library.ods-library.version' | cut -d= -f2", returnStdout: true, label : 'getting ODS shared lib version').trim()
 
     logger.debug "Validating environment variables ..."
@@ -66,8 +74,8 @@ class OdsContext implements Context {
     if (!config.openshiftHost) {
       logger.error 'OPENSHIFT_API_URL is required, but not set'
     }
-    if (!config.bitbucketHost) {
-      logger.error 'BITBUCKET_HOST is required, but not set'
+    if (!config.bitbucketUrl) {
+      logger.error 'BITBUCKET_URL is required, but not set'
     }
     if (!config.buildUrl) {
       logger.info 'BUILD_URL is required to set a proper build status in ' +
@@ -377,7 +385,11 @@ class OdsContext implements Context {
   }
 
   String getBitbucketHost() {
-      config.bitbucketHost
+    config.bitbucketHost
+  }
+
+  String getBitbucketUrl() {
+    config.bitbucketUrl
   }
 
   int getOpenshiftBuildTimeout() {

--- a/src/org/ods/OdsPipeline.groovy
+++ b/src/org/ods/OdsPipeline.groovy
@@ -186,7 +186,7 @@ class OdsPipeline implements Serializable {
     if (!context.getBitbucketNotificationEnabled()) {
       return
     }
-    if (!context.jobName || !context.tagversion || !context.credentialsId || !context.buildUrl || !context.bitbucketHost || !context.gitCommit) {
+    if (!context.jobName || !context.tagversion || !context.credentialsId || !context.buildUrl || !context.bitbucketUrl || !context.gitCommit) {
       logger.info "Cannot set BitBucket build status to ${state} because required data is missing!"
       return
     }
@@ -205,7 +205,7 @@ class OdsPipeline implements Serializable {
             --request POST \\
             --header \"Content-Type: application/json\" \\
             --data '{\"state\":\"${state}\",\"key\":\"${buildName}\",\"name\":\"${buildName}\",\"url\":\"${context.buildUrl}\"}' \\
-            https://${context.bitbucketHost}/rest/build-status/1.0/commits/${context.gitCommit}
+            ${context.bitbucketUrl}/rest/build-status/1.0/commits/${context.gitCommit}
           """
         }
         return


### PR DESCRIPTION
Following this, we should update ods-core to set BITBUCKET_URL instead of
BITBUCKET_HOST. Older projects still using BITBUCKET_HOST will continue
to work as HTTPS is already assumed at the moment.

Therefore, I consider this a non-breaking change. It should not be
needed to run any migration script to convert old projects as HTTPS
should be used in real environments anyway, the HTTP variant only exists
for (temporary) testing/local environments.

Addresses one part of #74.