### PR TITLE
Add quickstarter pipeline

### DIFF
--- a/src/org/ods/quickstarter/CheckoutStage.groovy
+++ b/src/org/ods/quickstarter/CheckoutStage.groovy
@@ -1,0 +1,13 @@
+package org.ods.quickstarter
+
+class CheckoutStage extends Stage {
+  protected String STAGE_NAME = 'Checkout quickstarter'
+
+  CheckoutStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+  }
+
+  def run() {
+    script.checkout script.scm
+  }
+}

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -37,8 +37,8 @@ class Context implements IContext {
   }
 
   @NonCPS
-  String getQuickstarterId() {
-    config.quickstarterId
+  String getSourceDir() {
+    config.sourceDir
   }
 
   @NonCPS
@@ -57,8 +57,8 @@ class Context implements IContext {
   }
 
   @NonCPS
-  String getOutputDir() {
-    config.outputDir
+  String getTargetDir() {
+    config.targetDir
   }
 
   @NonCPS

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -10,18 +10,22 @@ class Context implements IContext {
     this.config = config
   }
 
+  @NonCPS
   String getJobName() {
     config.jobName
   }
 
+  @NonCPS
   String getBuildNumber() {
     config.buildNumber
   }
 
+  @NonCPS
   String getBuildUrl() {
     config.buildUrl
   }
 
+  @NonCPS
   String getBuildTime() {
     config.buildTime
   }

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -1,0 +1,79 @@
+package org.ods.quickstarter
+
+import com.cloudbees.groovy.cps.NonCPS
+
+class Context implements IContext {
+
+  private Map config
+
+  Context(Map config) {
+    this.config = config
+  }
+
+  String getJobName() {
+    config.jobName
+  }
+
+  String getBuildNumber() {
+    config.buildNumber
+  }
+
+  String getBuildUrl() {
+    config.buildUrl
+  }
+
+  String getBuildTime() {
+    config.buildTime
+  }
+
+  @NonCPS
+  String getProjectId() {
+    config.projectId
+  }
+
+  @NonCPS
+  String getComponentId() {
+    config.componentId
+  }
+
+  @NonCPS
+  String getQuickstarterId() {
+    config.quickstarterId
+  }
+
+  @NonCPS
+  String getGitUrlHttp() {
+    config.gitUrlHttp
+  }
+
+  @NonCPS
+  String getOdsImageTag() {
+    config.odsImageTag
+  }
+
+  @NonCPS
+  String getOdsGitRef() {
+    config.odsGitRef
+  }
+
+  @NonCPS
+  String getOutputDir() {
+    config.outputDir
+  }
+
+  @NonCPS
+  String getPackageName() {
+    config.packageName
+  }
+
+  @NonCPS
+  String getGroup() {
+    config.group
+  }
+
+  @NonCPS
+  String getCdUserCredentialsId() {
+    config.cdUserCredentialsId
+  }
+
+}

--- a/src/org/ods/quickstarter/CopyFilesStage.groovy
+++ b/src/org/ods/quickstarter/CopyFilesStage.groovy
@@ -9,8 +9,8 @@ class CopyFilesStage extends Stage {
 
   def run() {
     script.sh(
-      script: "cp -rv ${context.quickstarterId}/files/. ${context.outputDir}",
-      label: "Copy files from '${context.quickstarterId}/files' to '${context.outputDir}'"
+      script: "cp -rv ${context.sourceDir}/files/. ${context.targetDir}",
+      label: "Copy files from '${context.sourceDir}/files' to '${context.targetDir}'"
     )
   }
 }

--- a/src/org/ods/quickstarter/CopyFilesStage.groovy
+++ b/src/org/ods/quickstarter/CopyFilesStage.groovy
@@ -1,0 +1,16 @@
+package org.ods.quickstarter
+
+class CopyFilesStage extends Stage {
+  protected String STAGE_NAME = 'Copy files from quickstarter'
+
+  CopyFilesStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+  }
+
+  def run() {
+    script.sh(
+      script: "cp -rv ${context.quickstarterId}/files/. ${context.outputDir}",
+      label: "Copy files from '${context.quickstarterId}/files' to '${context.outputDir}'"
+    )
+  }
+}

--- a/src/org/ods/quickstarter/CreateOpenShiftResourcesStage.groovy
+++ b/src/org/ods/quickstarter/CreateOpenShiftResourcesStage.groovy
@@ -1,0 +1,43 @@
+package org.ods.quickstarter
+
+class CreateOpenShiftResourcesStage extends Stage {
+  protected String STAGE_NAME = 'Create OpenShift resources'
+
+  CreateOpenShiftResourcesStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+    if (!config.directory) {
+      config.directory = "${context.sourceDir}/openshift"
+    }
+    if (!config.envFile) {
+      config.envFile = "${context.sourceDir}/ocp.env"
+    }
+    if(!config.selector) {
+      config.selector = "app=${context.projectId}-${context.componentId}"
+    }
+  }
+
+  def run() {
+    ['dev', 'test'].each { env ->
+      def namespace = "${context.projectId}-${env}"
+
+      def tailorParams = [
+        "--upsert-only",
+        "--selector ${config.selector}",
+        "--param=PROJECT=${context.projectId}",
+        "--param=COMPONENT=${context.componentId}",
+        "--param=ENV=${env}"
+      ]
+
+      if (script.fileExists(config.envFile)) {
+        tailorParams << "--param-file ${script.env.WORKSPACE}/${config.envFile}"
+      }
+
+      script.dir(config.directory) {
+        script.sh(
+          script: "tailor --non-interactive -n ${namespace} apply ${tailorParams.join(' ')}",
+          label: "Create component ${context.componentId} in namespace ${namespace}"
+        )
+      }
+    }
+  }
+}

--- a/src/org/ods/quickstarter/CreateOutputDirectoryStage.groovy
+++ b/src/org/ods/quickstarter/CreateOutputDirectoryStage.groovy
@@ -1,0 +1,16 @@
+package org.ods.quickstarter
+
+class CreateOutputDirectoryStage extends Stage {
+  protected String STAGE_NAME = 'Initialize output directory'
+
+  CreateOutputDirectoryStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+  }
+
+  def run() {
+    script.sh(
+      script: "mkdir -p ${context.outputDir}",
+      label: "Create directory '${context.outputDir}'"
+    )
+  }
+}

--- a/src/org/ods/quickstarter/CreateOutputDirectoryStage.groovy
+++ b/src/org/ods/quickstarter/CreateOutputDirectoryStage.groovy
@@ -9,8 +9,8 @@ class CreateOutputDirectoryStage extends Stage {
 
   def run() {
     script.sh(
-      script: "mkdir -p ${context.outputDir}",
-      label: "Create directory '${context.outputDir}'"
+      script: "mkdir -p ${context.targetDir}",
+      label: "Create directory '${context.targetDir}'"
     )
   }
 }

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -20,8 +20,8 @@ interface IContext {
   // Component ID, e.g. "be-auth-service".
   String getComponentId()
 
-  // Quickstarter ID, e.g. "be-golang-plain".
-  String getQuickstarterId()
+  // Source directory, e.g. "be-golang-plain".
+  String getSourceDir()
 
   String getGitUrlHttp()
 
@@ -29,7 +29,7 @@ interface IContext {
 
   String getOdsGitRef()
 
-  String getOutputDir()
+  String getTargetDir()
 
   String getPackageName()
 

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -1,0 +1,39 @@
+package org.ods.quickstarter
+
+interface IContext {
+
+  // Value of JOB_NAME. It is the name of the project of the build.
+  String getJobName()
+
+  // Value of BUILD_NUMBER. The current build number, such as "153".
+  String getBuildNumber()
+
+  // Value of BUILD_URL. The URL where the results of the build can be found (e.g. http://buildserver/jenkins/job/MyJobName/123/)
+  String getBuildUrl()
+
+  // Time of the build, collected when the odsPipeline starts.
+  String getBuildTime()
+
+  // Project ID, e.g. "foo".
+  String getProjectId()
+
+  // Component ID, e.g. "be-auth-service".
+  String getComponentId()
+
+  // Quickstarter ID, e.g. "be-golang-plain".
+  String getQuickstarterId()
+
+  String getGitUrlHttp()
+
+  String getOdsImageTag()
+
+  String getOdsGitRef()
+
+  String getOutputDir()
+
+  String getPackageName()
+
+  String getGroup()
+
+  String getCdUserCredentialsId()
+}

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -1,0 +1,122 @@
+package org.ods.quickstarter
+
+class Pipeline implements Serializable {
+
+  private def script
+  private Map config
+
+  Pipeline(def script, Map config) {
+    this.script = script
+    this.config = config
+  }
+
+  def execute(Closure block) {
+    // build params
+    checkRequiredBuildParams()
+    config.odsImageTag = script.env.ODS_IMAGE_TAG ?: 'latest'
+    config.odsGitRef = script.env.ODS_GIT_REF ?: 'production'
+    config.projectId = script.env.PROJECT_ID
+    config.componentId = script.env.COMPONENT_ID.toLowerCase()
+    config.gitUrlHttp = script.env.GIT_URL_HTTP
+    config.packageName = script.env.PACKAGE_NAME
+    config.group = script.env.GROUP_ID
+
+    // config options
+    if (!config.quickstarterId) {
+      script.error "Config option 'quickstarterId' is required but not given!"
+    }
+    if (!config.image && !config.podContainers) {
+      script.error "Config option 'image' or 'podContainers' is required but not given!"
+    }
+    if (!config.cdUserCredentialsId) {
+      config.cdUserCredentialsId = "${config.projectId}-cd-cd-user-with-password"
+    }
+    if (!config.outputDir) {
+      config.outputDir = 'out'
+    }
+    if (!config.podVolumes) {
+      config.podVolumes = []
+    }
+
+    // vars from jenkins master
+    def gitHost
+    script.node {
+      gitHost =  script.env.BITBUCKET_HOST.split(":")[0]
+      config.jobName = script.env.JOB_NAME
+      config.buildNumber = script.env.BUILD_NUMBER
+      config.buildUrl = script.env.BUILD_URL
+      config.buildTime = new Date()
+    }
+
+    onAgentNode(config) { context ->
+      new CheckoutStage(script, context).execute()
+      new CreateOutputDirectoryStage(script, context).execute()
+
+      // Execute user-defined stages.
+      block(context)
+
+      new PushToRemoteStage(script, context, [gitHost: gitHost]).execute()
+    }
+  }
+
+  private def checkRequiredBuildParams() {
+    def requiredParams = ['PROJECT_ID', 'COMPONENT_ID', 'GIT_URL_HTTP']
+    for (def i = 0; i < requiredParams.size(); i++) {
+      def param = requiredParams[i]
+      if (!script.env[param]) {
+        script.error "Build param '${param}' is required but not given!"
+      }
+    }
+  }
+
+  private def onAgentNode(Map config, Closure block) {
+    if (!config.podContainers) {
+      if (!config.containsKey('alwaysPullImage')) {
+        config.alwaysPullImage = true
+      }
+      if (!config.podServiceAccount) {
+        config.podServiceAccount = 'jenkins'
+      }
+      if (!config.resourceRequestMemory) {
+        config.resourceRequestMemory = '512Mi'
+      }
+      if (!config.resourceLimitMemory) {
+        config.resourceLimitMemory = '1Gi'
+      }
+      if (!config.resourceRequestCpu) {
+        config.resourceRequestCpu = '100m'
+      }
+      if (!config.resourceLimitCpu) {
+        config.resourceLimitCpu = '1'
+      }
+      config.podContainers = [
+        script.containerTemplate(
+          name: 'jnlp',
+          image: config.image,
+          workingDir: '/tmp',
+          alwaysPullImage: config.alwaysPullImage,
+          resourceRequestMemory: config.resourceRequestMemory,
+          resourceLimitMemory: config.resourceLimitMemory,
+          resourceRequestCpu: config.resourceRequestCpu,
+          resourceLimitCpu: config.resourceLimitCpu,
+          args: ''
+        )
+      ]
+    }
+
+    def podLabel = "quickstarter-${config.quickstarterId}-${config.projectId}-${config.componentId}"
+
+    script.podTemplate(
+      label: podLabel,
+      cloud: 'openshift',
+      containers: config.podContainers,
+      volumes: config.podVolumes,
+      serviceAccount: config.podServiceAccount
+    ) {
+      script.node(podLabel) {
+        IContext context = new Context(config)
+        block(context)
+      }
+    }
+  }
+}

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -25,8 +25,8 @@ class Pipeline implements Serializable {
     if (!config.quickstarterId) {
       script.error "Config option 'quickstarterId' is required but not given!"
     }
-    if (!config.image && !config.podContainers) {
-      script.error "Config option 'image' or 'podContainers' is required but not given!"
+    if (!config.image && !config.imageStreamTag && !config.podContainers) {
+      script.error "One of 'image', 'imageStreamTag' or 'podContainers' is required but not given!"
     }
     if (!config.cdUserCredentialsId) {
       config.cdUserCredentialsId = "${config.projectId}-cd-cd-user-with-password"
@@ -46,6 +46,7 @@ class Pipeline implements Serializable {
       config.buildNumber = script.env.BUILD_NUMBER
       config.buildUrl = script.env.BUILD_URL
       config.buildTime = new Date()
+      config.dockerRegistry = script.env.DOCKER_REGISTRY
     }
 
     onAgentNode(config) { context ->
@@ -88,6 +89,9 @@ class Pipeline implements Serializable {
       }
       if (!config.resourceLimitCpu) {
         config.resourceLimitCpu = '1'
+      }
+      if (!config.image) {
+        config.image = "${config.dockerRegistry}/${config.imageStreamTag}"
       }
       config.podContainers = [
         script.containerTemplate(

--- a/src/org/ods/quickstarter/PushToRemoteStage.groovy
+++ b/src/org/ods/quickstarter/PushToRemoteStage.groovy
@@ -1,0 +1,46 @@
+package org.ods.quickstarter
+
+class PushToRemoteStage extends Stage {
+  protected String STAGE_NAME = 'Push to remote'
+
+  PushToRemoteStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+    if (!config.branch) {
+      config.branch = 'master'
+    }
+  }
+
+  def run() {
+    script.withCredentials([script.usernamePassword(credentialsId: context.cdUserCredentialsId, passwordVariable: 'pass', usernameVariable: 'user')]) {
+      script.writeFile file: "/home/jenkins/.netrc", text: "machine ${config.gitHost} login ${script.user} password ${script.pass}"
+    }
+
+    script.dir(context.outputDir) {
+      script.sh(
+        script: """
+        # Clone first (there is ALWAYS a remote repo!)
+        git clone ${context.gitUrlHttp}
+        basename=\$(basename ${context.gitUrlHttp})
+        clonedGitFolderName=\${basename%.*}
+        files=\$(ls \$clonedGitFolderName | grep -v ^l | wc -l)
+        if [ \$files == 0 ]; then 
+          echo "Init project from scratch \$(pwd)"
+          git init .
+          git remote add origin ${context.gitUrlHttp}
+        else
+          echo "Upgrading existing project: ${context.gitUrlHttp}"
+          mv "\$clonedGitFolderName"/* .
+          mv "\$clonedGitFolderName"/.[!.]* .
+        fi
+        git config user.email "undefined"
+        git config user.name "ODS System User"
+        rm -rf \$clonedGitFolderName
+        git add --all .
+        git commit -m "Initial OpenDevStack commit"
+        git push -u origin ${config.branch}
+        """,
+        label: "Push to remote"
+      )
+    }
+  }
+}

--- a/src/org/ods/quickstarter/PushToRemoteStage.groovy
+++ b/src/org/ods/quickstarter/PushToRemoteStage.groovy
@@ -15,7 +15,7 @@ class PushToRemoteStage extends Stage {
       script.writeFile file: "/home/jenkins/.netrc", text: "machine ${config.gitHost} login ${script.user} password ${script.pass}"
     }
 
-    script.dir(context.outputDir) {
+    script.dir(context.targetDir) {
       script.sh(
         script: """
         # Clone first (there is ALWAYS a remote repo!)

--- a/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
+++ b/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
@@ -1,0 +1,26 @@
+package org.ods.quickstarter
+
+class RenderJenkinsfileStage extends Stage {
+  protected String STAGE_NAME = 'Create Jenkinsfile'
+
+  RenderJenkinsfileStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+    if (!config.source) {
+      config.source = 'Jenkinsfile.template'
+    }
+    if (!config.target) {
+      config.target = 'Jenkinsfile'
+    }
+  }
+
+  def run() {
+    def source = "${context.quickstarterId}/${config.source}"
+    def target = "${context.outputDir}/${config.target}"
+    script.sh(
+      script: """
+      sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.quickstarterId}|g; s|@git_url_http@|${context.gitUrlHttp}|g;  s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g' ${source} > ${target}
+      """,
+      label: "Render '${config.source}' to '${config.target}'"
+    )
+  }
+}

--- a/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
+++ b/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
@@ -14,11 +14,11 @@ class RenderJenkinsfileStage extends Stage {
   }
 
   def run() {
-    def source = "${context.quickstarterId}/${config.source}"
-    def target = "${context.outputDir}/${config.target}"
+    def source = "${context.sourceDir}/${config.source}"
+    def target = "${context.targetDir}/${config.target}"
     script.sh(
       script: """
-      sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.quickstarterId}|g; s|@git_url_http@|${context.gitUrlHttp}|g;  s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g' ${source} > ${target}
+      sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.sourceDir}|g; s|@git_url_http@|${context.gitUrlHttp}|g;  s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g' ${source} > ${target}
       """,
       label: "Render '${config.source}' to '${config.target}'"
     )

--- a/src/org/ods/quickstarter/RenderSonarPropertiesStage.groovy
+++ b/src/org/ods/quickstarter/RenderSonarPropertiesStage.groovy
@@ -14,8 +14,8 @@ class RenderSonarPropertiesStage extends Stage {
   }
 
   def run() {
-    def source = "${context.quickstarterId}/${config.source}"
-    def target = "${context.outputDir}/${config.target}"
+    def source = "${context.sourceDir}/${config.source}"
+    def target = "${context.targetDir}/${config.target}"
     script.sh(
       script: """
       sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g' ${source} > ${target}

--- a/src/org/ods/quickstarter/RenderSonarPropertiesStage.groovy
+++ b/src/org/ods/quickstarter/RenderSonarPropertiesStage.groovy
@@ -1,0 +1,26 @@
+package org.ods.quickstarter
+
+class RenderSonarPropertiesStage extends Stage {
+  protected String STAGE_NAME = 'Create sonar-project.properties'
+
+  RenderSonarPropertiesStage(def script, IContext context, Map config = [:]) {
+    super(script, context, config)
+    if (!config.source) {
+      config.source = 'sonar-project.properties.template'
+    }
+    if (!config.target) {
+      config.target = 'sonar-project.properties'
+    }
+  }
+
+  def run() {
+    def source = "${context.quickstarterId}/${config.source}"
+    def target = "${context.outputDir}/${config.target}"
+    script.sh(
+      script: """
+      sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g' ${source} > ${target}
+      """,
+      label: "Render '${config.source}' to '${config.target}'"
+    )
+  }
+}

--- a/src/org/ods/quickstarter/Stage.groovy
+++ b/src/org/ods/quickstarter/Stage.groovy
@@ -1,0 +1,21 @@
+package org.ods.quickstarter
+
+class Stage {
+  protected def script
+  protected def context
+  protected Map config
+
+  protected String STAGE_NAME = 'NOT SET'
+
+  Stage(def script, IContext context, Map config) {
+    this.script = script
+    this.context = context
+    this.config = config
+  }
+
+  def execute() {
+    script.echo "**** STARTING stage '${STAGE_NAME}' ****"
+    this.run()
+    script.echo "**** ENDED stage '${STAGE_NAME}' ****"
+  }
+}

--- a/test/groovy/vars/OdsQuickstarterStageCopyFilesSpec.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageCopyFilesSpec.groovy
@@ -10,8 +10,8 @@ class OdsQuickstarterStageCopyFilesSpec extends PipelineSpockTestBase {
   def "run successfully"() {
     given:
     def config = [
-        quickstarterId: 'be-golang-plain',
-        outputDir: 'out'
+        sourceDir: 'be-golang-plain',
+        targetDir: 'out'
     ]
     IContext context = new Context(config)
 

--- a/test/groovy/vars/OdsQuickstarterStageCopyFilesSpec.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageCopyFilesSpec.groovy
@@ -1,0 +1,27 @@
+package vars
+
+import org.ods.quickstarter.Context
+import org.ods.quickstarter.IContext
+import vars.test_helper.PipelineSpockTestBase
+import spock.lang.*
+
+class OdsQuickstarterStageCopyFilesSpec extends PipelineSpockTestBase {
+
+  def "run successfully"() {
+    given:
+    def config = [
+        quickstarterId: 'be-golang-plain',
+        outputDir: 'out'
+    ]
+    IContext context = new Context(config)
+
+    when:
+    def script = loadScript('vars/odsQuickstarterStageCopyFiles.groovy')
+    script.call(context)
+
+    then:
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+}

--- a/test/groovy/vars/OdsQuickstarterStageCreateOpenShiftResources.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageCreateOpenShiftResources.groovy
@@ -1,0 +1,30 @@
+package vars
+
+import org.ods.quickstarter.Context
+import org.ods.quickstarter.IContext
+import vars.test_helper.PipelineSpockTestBase
+import spock.lang.*
+
+class OdsQuickstarterStageCreateOpenShiftResourcesSpec extends PipelineSpockTestBase {
+
+  def "run successfully"() {
+    given:
+    def config = [
+        sourceDir: 'be-golang-plain',
+        targetDir: 'out',
+        projectId: 'foo',
+        componentId: 'bar'
+    ]
+    IContext context = new Context(config)
+
+    when:
+    def script = loadScript('vars/odsQuickstarterStageCreateOpenShiftResources.groovy')
+    helper.registerAllowedMethod("fileExists", [ String ]) { true }
+    script.call(context)
+
+    then:
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+}

--- a/test/groovy/vars/OdsQuickstarterStageRenderJenkinsfileSpec.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageRenderJenkinsfileSpec.groovy
@@ -1,0 +1,32 @@
+package vars
+
+import org.ods.quickstarter.Context
+import org.ods.quickstarter.IContext
+import vars.test_helper.PipelineSpockTestBase
+import spock.lang.*
+
+class OdsQuickstarterStageRenderJenkinsfileSpec extends PipelineSpockTestBase {
+
+  def "run successfully"() {
+    given:
+    def config = [
+        projectId: 'foo',
+        componentId: 'bar',
+        quickstarterId: 'be-golang-plain',
+        outputDir: 'out',
+        gitUrlHttp: 'https://bitbucket.example.com/scm/foo/bar.git',
+        odsImageTag: '2.x',
+        odsGitRef: '2.x'
+    ]
+    IContext context = new Context(config)
+
+    when:
+    def script = loadScript('vars/odsQuickstarterStageRenderJenkinsfile.groovy')
+    script.call(context)
+
+    then:
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+}

--- a/test/groovy/vars/OdsQuickstarterStageRenderJenkinsfileSpec.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageRenderJenkinsfileSpec.groovy
@@ -12,8 +12,8 @@ class OdsQuickstarterStageRenderJenkinsfileSpec extends PipelineSpockTestBase {
     def config = [
         projectId: 'foo',
         componentId: 'bar',
-        quickstarterId: 'be-golang-plain',
-        outputDir: 'out',
+        sourceDir: 'be-golang-plain',
+        targetDir: 'out',
         gitUrlHttp: 'https://bitbucket.example.com/scm/foo/bar.git',
         odsImageTag: '2.x',
         odsGitRef: '2.x'

--- a/test/groovy/vars/OdsQuickstarterStageRenderSonarPropertiesSpec.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageRenderSonarPropertiesSpec.groovy
@@ -1,0 +1,32 @@
+package vars
+
+import org.ods.quickstarter.Context
+import org.ods.quickstarter.IContext
+import vars.test_helper.PipelineSpockTestBase
+import spock.lang.*
+
+class OdsQuickstarterStageRenderSonarPropertiesSpec extends PipelineSpockTestBase {
+
+  def "run successfully"() {
+    given:
+    def config = [
+        projectId: 'foo',
+        componentId: 'bar',
+        quickstarterId: 'be-golang-plain',
+        outputDir: 'out',
+        gitUrlHttp: 'https://bitbucket.example.com/scm/foo/bar.git',
+        odsImageTag: '2.x',
+        odsGitRef: '2.x'
+    ]
+    IContext context = new Context(config)
+
+    when:
+    def script = loadScript('vars/odsQuickstarterStageRenderSonarProperties.groovy')
+    script.call(context)
+
+    then:
+    printCallStack()
+    assertJobStatusSuccess()
+  }
+
+}

--- a/test/groovy/vars/OdsQuickstarterStageRenderSonarPropertiesSpec.groovy
+++ b/test/groovy/vars/OdsQuickstarterStageRenderSonarPropertiesSpec.groovy
@@ -12,8 +12,8 @@ class OdsQuickstarterStageRenderSonarPropertiesSpec extends PipelineSpockTestBas
     def config = [
         projectId: 'foo',
         componentId: 'bar',
-        quickstarterId: 'be-golang-plain',
-        outputDir: 'out',
+        sourceDir: 'be-golang-plain',
+        targetDir: 'out',
         gitUrlHttp: 'https://bitbucket.example.com/scm/foo/bar.git',
         odsImageTag: '2.x',
         odsGitRef: '2.x'

--- a/vars/odsQuickstarterPipeline.groovy
+++ b/vars/odsQuickstarterPipeline.groovy
@@ -1,0 +1,9 @@
+import org.ods.quickstarter.Pipeline
+
+def call(Map config, Closure body) {
+
+  def pipeline = new Pipeline(this, config)
+  pipeline.execute(body)
+}
+
+return this

--- a/vars/odsQuickstarterStageCopyFiles.groovy
+++ b/vars/odsQuickstarterStageCopyFiles.groovy
@@ -1,0 +1,8 @@
+import org.ods.quickstarter.CopyFilesStage
+import org.ods.quickstarter.IContext
+
+def call(IContext context, Map config = [:]) {
+    def stage = new CopyFilesStage(this, context, config)
+    stage.execute()
+}
+return this

--- a/vars/odsQuickstarterStageCreateOpenShiftResources.groovy
+++ b/vars/odsQuickstarterStageCreateOpenShiftResources.groovy
@@ -1,0 +1,8 @@
+import org.ods.quickstarter.CreateOpenShiftResourcesStage
+import org.ods.quickstarter.IContext
+
+def call(IContext context, Map config = [:]) {
+    def stage = new CreateOpenShiftResourcesStage(this, context, config)
+    stage.execute()
+}
+return this

--- a/vars/odsQuickstarterStageRenderJenkinsfile.groovy
+++ b/vars/odsQuickstarterStageRenderJenkinsfile.groovy
@@ -1,0 +1,8 @@
+import org.ods.quickstarter.RenderJenkinsfileStage
+import org.ods.quickstarter.IContext
+
+def call(IContext context, Map config = [:]) {
+    def stage = new RenderJenkinsfileStage(this, context, config)
+    stage.execute()
+}
+return this

--- a/vars/odsQuickstarterStageRenderSonarProperties.groovy
+++ b/vars/odsQuickstarterStageRenderSonarProperties.groovy
@@ -1,0 +1,8 @@
+import org.ods.quickstarter.RenderSonarPropertiesStage
+import org.ods.quickstarter.IContext
+
+def call(IContext context, Map config = [:]) {
+    def stage = new RenderSonarPropertiesStage(this, context, config)
+    stage.execute()
+}
+return this


### PR DESCRIPTION
Implements a new pipeline that can be used to provision quickstarters.

It uses the same style as the new "component pipeline", with some simplifications. For now, this pipeline has only been used for the Go quickstarter (https://github.com/opendevstack/ods-quickstarters/pull/222). I'll convert the other ones after this PR is merged .. in the process, I might need to do some minor adjustments to the pipeline.

To visualise what a new `Jenkinsfile` looks like, here's the one from Go (updated):
```
def odsGitRef = env.ODS_GIT_REF ?: 'production'
def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
library("ods-jenkins-shared-library@${odsGitRef}")

odsQuickstarterPipeline(
  imageStreamTag: "cd/jenkins-slave-golang:${odsImageTag}",
) { context ->

  odsQuickstarterStageCopyFiles(context)

  stage('Write go.mod') {
    dir(context.targetDir) {
      sh "echo 'module example.com/${context.projectId}/${context.componentId}' > go.mod"
      sh "echo '' >> go.mod"
      sh "echo 'go 1.12' >> go.mod"
    }
  }

  odsQuickstarterStageCreateOpenShiftResources(
    context,
    [directory: 'common/ocp-config/component-environment']
  )

  odsQuickstarterStageRenderJenkinsfile(context)

  odsQuickstarterStageRenderSonarProperties(context)
}
```

Some observations:
* I noticed that the way I implemented it, we basically don't need the `IContext` as `Context` is just data access. Thoughts on this?
* ~There's some boilerplate around the image (`dockerRegistry`/`odsImageTag`). I guess we can get rid of it, but might be a bit of magic~
* ~The `quickstarterId` is required right now - that could also be read from the pipeline itself - it has `jenkinsfilePath: "be-golang-plain/Jenkinsfile"` set. I might default to that, and allow people to override?~
* ~Setting up OpenShift resources will likely be similar across most quickstarters. Maybe we can simplify that too - but unsure what the right level of abstraction is. Right now I'm leaving that for later ...~