### PR TITLE
Bugfix/swap snyk monitor test

### DIFF
--- a/src/org/ods/component/ScanWithSnykStage.groovy
+++ b/src/org/ods/component/ScanWithSnykStage.groovy
@@ -42,7 +42,7 @@ class ScanWithSnykStage extends Stage {
         "buildFile=${config.buildFile}, " +
         "failOnVulnerabilities=${config.failOnVulnerabilities}."
 
-    boolean vulnerabilitiesFound
+    boolean noVulnerabilitiesFound
 
     def envVariables = [
       "NEXUS_HOST=${context.nexusHost}",
@@ -51,11 +51,11 @@ class ScanWithSnykStage extends Stage {
     ]
     // nexus credentials are provided here because snyk runs build.gradle who needs them
     script.withEnv(envVariables) {
-      vulnerabilitiesFound = snyk.test(config.organisation, config.buildFile)
-      if (vulnerabilitiesFound) {
-        script.echo 'Snyk test detected vulnerabilities.'
-      } else {
+      noVulnerabilitiesFound = snyk.test(config.organisation, config.buildFile)
+      if (noVulnerabilitiesFound) {
         script.echo 'No vulnerabilities detected.'
+      } else {
+        script.echo 'Snyk test detected vulnerabilities.'
       }
     }
 
@@ -65,7 +65,7 @@ class ScanWithSnykStage extends Stage {
 
     generateAndArchiveReport()
 
-    if (vulnerabilitiesFound && config.failOnVulnerabilities) {
+    if (!noVulnerabilitiesFound && config.failOnVulnerabilities) {
       script.error 'Snyk scan stage failed. See snyk report for details.'
     }
   }

--- a/src/org/ods/component/ScanWithSnykStage.groovy
+++ b/src/org/ods/component/ScanWithSnykStage.groovy
@@ -62,7 +62,7 @@ class ScanWithSnykStage extends Stage {
     ]
     // nexus credentials are provided here because snyk runs build.gradle who needs them
     script.withEnv(envVariables) {
-      noVulnerabilitiesFound = snyk.test(config.organisation, config.buildFile)
+      noVulnerabilitiesFound = snyk.test(config.organisation, config.buildFile, config.severityThreshold)
       if (noVulnerabilitiesFound) {
         script.echo 'No vulnerabilities detected.'
       } else {

--- a/src/org/ods/component/ScanWithSnykStage.groovy
+++ b/src/org/ods/component/ScanWithSnykStage.groovy
@@ -59,7 +59,7 @@ class ScanWithSnykStage extends Stage {
       }
     }
 
-    if (!snyk.monitor(config.organisation, config.buildFile, config.projectName)) {
+    if (!snyk.monitor(config.organisation, config.buildFile)) {
       script.error 'Snyk monitor failed'
     }
 

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -30,19 +30,19 @@ class SnykService {
     ) == 0
   }
 
+  boolean test(String organisation, String buildFile) {
+    script.sh(
+        script: "snyk test --org=${organisation} --file=${buildFile} --all-sub-projects | tee -a ${reportFile}",
+        returnStatus: true,
+        label: "Run Snyk test"
+    ) == 0
+  }
+
   boolean monitor(String organisation, String buildFile, String projectName) {
     script.sh(
       script: "snyk monitor --org=${organisation} --file=${buildFile} --project-name=${projectName} --all-sub-projects | tee -a ${reportFile}",
       returnStatus: true,
       label: "Start monitoring ${projectName} in Snyk"
-    ) == 0
-  }
-
-  boolean test(String organisation, String buildFile) {
-    script.sh(
-      script: "snyk test --org=${organisation} --file=${buildFile} --all-sub-projects | tee -a ${reportFile}",
-      returnStatus: true,
-      label: "Run Snyk test"
     ) == 0
   }
 }

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -40,7 +40,7 @@ class SnykService {
 
   boolean monitor(String organisation, String buildFile, String projectName) {
     script.sh(
-      script: "snyk monitor --org=${organisation} --file=${buildFile} --project-name=${projectName} --all-sub-projects | tee -a ${reportFile}",
+      script: "snyk monitor --org=${organisation} --file=${buildFile} --all-sub-projects | tee -a ${reportFile}",
       returnStatus: true,
       label: "Start monitoring ${projectName} in Snyk"
     ) == 0

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -38,11 +38,11 @@ class SnykService {
     ) == 0
   }
 
-  boolean monitor(String organisation, String buildFile, String projectName) {
+  boolean monitor(String organisation, String buildFile) {
     script.sh(
       script: "snyk monitor --org=${organisation} --file=${buildFile} --all-sub-projects | tee -a ${reportFile}",
       returnStatus: true,
-      label: "Start monitoring ${projectName} in Snyk"
+      label: "Start monitoring in snyk.io"
     ) == 0
   }
 }


### PR DESCRIPTION
Fixes #253 

- swapped call of monitor with test
- removed project-name param from monitor call since it is incompatible with all-sub-projects flag and lead to not running the monitor call at all. project-name was used to override the default name that is displayed for the project on snyk.io, see further explanation: https://support.snyk.io/hc/en-us/articles/360000910677-Snyk-CLI-monitored-projects-are-created-with-IDs-in-the-project-name
- renamed result var of test script from 'testSuccess' to 'noVulnerabilitiesFound' to understand better
- moved scanning echo closer to actual scanning (snyk.test)