### PR TITLE
add '|| true' to always return with exit code 0

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -679,13 +679,13 @@ class Context implements IContext {
     }
   }
   
-  public Map<String,String> getExtensionBuildParams () {
+  Map<String,String> getExtensionBuildParams () {
     String rawEnv = script.sh(
-        returnStdout: true, script: "env | grep ods.build.",
+        returnStdout: true, script: "env | grep ods.build. || true",
         label: 'getting extension environment labels'
       ).trim()
     
-    if (rawEnv.trim().size() == 0 ) {
+    if (rawEnv.size() == 0 ) {
       return [:]
     }
       


### PR DESCRIPTION
I ran the shared lib on a branch that was branched from ods/master with an already existing test project and it failed because the 'env | grep ods.build.' shell script returned with exit code 1 (apparently grep found nothing).

Thus, I had to add this '|| true' to always return with code 0, even if nothing was found by grep.


also removed public modifier since it is redundant here and removed the trim because it is already done in the line above