### PR TITLE
Decorate pull requests in Bitbucket with SonarQube analysis

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -107,7 +107,9 @@ class Context implements IContext {
     if (!config.containsKey('cloneProjectScriptBranch')) {
       config.cloneProjectScriptBranch = 'production'
     }
-    if (!config.containsKey('sonarQubeBranch')) {
+    if (config.containsKey('sonarQubeBranch')) {
+      script.echo "Setting option 'sonarQubeBranch' of the pipeline is deprecated, please use option 'branch' of the stage."
+    } else {
       config.sonarQubeBranch = 'master'
     }
     if (!config.containsKey('failOnSnykScanVulnerabilities')) {
@@ -248,6 +250,7 @@ class Context implements IContext {
     config.gitBranch
   }
 
+  @NonCPS
   String getCredentialsId() {
     config.credentialsId
   }
@@ -387,6 +390,7 @@ class Context implements IContext {
     config.targetProject
   }
 
+  @NonCPS
   String getSonarQubeBranch() {
     config.sonarQubeBranch
   }

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -324,7 +324,8 @@ class Context implements IContext {
     config.nexusHost.replace("://", "://${config.nexusUsername}:${config.nexusPassword}@")
   }
 
-  String getBranchToEnvironmentMapping() {
+  @NonCPS
+  Map getBranchToEnvironmentMapping() {
     config.branchToEnvironmentMapping
   }
 

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -328,7 +328,7 @@ class Context implements IContext {
   }
 
   @NonCPS
-  Map getBranchToEnvironmentMapping() {
+  Map<String, String> getBranchToEnvironmentMapping() {
     config.branchToEnvironmentMapping
   }
 

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -80,7 +80,7 @@ interface IContext {
     String getNexusHostWithBasicAuth()
 
     // Define which branches are deployed to which environments.
-    String getBranchToEnvironmentMapping()
+    Map getBranchToEnvironmentMapping()
 
     // Define which environments are cloned from which source environments.
     String getAutoCloneEnvironmentsFromSourceMapping()

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -80,7 +80,7 @@ interface IContext {
     String getNexusHostWithBasicAuth()
 
     // Define which branches are deployed to which environments.
-    Map getBranchToEnvironmentMapping()
+    Map<String, String> getBranchToEnvironmentMapping()
 
     // Define which environments are cloned from which source environments.
     String getAutoCloneEnvironmentsFromSourceMapping()

--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -1,6 +1,7 @@
 package org.ods.component
 
 import org.ods.services.GitService
+import org.ods.services.BitbucketService
 import org.ods.services.OpenShiftService
 import org.ods.services.SonarQubeService
 import org.ods.services.ServiceRegistry
@@ -42,10 +43,15 @@ class Pipeline implements Serializable {
             registry.add(GitService, new GitService(script))
             gitService = registry.get(GitService)
 
+            registry.add(BitbucketService, new BitbucketService(
+              script,
+              context.bitbucketUrl,
+              context.projectId,
+              context.credentialsId
+            ))
+
             registry.add(OpenShiftService, new OpenShiftService(script, context.targetProject))
             openShiftService = registry.get(OpenShiftService)
-
-            registry.add(SonarQubeService, new SonarQubeService(script, 'SonarServerConfig'))
           }
 
           def autoCloneEnabled = !!context.cloneSourceEnv

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -1,29 +1,46 @@
 package org.ods.component
 
+import com.cloudbees.groovy.cps.NonCPS
+
+import org.ods.services.BitbucketService
 import org.ods.services.SonarQubeService
 
 class ScanWithSonarStage extends Stage {
   public final String STAGE_NAME = 'SonarQube Analysis'
+  private BitbucketService bitbucket
   private SonarQubeService sonarQube
 
-  ScanWithSonarStage(def script, IContext context, Map config, SonarQubeService sonarQube) {
+  ScanWithSonarStage(def script, IContext context, Map config, BitbucketService bitbucket, SonarQubeService sonarQube) {
     super(script, context, config)
-    if (!config.requireQualityGatePass) {
+    if (config.branch) {
+      config.eligibleBranches = config.branch.split(',')
+    } else {
+      config.eligibleBranches = context.sonarQubeBranch.split(',')
+    }
+    if (!config.containsKey('analyzePullRequests')) {
+      config.analyzePullRequests = true
+    }
+    if (!config.containsKey('requireQualityGatePass')) {
       config.requireQualityGatePass = false
     }
+    if (!config.longLivedBranches) {
+      config.longLivedBranches = extractLongLivedBranches(context.branchToEnvironmentMapping)
+      script.echo "Long-lived branches: ${config.longLivedBranches.join(', ')}."
+    }
+    this.bitbucket = bitbucket
     this.sonarQube = sonarQube
   }
 
   def run() {
-    if (context.sonarQubeBranch != '*' && context.sonarQubeBranch != context.gitBranch) {
-      script.echo "Skipping as branch '${context.gitBranch}' is not covered by the 'sonarQubeBranch' property."
+    if (!isEligible(context.gitBranch)) {
+      script.echo "Skipping as branch '${context.gitBranch}' is not covered by the 'branch' option."
       return
     }
 
     def sonarProperties = sonarQube.readProperties()
     def sonarProjectKey = sonarProperties['sonar.projectKey']
 
-    sonarQube.scan(sonarProperties, context.gitCommit, context.debug)
+    scan(sonarProperties)
 
     generateAndArchiveReports(sonarProjectKey, context.buildTag)
 
@@ -39,7 +56,105 @@ class ScanWithSonarStage extends Stage {
     }
   }
 
-  private generateAndArchiveReports(String projectKey, String author) {
+  @NonCPS
+  private List<String> extractLongLivedBranches(Map branchMapping) {
+    def branches = branchMapping.keySet()
+    branches.removeAll { it.toLowerCase().endsWith('/') }
+    branches.removeAll { it == '*' }
+    branches.toList()
+  }
+
+  private void scan(Map sonarProperties) {
+    def pullRequestInfo = assemblePullRequestInfo()
+    def doScan = { Map prInfo ->
+      sonarQube.scan(sonarProperties, context.gitCommit, prInfo, context.debug)
+    }
+    if (pullRequestInfo) {
+      bitbucket.withTokenCredentials { username, token ->
+        doScan(pullRequestInfo + [bitbucketToken: token])
+      }
+    } else {
+      doScan([:])
+    }
+  }
+
+  private boolean isEligible(String branch) {
+    // Check if any branch is allowed
+    if (config.eligibleBranches.contains('*')) {
+      return true
+    }
+    // Check if prefix (e.g. "release/") is allowed
+    for (def i = 0; i < config.eligibleBranches.size(); i++) {
+      def eligibleBranch = config.eligibleBranches[i]
+      if (eligibleBranch.endsWith('/') && branch.startsWith(eligibleBranch)) {
+        return true
+      }
+    }
+    // Check if specific branch is allowed
+    config.eligibleBranches.contains(branch)
+  }
+
+  private assemblePullRequestInfo() {
+    if (!config.analyzePullRequests) {
+      script.echo "PR analysis is disabled."
+      return [:]
+    }
+    if (config.longLivedBranches.contains(context.gitBranch)) {
+      script.echo "Branch '${context.gitBranch}' is considered to be long-lived. PR analysis will not be performed."
+      return [:]
+    }
+
+    def repo = "${context.projectId}-${context.componentId}"
+    def apiResponse = bitbucket.getPullRequests(repo)
+    def pullRequest = findPullRequest(apiResponse, context.gitBranch)
+
+    if (pullRequest) {
+      return [
+        bitbucketUrl: context.bitbucketUrl,
+        bitbucketProject: context.projectId,
+        bitbucketRepository: repo,
+        bitbucketPullRequestKey: pullRequest.key,
+        branch: context.gitBranch,
+        baseBranch: pullRequest.base
+      ]
+    } else {
+      def longLivedList = config.longLivedBranches.join(', ')
+      script.echo "No open PR found for ${context.gitBranch} even though it is not one of the long-lived branches (${longLivedList})."
+      return [:]
+    }
+  }
+
+  private Map findPullRequest(String apiResponse, String branch) {
+    def prCandidates = []
+    try {
+      def js = script.readJSON(text: apiResponse)
+      prCandidates = js['values']
+      if (prCandidates == null) {
+        throw new RuntimeException('Field "values" of JSON response must not be empty!')
+      }
+    } catch (Exception ex) {
+      script.echo "WARN: Could not understand API response. Error was: ${ex}"
+      return [:]
+    }
+    for (def i = 0; i < prCandidates.size(); i++) {
+      def prCandidate = prCandidates[i]
+      try {
+        def prFromBranch = prCandidate['fromRef']['displayId']
+        if (prFromBranch == branch) {
+          return [
+            key: prCandidate['id'],
+            base: prCandidate['toRef']['displayId']
+          ]
+        }
+      } catch (Exception ex) {
+        script.echo "WARN: Unexpected API response. Error was: ${ex}"
+        return [:]
+      }
+    }
+    return [:]
+  }
+
+  private void generateAndArchiveReports(String projectKey, String author) {
     def targetReport = "SCRR-${projectKey}.docx"
     def targetReportMd = "SCRR-${projectKey}.md"
     sonarQube.generateCNESReport(projectKey, author)

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -1,0 +1,156 @@
+package org.ods.services
+
+class BitbucketService {
+
+  private def script
+
+  // Bae URL of Bitbucket server, such as "https://bitbucket.example.com".
+  private String bitbucketUrl
+
+  // Name of Bitbucket project, such as "foo".
+  // This name is also the prefix for OpenShift projects ("foo-cd", "foo-dev", ...).
+  private String project
+
+  // Name of the CD project in OpenShift, based on the "project" name.
+  private String openShiftCdProject
+
+  // Name of the credentials which store the username/password of a user with
+  // access to the BitBucket server identified by "bitbucketUrl".
+  private String passwordCredentialsId
+
+  // Name of the secret in "openShiftCdProject", which contains the username/token
+  // of a user with access to the BitBucket server identified by "bitbucketUrl".
+  // This secret does not need to exist ahead of time, it will be created
+  // automatically through the API using "passwordCredentialsId".
+  private String tokenSecretName
+
+  // Name of the credentials which store the username/token of a user with
+  // access to the BitBucket server identified by "bitbucketUrl".
+  // These credentials do not need to exist ahead of time, it will be created
+  // automatically (by syncing the "tokenSecretName").
+  private String tokenCredentialsId
+
+  BitbucketService(def script, String bitbucketUrl, String project, String passwordCredentialsId) {
+    this.script = script
+    this.bitbucketUrl = bitbucketUrl
+    this.project = project
+    this.openShiftCdProject = "${project}-cd"
+    this.passwordCredentialsId = passwordCredentialsId
+    this.tokenSecretName = 'cd-user-bitbucket-token'
+  }
+
+  // Get pull requests of "repo" in given "state" (can be OPEN, DECLINED or MERGED).
+  String getPullRequests(String repo, String state = 'OPEN') {
+    String res
+    withTokenCredentials { username, token ->
+      res = script.sh(
+        label: 'Get pullrequests via API',
+        script: "curl -H 'Authorization: Bearer ${token}' ${bitbucketUrl}/rest/api/1.0/projects/${project}/repos/${repo}/pull-requests?state=${state}",
+        returnStdout: true
+      ).trim()
+    }
+    res
+  }
+
+  def withTokenCredentials(Closure block) {
+    if (!tokenCredentialsId) {
+      createUserTokenIfMissing()
+    }
+    script.withCredentials([
+      script.usernamePassword(
+        credentialsId: tokenCredentialsId,
+        usernameVariable: 'USERNAME',
+        passwordVariable: 'TOKEN'
+      )
+    ]) {
+      block(script.USERNAME, script.TOKEN)
+    }
+  }
+
+  private void createUserTokenIfMissing() {
+    def credentialsId = "${openShiftCdProject}-${tokenSecretName}"
+
+    if (basicAuthCredentialsIdExists(credentialsId)) {
+      script.echo "Secret ${tokenSecretName} exists and is synced."
+      this.tokenCredentialsId = credentialsId
+      return
+    }
+
+    def credentialsAvailable = false
+    script.echo "Secret ${tokenSecretName} does not exist yet, it will be created now."
+    def token = createUserToken()
+    if (token['password']) {
+      createUserTokenSecret(token['username'], token['password'])
+    }
+
+    // Ensure that secret is synced to Jenkins before continuing.
+    def waitTime = 10 // seconds
+    def retries = 3
+    for (def i = 0; i < retries; i++) {
+      if (basicAuthCredentialsIdExists(credentialsId)) {
+        credentialsAvailable = true
+        break
+      } else {
+        script.echo "Waiting ${waitTime} for credentials '${credentialsId}' to become available."
+        script.sleep(waitTime)
+        waitTime = waitTime * 2
+      }
+    }
+    if (credentialsAvailable) {
+      this.tokenCredentialsId = credentialsId
+    } else {
+      throw new RuntimeException("ERROR: Secret ${openShiftCdProject}/${tokenSecretName} has been created, but credentials '${credentialsId}' are not available. Please ensure that the secret is synced and re-run the pipeline.")
+    }
+  }
+
+  private Map<String, String> createUserToken() {
+    def tokenMap = [username:'', password: '']
+    def res = ""
+    script.withCredentials([script.usernamePassword(credentialsId: passwordCredentialsId, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+      tokenMap['username'] = script.USERNAME
+      res = script.sh(
+        returnStdout: true,
+        script: """curl \\
+          --fail \\
+          --silent \\
+          --user ${script.USERNAME.replace('$', '\'$\'')}:${script.PASSWORD.replace('$', '\'$\'')} \\
+          --request PUT \\
+          --header \"Content-Type: application/json\" \\
+          --data '{\"name\":\"ods-jenkins-shared-library\",\"permissions\":[\"PROJECT_WRITE\", \"REPO_WRITE\"]}' \\
+          ${bitbucketUrl}/rest/access-tokens/1.0/users/${script.USERNAME.replace('@', '_')}
+        """
+      ).trim()
+    }
+    try {
+      def js = script.readJSON(text: res)
+      tokenMap['password'] = js['token']
+    } catch (Exception ex) {
+      script.echo "WARN: Could not understand API response. Error was: ${ex}"
+    }
+    return tokenMap
+  }
+
+  private void createUserTokenSecret(String username, String password) {
+    script.sh """
+      set +x
+      oc -n ${openShiftCdProject} create secret generic ${tokenSecretName} --from-literal=password=${password} --from-literal=username=${username} --type=\"kubernetes.io/basic-auth\"
+      oc -n ${openShiftCdProject} label secret ${tokenSecretName} credential.sync.jenkins.openshift.io=true
+    """
+  }
+
+  private boolean basicAuthCredentialsIdExists(String credentialsId) {
+    try {
+      script.withCredentials([
+        script.usernamePassword(
+          credentialsId: credentialsId,
+          usernameVariable: 'USERNAME',
+          passwordVariable: 'TOKEN'
+        )
+      ]) {
+        true
+      }
+    } catch (_) {
+      false
+    }
+  }
+}

--- a/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
@@ -3,6 +3,7 @@ package vars
 import org.ods.component.Logger
 import org.ods.component.Context
 import org.ods.component.IContext
+import org.ods.services.BitbucketService
 import org.ods.services.SonarQubeService
 import org.ods.services.ServiceRegistry
 import vars.test_helper.PipelineSpockTestBase
@@ -14,7 +15,10 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
 
   @Shared
   def config = [
-      gitUrl: 'https://example.com/scm/foo/bar.git',
+      bitbucketUrl: 'https://bitbucket.example.com',
+      projectId: 'foo',
+      componentId: 'bar',
+      gitUrl: 'https://bitbucket.example.com/scm/foo/foo-bar.git',
       gitCommit: 'cd3e9082d7466942e1de86902bb9e663751dae8e',
       gitCommitMessage: """Foo\n\nSome "explanation".""",
       gitCommitAuthor: "John O'Hare",
@@ -23,12 +27,19 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
       buildUrl: 'https://jenkins.example.com/job/foo-cd/job/foo-cd-bar-master/11/console',
       buildTime: '2020-03-23 12:27:08 +0100',
       odsSharedLibVersion: '2.x',
+      branchToEnvironmentMapping: ['master': 'dev', 'release/': 'test'],
+      sonarQubeBranch: 'master'
   ]
 
   def "run successfully"() {
     given:
     def c = config + [environment: 'dev']
     IContext context = new Context(null, c, logger)
+    BitbucketService bitbucketService = Stub(BitbucketService.class)
+
+    def res = readResource('no-pull-requests.json');
+    bitbucketService.getPullRequests(*_) >> res
+    ServiceRegistry.instance.add(BitbucketService, bitbucketService)
     SonarQubeService sonarQubeService = Stub(SonarQubeService.class)
     sonarQubeService.readProperties() >> ['sonar.projectKey': 'foo']
     sonarQubeService.scan(*_) >> null
@@ -42,6 +53,45 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
 
     then:
     printCallStack()
+    assertJobStatusSuccess()
+  }
+
+  def "run successfully with PR analysis"() {
+    given:
+    def c = config + [environment: 'dev', gitBranch: 'feature/foo']
+    IContext context = new Context(null, c, logger)
+    BitbucketService bitbucketService = Stub(BitbucketService.class)
+    bitbucketService.withTokenCredentials(*_) >> { Closure block -> block('user', 's3cr3t') }
+
+    def res = readResource('pull-requests.json');
+    bitbucketService.getPullRequests(*_) >> res
+    ServiceRegistry.instance.add(BitbucketService, bitbucketService)
+    SonarQubeService sonarQubeService = Mock(SonarQubeService.class)
+    sonarQubeService.readProperties() >> ['sonar.projectKey': 'foo']
+    ServiceRegistry.instance.add(SonarQubeService, sonarQubeService)
+
+    when:
+    def script = loadScript('vars/odsComponentStageScanWithSonar.groovy')
+    helper.registerAllowedMethod('archiveArtifacts', [ Map ]) { Map args -> }
+    helper.registerAllowedMethod('stash', [ Map ]) { Map args -> }
+    script.call(context, ['branch': '*'])
+
+    then:
+    printCallStack()
+    1 * sonarQubeService.scan(
+      ['sonar.projectKey': 'foo'],
+      'cd3e9082d7466942e1de86902bb9e663751dae8e',
+      [
+        bitbucketUrl: 'https://bitbucket.example.com',
+        bitbucketToken: 's3cr3t',
+        bitbucketProject: 'foo',
+        bitbucketRepository: 'foo-bar',
+        bitbucketPullRequestKey: 1,
+        branch: 'feature/foo',
+        baseBranch: 'master'
+      ],
+      false
+    )
     assertJobStatusSuccess()
   }
 
@@ -83,16 +133,19 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
 
   def "skip branch should not be scanned"() {
     given:
-    def config = [sonarQubeBranch: 'master', gitBranch: 'feature/foo']
+    def config = [
+      branchToEnvironmentMapping: ['master': 'dev', 'release/': 'test'],
+      gitBranch: 'feature/foo'
+    ]
     def context = new Context(null, config, logger)
 
     when:
     def script = loadScript('vars/odsComponentStageScanWithSonar.groovy')
-    script.call(context)
+    script.call(context, ['branch': 'master'])
 
     then:
     printCallStack()
-    assertCallStackContains("Skipping as branch 'feature/foo' is not covered by the 'sonarQubeBranch' property.")
+    assertCallStackContains("Skipping as branch 'feature/foo' is not covered by the 'branch' option.")
     assertJobStatusSuccess()
   }
 

--- a/test/groovy/vars/test_helper/PipelineSpockTestBase.groovy
+++ b/test/groovy/vars/test_helper/PipelineSpockTestBase.groovy
@@ -1,5 +1,6 @@
 package vars.test_helper
 
+import groovy.json.JsonSlurper
 import com.lesfurets.jenkins.unit.BasePipelineTest
 import org.ods.component.IContext
 import spock.lang.Specification
@@ -18,6 +19,7 @@ class PipelineSpockTestBase extends Specification {
       @Override
       void registerAllowedMethods() {
         super.registerAllowedMethods()
+        helper.registerAllowedMethod('readJSON', [ Map ]) { Map args -> new JsonSlurper().parseText(args.text) }
         // we register our custom groovy method withStage so that is is available
         // in every script executed by the Jenkins Pipeline Unit testing framework
         helper.registerAllowedMethod("withStage", [String, IContext, Closure], { String stageLabel, IContext context, Closure closure ->
@@ -26,5 +28,11 @@ class PipelineSpockTestBase extends Specification {
       }
     }
     basePipelineTest.setUp()
+  }
+
+  protected String readResource(String name) {
+    def classLoader = getClass().getClassLoader();
+    def file = new File(classLoader.getResource(name).getFile());
+    file.text
   }
 }

--- a/test/resources/no-pull-requests.json
+++ b/test/resources/no-pull-requests.json
@@ -1,0 +1,1 @@
+{"size":0,"limit":25,"isLastPage":true,"values":[],"start":0}

--- a/test/resources/pull-requests.json
+++ b/test/resources/pull-requests.json
@@ -1,0 +1,151 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "id": 1,
+      "version": 9,
+      "title": "Foo",
+      "state": "OPEN",
+      "open": true,
+      "closed": false,
+      "createdDate": 1586270387142,
+      "updatedDate": 1586953085033,
+      "fromRef": {
+        "id": "refs/heads/feature/foo",
+        "displayId": "feature/foo",
+        "latestCommit": "e05056d3e368b0a5d58ce5f04616903274d04bc9",
+        "repository": {
+          "slug": "foo-bar",
+          "id": 5763,
+          "name": "foo-bar",
+          "scmId": "git",
+          "state": "AVAILABLE",
+          "statusMessage": "Available",
+          "forkable": true,
+          "project": {
+            "key": "FOO",
+            "id": 4082,
+            "name": "Foo",
+            "description": "Foo",
+            "public": false,
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://bitbucket.example.com/projects/FOO"
+                }
+              ]
+            }
+          },
+          "public": false,
+          "links": {
+            "clone": [
+              {
+                "href": "https://bitbucket.example.com/scm/foo/foo-bar.git",
+                "name": "http"
+              },
+              {
+                "href": "ssh://git@bitbucket.example.com:7999/foo/foo-bar.git",
+                "name": "ssh"
+              }
+            ],
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/projects/FOO/repos/foo-bar/browse"
+              }
+            ]
+          }
+        }
+      },
+      "toRef": {
+        "id": "refs/heads/master",
+        "displayId": "master",
+        "latestCommit": "90c5bce6fdab02f49fc1b9af26d2d088135aebeb",
+        "repository": {
+          "slug": "foo-bar",
+          "id": 5763,
+          "name": "foo-bar",
+          "scmId": "git",
+          "state": "AVAILABLE",
+          "statusMessage": "Available",
+          "forkable": true,
+          "project": {
+            "key": "FOO",
+            "id": 4082,
+            "name": "Foo",
+            "description": "Foo",
+            "public": false,
+            "type": "NORMAL",
+            "links": {
+              "self": [
+                {
+                  "href": "https://bitbucket.example.com/projects/FOO"
+                }
+              ]
+            }
+          },
+          "public": false,
+          "links": {
+            "clone": [
+              {
+                "href": "https://bitbucket.example.com/scm/foo/foo-bar.git",
+                "name": "http"
+              },
+              {
+                "href": "ssh://git@bitbucket.example.com:7999/foo/foo-bar.git",
+                "name": "ssh"
+              }
+            ],
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/projects/FOO/repos/foo-bar/browse"
+              }
+            ]
+          }
+        }
+      },
+      "locked": false,
+      "author": {
+        "user": {
+          "name": "max.mustermann@example.com",
+          "emailAddress": "max.mustermann@example.com",
+          "id": 4653,
+          "displayName": "Mustermann,Max",
+          "active": true,
+          "slug": "max.mustermann_example.com",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://bitbucket.example.com/users/max.mustermann_example.com"
+              }
+            ]
+          }
+        },
+        "role": "AUTHOR",
+        "approved": false,
+        "status": "UNAPPROVED"
+      },
+      "reviewers": [],
+      "participants": [],
+      "properties": {
+        "mergeResult": {
+          "outcome": "CLEAN",
+          "current": true
+        },
+        "resolvedTaskCount": 0,
+        "openTaskCount": 0
+      },
+      "links": {
+        "self": [
+          {
+            "href": "https://bitbucket.example.com/projects/FOO/repos/foo-bar/pull-requests/1"
+          }
+        ]
+      }
+    }
+  ],
+  "start": 0
+}

--- a/vars/odsComponentStageScanWithSonar.groovy
+++ b/vars/odsComponentStageScanWithSonar.groovy
@@ -1,15 +1,33 @@
 import org.ods.component.ScanWithSonarStage
 import org.ods.component.IContext
 
+import org.ods.services.BitbucketService
 import org.ods.services.SonarQubeService
 import org.ods.services.ServiceRegistry
 
 def call(IContext context, Map config = [:]) {
+    def bitbucketService = ServiceRegistry.instance.get(BitbucketService)
+    if (!bitbucketService) {
+        bitbucketService = new BitbucketService(
+            this,
+            context.bitbucketUrl,
+            context.projectId,
+            context.credentialsId
+        )
+    }
+    def sonarQubeService = ServiceRegistry.instance.get(SonarQubeService)
+    if (!sonarQubeService) {
+        sonarQubeService = new SonarQubeService(
+            this,
+            'SonarServerConfig'
+        )
+    }
     def stage = new ScanWithSonarStage(
         this,
         context,
         config,
-        ServiceRegistry.instance.get(SonarQubeService)
+        bitbucketService,
+        sonarQubeService
     )
     stage.execute()
 }


### PR DESCRIPTION
When a branch is eligible to be scanned, and it is not one of the
long-lived branches, we ask SonarQube to perform PR analysis and
decorate the associated pull request in Bitbucket.

As a side-effect, we now have a Bitbucket token for the cd_user. This is
required as PR decoration is token based. However, a token is good to
have anyway, and we can move other Bitbucket API calls over to the
BitbucketService in the future, making use of the token instead of the
password.

Closes #174.