### PR TITLE
Specify credentials/URL explicitly

### DIFF
--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -94,7 +94,10 @@ class Pipeline implements Serializable {
           try {
             setBitbucketBuildStatus('INPROGRESS')
             script.wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
-              gitService.checkout(context.gitCommit, script.scm.userRemoteConfigs)
+              gitService.checkout(
+                context.gitCommit,
+                [[credentialsId: context.credentialsId, url: context.gitUrl]]
+              )
               if (context.getDisplayNameUpdateEnabled()) {
                 script.currentBuild.displayName = "#${context.tagversion}"
               }


### PR DESCRIPTION
Otherwise the URL is incorrect when the pipeline is called from the MRO
pipeline. In that case, `scm` points to the repo of the release manager.