### PR TITLE
Add nexusUrl in favour of nexusHost

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -201,8 +201,11 @@ When you write stages, you have access to both global variables (defined without
 | notifyNotGreen
 | Whether to send notifications if the build is not successful.
 
+| nexusUrl
+| Nexus URL (with scheme).
+
 | nexusHost
-| Nexus host (with scheme).
+| Nexus host (without scheme).
 
 | nexusUsername
 | Nexus username.
@@ -210,8 +213,8 @@ When you write stages, you have access to both global variables (defined without
 | nexusPassword
 | Nexus password.
 
-| nexusHostWithBasicAuth
-| Nexus host (with scheme), including username and password as BasicAuth.
+| nexusUrlWithBasicAuth
+| Nexus URL (with scheme), including username and password as BasicAuth.
 
 | branchToEnvironmentMapping
 | Define which branches are deployed to which environments.

--- a/src/org/ods/Context.groovy
+++ b/src/org/ods/Context.groovy
@@ -64,7 +64,10 @@ interface Context {
     // Enable/disable notifications
     void setNotifyNotGreen(boolean notifyNotGreen)
 
-    // Nexus host (with scheme).
+    // Nexus URL (with scheme).
+    String getNexusUrl()
+
+    // Nexus host (without scheme).
     String getNexusHost()
 
     // Nexus username.
@@ -73,8 +76,8 @@ interface Context {
     // Nexus password.
     String getNexusPassword()
 
-    // Nexus host (with scheme), including username and password as BasicAuth.
-    String getNexusHostWithBasicAuth()
+    // Nexus URL (with scheme), including username and password as BasicAuth.
+    String getNexusUrlWithBasicAuth()
 
     // Define which branches are deployed to which environments.
     String getBranchToEnvironmentMapping()

--- a/src/org/ods/OdsContext.groovy
+++ b/src/org/ods/OdsContext.groovy
@@ -40,9 +40,18 @@ class OdsContext implements Context {
     config.buildNumber = script.env.BUILD_NUMBER
     config.buildUrl = script.env.BUILD_URL
     config.buildTime = new Date()
-    config.nexusHost = script.env.NEXUS_HOST
+
+    if (script.env.NEXUS_URL) {
+      config.nexusUrl = script.env.NEXUS_URL
+      config.nexusHost = config.nexusUrl.minus(~/^https?:\/\//)
+    } else if (script.env.NEXUS_HOST) {
+      // Weirdly, NEXUS_HOST contained the scheme as well ...
+      config.nexusUrl = script.env.NEXUS_HOST
+      config.nexusHost = config.nexusUrl.minus(~/^https?:\/\//)
+    }
     config.nexusUsername = script.env.NEXUS_USERNAME
     config.nexusPassword = script.env.NEXUS_PASSWORD
+
     config.openshiftHost = script.env.OPENSHIFT_API_URL
     config.bitbucketHost = script.env.BITBUCKET_HOST
     config.odsSharedLibVersion = script.sh(script: "env | grep 'library.ods-library.version' | cut -d= -f2", returnStdout: true, label : 'getting ODS shared lib version').trim()
@@ -54,8 +63,8 @@ class OdsContext implements Context {
     if (!config.buildNumber) {
       logger.error 'BUILD_NUMBER is required, but not set (usually provided by Jenkins)'
     }
-    if (!config.nexusHost) {
-      logger.error 'NEXUS_HOST is required, but not set'
+    if (!config.nexusUrl) {
+      logger.error 'NEXUS_URL is required, but not set'
     }
     if (!config.nexusUsername) {
       logger.error 'NEXUS_USERNAME is required, but not set'
@@ -276,6 +285,10 @@ class OdsContext implements Context {
     config.notifyNotGreen = notifyNotGreen
   }
 
+  String getNexusUrl() {
+      config.nexusUrl
+  }
+
   String getNexusHost() {
       config.nexusHost
   }
@@ -288,8 +301,8 @@ class OdsContext implements Context {
       config.nexusPassword
   }
 
-  String getNexusHostWithBasicAuth() {
-    config.nexusHost.replace("://", "://${config.nexusUsername}:${config.nexusPassword}@")
+  String getNexusUrlWithBasicAuth() {
+    config.nexusUrl.replace("://", "://${config.nexusUsername}:${config.nexusPassword}@")
   }
 
   String getBranchToEnvironmentMapping() {

--- a/vars/stageScanForSnyk.groovy
+++ b/vars/stageScanForSnyk.groovy
@@ -16,7 +16,7 @@ def call(def context, def snykAuthenticationCode, def buildFile, def organisatio
     stage('Snyk Security Scan') {
       withEnv(["SNYK_AUTHENTICATION_CODE=${snykAuthenticationCode}", "PROJECT_NAME=${context.targetProject}",
                "COMPONENT_NAME=${context.componentId}", "BUILD_FILE=${buildFile}", "ORGANISATION=${organisation}",
-               "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}"]) {
+               "NEXUS_URL=${context.nexusUrl}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}"]) {
         // Verify that snyk is installed
         def status = sh(script: "snyk version", returnStatus: true, label : "getting snyk version")
         if (status != 0) {

--- a/vars/stageUploadToNexus.groovy
+++ b/vars/stageUploadToNexus.groovy
@@ -1,7 +1,7 @@
 def call(def context) {
   stage('Upload to Nexus') {
     def distFile = "${context.componentId}-${context.tagversion}.tar.gz"
-    sh "curl -u ${context.nexusUsername}:${context.nexusPassword} --upload-file ${distFile} ${context.nexusHost}/repository/candidates/${context.groupId.replace('.', '/')}/${context.componentId}/${context.tagversion}/${distFile}"
+    sh "curl -u ${context.nexusUsername}:${context.nexusPassword} --upload-file ${distFile} ${context.nexusUrl}/repository/candidates/${context.groupId.replace('.', '/')}/${context.componentId}/${context.tagversion}/${distFile}"
   }
 }
 


### PR DESCRIPTION
nexusHost contained the value of NEXUS_HOST previously, which, despite
its name, contained not just the host but also the scheme part.

For consistency, we now prefer NEXUS_URL, and expose this as nexusUrl.
nexusHost will now NOT include the scheme anymore. This is a breaking
change. Users of ODS will be affected and need to update their
Jenkinsfiles accordingly. There is no way to make this non-breaking, we
could only delay the impact by setting NEXUS_HOST/nexusHost to the same
value as nexusUrl, but that would be weird end end up being a breaking
change when we adapt it to be host only in the future.

Addresses part of #74.

There will need to be follow-up PRs in ods-quickstarters and ods-core.

I do not see a way to make this non-breaking (different to #182, which does not have that problem). If you have ideas, please mention them. FYI @tjaeschke @clemensutschig @metmajer @hugowschneider 