### PR TITLE
Fix build args patches

### DIFF
--- a/src/org/ods/component/BuildOpenShiftImageStage.groovy
+++ b/src/org/ods/component/BuildOpenShiftImageStage.groovy
@@ -80,39 +80,39 @@ class BuildOpenShiftImageStage extends Stage {
       )
     }
 
-    private Map buildImageLabels() {
-      def imageLabels = [
-        'ods.build.source.repo.url': context.gitUrl,
-        'ods.build.source.repo.commit.sha': context.gitCommit,
-        'ods.build.source.repo.commit.msg': context.gitCommitMessage,
-        'ods.build.source.repo.commit.author': context.gitCommitAuthor,
-        'ods.build.source.repo.commit.timestamp': context.gitCommitTime,
-        'ods.build.source.repo.branch': context.gitBranch,
-        'ods.build.jenkins.job.url': context.buildUrl,
-        'ods.build.timestamp': context.buildTime,
-        'ods.build.lib.version': context.odsSharedLibVersion,
-      ]
-      // Add custom image labels (prefixed with ext).
-      for (def key : config.imageLabels.keySet()) {
-        imageLabels["ext.${key}"] = config.imageLabels[key]
-      }
-      // Sanitize image labels.
-      def sanitizedImageLabels = [:]
-      for (def key : imageLabels.keySet()) {
-        def val = imageLabels[key].toString()
-        def sanitizedVal = val.replaceAll("[\r\n]+", " ").trim().replaceAll("[\"']+", "")
-        sanitizedImageLabels[key] = sanitizedVal
-      }
-      sanitizedImageLabels
+  private Map buildImageLabels() {
+    def imageLabels = [
+      'ods.build.source.repo.url': context.gitUrl,
+      'ods.build.source.repo.commit.sha': context.gitCommit,
+      'ods.build.source.repo.commit.msg': context.gitCommitMessage,
+      'ods.build.source.repo.commit.author': context.gitCommitAuthor,
+      'ods.build.source.repo.commit.timestamp': context.gitCommitTime,
+      'ods.build.source.repo.branch': context.gitBranch,
+      'ods.build.jenkins.job.url': context.buildUrl,
+      'ods.build.timestamp': context.buildTime,
+      'ods.build.lib.version': context.odsSharedLibVersion,
+    ]
+    // Add custom image labels (prefixed with ext).
+    for (def key : config.imageLabels.keySet()) {
+      imageLabels["ext.${key}"] = config.imageLabels[key]
+    }
+    // Sanitize image labels.
+    def sanitizedImageLabels = [:]
+    for (def key : imageLabels.keySet()) {
+      def val = imageLabels[key].toString()
+      def sanitizedVal = val.replaceAll("[\r\n]+", " ").trim().replaceAll("[\"']+", "")
+      sanitizedImageLabels[key] = sanitizedVal
+    }
+    sanitizedImageLabels
   }
 
-    private writeReleaseFile(Map imageLabels) {
-      def jsonImageLabels = []
-      for (def key : imageLabels.keySet()) {
-        jsonImageLabels << """{"name": "${key}", "value": "${imageLabels[key]}"}"""
-      }
-
-      // Write docker/release.json file to be reachable from Dockerfile.
-      script.writeFile(file: 'docker/release.json', text: "[\n" + jsonImageLabels.join(",\n") + "\n]")
+  private writeReleaseFile(Map imageLabels) {
+    def jsonImageLabels = []
+    for (def key : imageLabels.keySet()) {
+      jsonImageLabels << """{"name": "${key}", "value": "${imageLabels[key]}"}"""
     }
+
+    // Write docker/release.json file to be reachable from Dockerfile.
+    script.writeFile(file: 'docker/release.json', text: "[\n" + jsonImageLabels.join(",\n") + "\n]")
+  }
 }

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -133,16 +133,14 @@ class OpenShiftService {
       ]}"""
     ]
 
-    // add build args - TODO: Ensure we are not replacing all buildArgs!!
+    // Add build args
     def buildArgsItems = []
     for (def key : buildArgs.keySet()) {
       def val = buildArgs[key]
       buildArgsItems << """{"name": "${key}", "value": "${val}"}"""
     }
     if (buildArgsItems.size() > 0) {
-      def buildArgsPatch = """{"op": "replace", "path": "/spec/strategy/dockerStrategy", "value": {"buildArgs": [
-      ${buildArgsItems.join(",")}
-    ]}}"""
+      def buildArgsPatch = """{"op": "replace", "path": "/spec/strategy/dockerStrategy/buildArgs", "value": [${buildArgsItems.join(",")}]}"""
       patches << buildArgsPatch
     }
 


### PR DESCRIPTION
Includes some indentation fixes, 822832d03ca033826640a0167a52225bc9be2153 addresses the actual problem.

Given that we seed the `BuildConfig` with an empty `dockerStrategy` (https://github.com/opendevstack/ods-quickstarters/blob/master/common/ocp-config/component-environment/component-template.yml#L90), I think this is safe enough.