### PR TITLE
Convert Snyk stage to new style

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -340,10 +340,12 @@ class Context implements IContext {
     config.groupId
   }
 
+  @NonCPS
   String getProjectId() {
     config.projectId
   }
 
+  @NonCPS
   String getComponentId() {
     config.componentId
   }
@@ -376,6 +378,7 @@ class Context implements IContext {
     config.sonarQubeBranch = sonarQubeBranch
   }
 
+  @NonCPS
   String getFailOnSnykScanVulnerabilities() {
     config.failOnSnykScanVulnerabilities
   }

--- a/src/org/ods/component/ScanWithSnykStage.groovy
+++ b/src/org/ods/component/ScanWithSnykStage.groovy
@@ -1,0 +1,88 @@
+package org.ods.component
+
+import org.ods.services.SnykService
+
+class ScanWithSnykStage extends Stage {
+  protected String STAGE_NAME = 'Snyk Security Scan'
+  protected SnykService snyk
+
+  ScanWithSnykStage(def script, IContext context, Map config, SnykService snyk) {
+    super(script, context, config)
+    if (!config.containsKey('failOnVulnerabilities')) {
+      config.failOnVulnerabilities = context.failOnSnykScanVulnerabilities
+    }
+    if (!config.organisation) {
+      config.organisation = context.projectId
+    }
+    if (!config.projectName) {
+      config.projectName = context.componentId
+    }
+    if (!config.buildFile) {
+      config.buildFile = 'build.gradle'
+    }
+    this.snyk = snyk
+  }
+
+  def run() {
+    if (!config.snykAuthenticationCode) {
+      script.error "Option 'snykAuthenticationCode' is not set!"
+    }
+
+    def message = "Snyk scan mode: build will " + (config.failOnVulnerabilities ? "" : "not ") +
+      "fail if vulnerabilities are found (failOnVulnerabilities=${config.failOnVulnerabilities})!"
+    script.echo message
+
+    if (!snyk.version()) {
+      script.error 'Snyk binary is not in $PATH'
+    }
+
+    if (!snyk.auth(config.snykAuthenticationCode)) {
+      script.error 'Snyk auth failed'
+    }
+
+    boolean testSuccess
+
+    def envVariables = [
+      "NEXUS_HOST=${context.nexusHost}",
+      "NEXUS_USERNAME=${context.nexusUsername}",
+      "NEXUS_PASSWORD=${context.nexusPassword}"
+    ]
+    script.withEnv(envVariables) {
+      if (!snyk.monitor(config.organisation, config.buildFile, config.projectName)) {
+        script.error 'Snyk monitor failed'
+      }
+
+      testSuccess = snyk.test(config.organisation, config.buildFile)
+      if (testSuccess) {
+        script.echo 'No vulnerabilities detected.'
+      } else {
+        script.echo 'Snyk test detected vulnerabilities.'
+      }
+    }
+
+    generateAndArchiveReport()
+
+    if (!testSuccess && config.failOnVulnerabilities) {
+      script.error 'Snyk scan stage failed. See snyk report for details.'
+    }
+  }
+
+  private generateAndArchiveReport() {
+    def targetReport = "SCSR-${context.projectId}-${context.componentId}-${snyk.reportFile}"
+    script.sh(
+      label: 'Create artifacts dir',
+      script: 'mkdir -p artifacts/SCSR'
+    )
+    script.sh(
+      label: 'Rename report to SCSR',
+      script: "mv ${snyk.reportFile} artifacts/${targetReport}"
+    )
+    script.archiveArtifacts(artifacts: 'artifacts/SCSR*')
+    script.stash(
+      name: "scrr-report-${context.componentId}-${context.buildNumber}",
+      includes: 'artifacts/SCSR*',
+      allowEmpty: true
+    )
+    context.addArtifactURI('SCSR', targetReport)
+  }
+}

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -1,0 +1,48 @@
+package org.ods.services
+
+class SnykService {
+
+  private def script
+  private String reportFile
+
+  SnykService(def script, String reportFile) {
+    this.script = script
+    this.reportFile = reportFile
+  }
+
+  String getReportFile() {
+    reportFile
+  }
+
+  boolean version() {
+    script.sh(
+      script: "snyk version | tee -a ${reportFile}",
+      returnStatus: true,
+      label: "Get Snyk version"
+    ) == 0
+  }
+
+  boolean auth(String authCode) {
+    script.sh(
+      script: "snyk auth ${authCode} | tee -a ${reportFile}",
+      returnStatus: true,
+      label: "Authenticate with Snyk server"
+    ) == 0
+  }
+
+  boolean monitor(String organisation, String buildFile, String projectName) {
+    script.sh(
+      script: "snyk monitor --org=${organisation} --file=${buildFile} --project-name=${projectName} --all-sub-projects | tee -a ${reportFile}",
+      returnStatus: true,
+      label: "Start monitoring ${projectName} in Snyk"
+    ) == 0
+  }
+
+  boolean test(String organisation, String buildFile) {
+    script.sh(
+      script: "snyk test --org=${organisation} --file=${buildFile} --all-sub-projects | tee -a ${reportFile}",
+      returnStatus: true,
+      label: "Run Snyk test"
+    ) == 0
+  }
+}

--- a/test/groovy/vars/OdsComponentStageScanWithSnykSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSnykSpec.groovy
@@ -1,0 +1,90 @@
+package vars
+
+ import org.ods.component.Logger
+ import org.ods.component.Context
+ import org.ods.component.IContext
+ import org.ods.services.SnykService
+ import org.ods.services.ServiceRegistry
+ import vars.test_helper.PipelineSpockTestBase
+ import spock.lang.*
+
+ class OdsComponentStageScanWithSnykSpec extends PipelineSpockTestBase {
+
+   private Logger logger = Mock(Logger)
+
+   @Shared
+   def config = [
+       projectId: 'foo',
+       componentId: 'bar',
+       nexusHost: 'https;//nexus.example.com',
+       nexusUsername: 'developer',
+       nexusPassword: 's3cr3t',
+       buildNumber: '42'
+   ]
+
+   def "run successfully"() {
+     given:
+     IContext context = new Context(null, config, logger)
+     SnykService snykService = Stub(SnykService.class)
+     snykService.version() >> true
+     snykService.auth(*_) >> true
+     snykService.monitor(*_) >> true
+     snykService.test(*_) >> true
+     ServiceRegistry.instance.add(SnykService, snykService)
+
+     when:
+     def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
+     helper.registerAllowedMethod('withEnv', [ List, Closure ]) { List args, Closure block -> block() }
+     helper.registerAllowedMethod('archiveArtifacts', [ Map ]) { Map args -> }
+     helper.registerAllowedMethod('stash', [ Map ]) { Map args -> }
+     script.call(context, [
+       failOnVulnerabilities: true,
+       snykAuthenticationCode: 's3cr3t'
+      ])
+
+     then:
+     printCallStack()
+     assertJobStatusSuccess()
+   }
+
+   @Unroll
+   def "may fail"() {
+     given:
+     IContext context = new Context(null, config, logger)
+     SnykService snykService = Stub(SnykService.class)
+     snykService.version() >> versionOk
+     snykService.auth(*_) >> authOk
+     snykService.monitor(*_) >> monitorOk
+     snykService.test(*_) >> testOk
+     ServiceRegistry.instance.add(SnykService, snykService)
+
+     when:
+     def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
+     helper.registerAllowedMethod('withEnv', [ List, Closure ]) { List args, Closure block -> block() }
+     helper.registerAllowedMethod('archiveArtifacts', [ Map ]) { Map args -> }
+     helper.registerAllowedMethod('stash', [ Map ]) { Map args -> }
+     script.call(context, [
+       failOnVulnerabilities: failOnVulnerabilities,
+       snykAuthenticationCode: 's3cr3t'
+      ])
+
+     then:
+     printCallStack()
+     assertCallStackContains(message)
+     if (expectedToFail) {
+       assertJobStatusFailure()
+     } else {
+       assertJobStatusSuccess()
+     }
+
+     where:
+     versionOk | authOk | monitorOk | testOk | failOnVulnerabilities || expectedToFail | message
+     false     | true   | true      | true   | true                  || true           | 'Snyk binary is not in $PATH'
+     true      | false  | true      | true   | true                  || true           | 'Snyk auth failed'
+     true      | true   | false     | true   | true                  || true           | 'Snyk monitor failed'
+     true      | true   | true      | true   | true                  || false          | 'No vulnerabilities detected'
+     true      | true   | true      | false  | false                 || false          | 'Snyk test detected vulnerabilities'
+     true      | true   | true      | false  | true                  || true           | 'Snyk scan stage failed'
+   }
+
+ }

--- a/vars/odsComponentStageScanWithSnyk.groovy
+++ b/vars/odsComponentStageScanWithSnyk.groovy
@@ -1,0 +1,15 @@
+import org.ods.component.ScanWithSnykStage
+import org.ods.component.IContext
+
+import org.ods.services.SnykService
+import org.ods.services.ServiceRegistry
+
+def call(IContext context, Map config = [:]) {
+    def snykService = ServiceRegistry.instance.get(SnykService)
+    if (!snykService) {
+        snykService = new SnykService('snyk-report.txt')
+    }
+    def stage = new ScanWithSnykStage(this, context, config, snykService)
+    stage.execute()
+}
+return this

--- a/vars/odsComponentStageScanWithSnyk.groovy
+++ b/vars/odsComponentStageScanWithSnyk.groovy
@@ -7,7 +7,7 @@ import org.ods.services.ServiceRegistry
 def call(IContext context, Map config = [:]) {
     def snykService = ServiceRegistry.instance.get(SnykService)
     if (!snykService) {
-        snykService = new SnykService('snyk-report.txt')
+        snykService = new SnykService(this, 'snyk-report.txt')
     }
     def stage = new ScanWithSnykStage(this, context, config, snykService)
     stage.execute()

--- a/vars/stageScanForSnyk.groovy
+++ b/vars/stageScanForSnyk.groovy
@@ -1,91 +1,13 @@
 def call(def context, def snykAuthenticationCode, def buildFile, def organisation) {
-
-  withStage('Snyk Security Scan', context) {
-
-    if (!snykAuthenticationCode) {
-      error "missing snyk authentication code (parameter snykAuthenticationCode is null or false)"
-    }
-    if (!organisation) {
-      error "missing organisation (parameter organisation is null or false)"
-    }
-
-    String message = "Snyk scan mode: build will " + (context.failOnSnykScanVulnerabilities ? "" : "not ") +
-        "fail if vulnerabilities are found (failOnSnykScanVulnerabilities=${context.failOnSnykScanVulnerabilities})!"
-    println(message)
-
-    if (!buildFile) {
-      error "build file definition for snyk security scan is null!"
-    } else {
-
-      String snykReport = "snyk-report.txt";
-      withEnv(["SNYK_AUTHENTICATION_CODE=${snykAuthenticationCode}", "PROJECT_NAME=${context.targetProject}", "SNYK_REPORT=${snykReport}",
-               "COMPONENT_NAME=${context.componentId}", "BUILD_FILE=${buildFile}", "ORGANISATION=${organisation}",
-               "NEXUS_HOST=${context.nexusHost}", "NEXUS_USERNAME=${context.nexusUsername}", "NEXUS_PASSWORD=${context.nexusPassword}"]) {
-
-        boolean failed = false;
-        String errorMessage = null;
-
-        // Verify that snyk is installed
-        def status = sh(script: "snyk version | tee -a $SNYK_REPORT", returnStatus: true, label: "getting snyk version")
-        if (status != 0) {
-          failed = true;
-          errorMessage = "snyk is not installed!"
-        }
-
-        // Authorise snyk
-        if (!failed) {
-          // TODO do we need to report auth call?!
-          status = sh(script: "snyk auth $SNYK_AUTHENTICATION_CODE | tee -a $SNYK_REPORT", returnStatus: true, label: "authenticating to snyk")
-          if (status != 0) {
-            failed = true;
-            errorMessage = "snyh auth failed!"
-          }
-        }
-
-        // Monitor project
-        if (!failed) {
-          status = sh(script: "snyk monitor --org=$ORGANISATION --file=$BUILD_FILE --project-name=$COMPONENT_NAME --all-sub-projects | tee -a $SNYK_REPORT", returnStatus: true, label: "start monitoring in snyk")
-          if (status != 0) {
-            failed = true;
-            errorMessage = "snyk monitor command failed!"
-          }
-        }
-
-        // fail if vulnerabilites are found!
-        if (!failed) {
-          status = sh(script: "snyk test --org=$ORGANISATION --file=$BUILD_FILE --all-sub-projects | tee -a $SNYK_REPORT", returnStatus: true, label: "run snyk test")
-          if (status != 0) {
-            failed = true;
-            errorMessage = "snyk test command failed!"
-          }
-        }
-
-        def projectKey = context.componentId
-        def targetSQreport = "SCSR-" + context.projectId + "-" + projectKey + "-" + snykReport
-        withEnv(["SQ_PROJECT=${projectKey}", "TARGET_SQ_REPORT=${targetSQreport}", "SNYK_REPORT=${snykReport}"]) {
-          sh(
-              label: "Create artifacts dir",
-              script: "mkdir -p artifacts/SCSR"
-          )
-          sh(
-              label: "Rename report to SCSR",
-              script: "mv $SNYK_REPORT artifacts/$TARGET_SQ_REPORT && ls -lart . && ls -lart artifacts/SCSR"
-          )
-          archiveArtifacts "artifacts/SCSR*"
-          stash(
-              name: "scrr-report-${context.componentId}-${context.buildNumber}",
-              includes: 'artifacts/SCSR*',
-              allowEmpty: true
-          )
-          context.addArtifactURI("SCSR", targetSQreport)
-        }
-
-        if (failed && context.failOnSnykScanVulnerabilities) {
-          error "snyk scan stage failed (see snyk report for details) due: " + errorMessage
-        }
-      }
-    }
-  }
+  echo "'stageScanForSnyk' has been replaced with 'odsComponentScanWithSnyk', please use that instead."
+  odsComponentScanWithSnyk(
+    context,
+    [
+      snykAuthenticationCode: snykAuthenticationCode,
+      buildFile: buildFile,
+      organisation: organisation
+    ]
+  )
 }
 
 return this

--- a/vars/stageScanForSnyk.groovy
+++ b/vars/stageScanForSnyk.groovy
@@ -1,6 +1,6 @@
 def call(def context, def snykAuthenticationCode, def buildFile, def organisation) {
-  echo "'stageScanForSnyk' has been replaced with 'odsComponentScanWithSnyk', please use that instead."
-  odsComponentScanWithSnyk(
+  echo "'stageScanForSnyk' has been replaced with 'odsComponentStageScanWithSnyk', please use that instead."
+  odsComponentStageScanWithSnyk(
     context,
     [
       snykAuthenticationCode: snykAuthenticationCode,


### PR DESCRIPTION
This commit also adapts the behaviour: previously the stage would only
fail if `failOnSnykScanVulnerabilities` was `true` and `snyk test` failed.

Now the stage fails on every error within the stage, such as `snyk auth`
failing, regardless if `failOnSnykScanVulnerabilities` is `true` or not.

Setting `failOnSnykScanVulnerabilities` to `false` only prevents an
error when `snyk test` fails.

Further, the stage now allows to override the `--project-name` flag
(which is defaulted to `componentId`), and it adds more defaults
(`projectId` for `organisation` and `build.gradle` for `buildFile`).