### PR TITLE
Allow image URLs without registry

### DIFF
--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -31,6 +31,11 @@ class Context implements IContext {
     }
 
     @NonCPS
+    String getDockerRegistry() {
+        config.dockerRegistry
+    }
+
+    @NonCPS
     String getProjectId() {
         config.projectId
     }

--- a/src/org/ods/quickstarter/CreateOpenShiftResourcesStage.groovy
+++ b/src/org/ods/quickstarter/CreateOpenShiftResourcesStage.groovy
@@ -23,10 +23,12 @@ class CreateOpenShiftResourcesStage extends Stage {
 
             def tailorParams = [
                 '--upsert-only',
+                '--ignore-unknown-parameters',
                 "--selector ${config.selector}",
                 "--param=PROJECT=${context.projectId}",
                 "--param=COMPONENT=${context.componentId}",
                 "--param=ENV=${env}",
+                "--param=DOCKER_REGISTRY=${context.dockerRegistry}",
             ]
 
             if (script.fileExists(config.envFile)) {

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -357,28 +357,36 @@ class OpenShiftService {
     // imageInfoForImageUrl expects an image URL like one of the following:
     // 172.30.21.196:5000/foo/bar:2-3ec425bc
     // 172.30.21.196:5000/foo/bar@sha256:eec4a4451a307bd1fa44bde6642077a3c2a722e0ad370c1c22fcebcd8d4efd33
+    // The registry part is optional.
     //
     // It returns a map with image parts:
-    // - registry
+    // - registry (empty if not specified)
     // - repository (= OpenShift project in case of image from ImageStream)
     // - name (= ImageStream name in case of image from ImageStream)
     Map<String, String> imageInfoForImageUrl(String url) {
         def imageInfo = [:]
+        def urlParts = url.split('/').toList()
 
-        def urlParts = url.split('/')
-        if (urlParts.size() != 3) {
+        if (urlParts.size() < 2) {
             throw new RuntimeException(
-                "ERROR: Image URL ${url} does not consist of three parts (registry/repository/reference)"
+                "ERROR: Image URL ${url} must have at least two parts (repository/reference)"
             )
         }
-        imageInfo.registry = urlParts[0]
-        imageInfo.repository = urlParts[1]
 
-        if (urlParts[2].contains('@')) {
-            def shaParts = urlParts[2].split('@')
+        if (urlParts.size() > 2) {
+            imageInfo.registry = urlParts[-3]
+        } else {
+            logger.debug "Image URL ${url} does not define the registry explicitly."
+            imageInfo.registry = ''
+        }
+
+        imageInfo.repository = urlParts[-2]
+
+        if (urlParts[-1].contains('@')) {
+            def shaParts = urlParts[-1].split('@').toList()
             imageInfo.name = shaParts[0]
         } else {
-            def tagParts = urlParts[2].split(':')
+            def tagParts = urlParts[-1].split(':').toList()
             imageInfo.name = tagParts[0]
         }
         imageInfo
@@ -387,9 +395,10 @@ class OpenShiftService {
     // imageInfoWithShaForImageStreamUrl expects an image URL like one of the following:
     // 172.30.21.196:5000/foo/bar:2-3ec425bc
     // 172.30.21.196:5000/foo/bar@sha256:eec4a4451a307bd1fa44bde6642077a3c2a722e0ad370c1c22fcebcd8d4efd33
+    // The registry part is optional.
     //
     // It returns a map with image parts:
-    // - registry
+    // - registry (empty if not specified)
     // - repository (= OpenShift project in case of image from ImageStream)
     // - name (= ImageStream name in case of image from ImageStream)
     // - reference (= <name>@sha256:<sha-identifier>)
@@ -397,23 +406,23 @@ class OpenShiftService {
     // - shaStripped (= <sha-identifier>)
     Map<String, String> imageInfoWithShaForImageStreamUrl(String imageStreamUrl) {
         def urlParts = imageStreamUrl.split('/').toList()
-        if (urlParts.size() != 3) {
+        if (urlParts.size() < 2) {
             throw new RuntimeException(
-                "ERROR: Image URL ${imageStreamUrl} does not consist of three parts (registry/repository/reference)"
+                "ERROR: Image URL ${imageStreamUrl} must have at least two parts (repository/reference)"
             )
         }
-        if (urlParts[2].contains('@sha256:')) {
+        if (urlParts[-1].contains('@sha256:')) {
             return imageInfoWithSha(urlParts)
         }
 
         // If the imageStreamUrl contains a tag, we resolve it to a SHA.
-        def tagParts = urlParts[2].split(':')
+        def tagParts = urlParts[-1].split(':')
         if (tagParts.size() != 2) {
             throw new RuntimeException(
                 "ERROR: Image reference ${urlParts[2]} does not consist of two parts (name:tag)"
             )
         }
-        def shaUrl = getImageReference(steps, urlParts[1], tagParts[0], tagParts[1])
+        def shaUrl = getImageReference(steps, urlParts[-2], tagParts[0], tagParts[1])
         imageInfoWithSha(shaUrl.split('/').toList())
     }
 
@@ -536,14 +545,20 @@ class OpenShiftService {
 
     private Map<String, String> imageInfoWithSha(List<String> urlParts) {
         def imageInfo = [:]
-        if (urlParts.size() != 3 || !urlParts[2].contains('@sha256:')) {
+        def url = urlParts.join('/')
+        if (urlParts.size() < 2 || !urlParts[-1].contains('@sha256:')) {
             throw new RuntimeException(
-                "ERROR: Image URL '${urlParts.join('/')}' must be of form REGISTRY/REPOSITORY/NAME@sha256:ID)"
+                "ERROR: Image URL '${url}' must be of form [REGISTRY/]REPOSITORY/NAME@sha256:ID)"
             )
         }
-        imageInfo.registry = urlParts[0]
-        imageInfo.repository = urlParts[1]
-        def nameParts = urlParts[2].split('@')
+        if (urlParts.size() > 2) {
+            imageInfo.registry = urlParts[-3]
+        } else {
+            logger.debug "Image URL ${url} does not define the registry explicitly."
+            imageInfo.registry = ''
+        }
+        imageInfo.repository = urlParts[-2]
+        def nameParts = urlParts[-1].split('@')
         imageInfo.name = nameParts[0]
         imageInfo.sha = nameParts[1]
         imageInfo.shaStripped = nameParts[1].replace('sha256:', '')

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -16,16 +16,14 @@ class OpenShiftServiceSpec extends SpecHelper {
         def result = service.imageInfoForImageUrl(imageUrl)
 
         then:
-        result == [
-            registry: registry,
-            repository: repository,
-            name: name,
-        ]
+        result == [registry: registry, repository: repository, name: name,]
 
         where:
         imageUrl                                || registry             | repository | name
         '172.30.21.196:5000/foo/bar:2-3ec425bc' || '172.30.21.196:5000' | 'foo'      | 'bar'
         '172.30.21.196:5000/baz/qux@sha256:abc' || '172.30.21.196:5000' | 'baz'      | 'qux'
+        'baz/qux@sha256:abc'                    || ''                   | 'baz'      | 'qux'
+        'foo/bar:2-3ec425bc'                    || ''                   | 'foo'      | 'bar'
     }
 
     def "image info with SHA for image stream URL"() {
@@ -50,6 +48,8 @@ class OpenShiftServiceSpec extends SpecHelper {
         imageStreamUrl                          | imageReference                          || registry             | repository | name  | sha          | shaStripped
         '172.30.21.196:5000/foo/bar:2-3ec425bc' | '172.30.21.196:5000/foo/bar@sha256:xyz' || '172.30.21.196:5000' | 'foo'      | 'bar' | 'sha256:xyz' | 'xyz'
         '172.30.21.196:5000/baz/qux@sha256:abc' | 'n/a'                                   || '172.30.21.196:5000' | 'baz'      | 'qux' | 'sha256:abc' | 'abc'
+        'foo/bar:2-3ec425bc'                    | '172.30.21.196:5000/foo/bar@sha256:xyz' || '172.30.21.196:5000' | 'foo'      | 'bar' | 'sha256:xyz' | 'xyz'
+        'baz/qux@sha256:abc'                    | 'n/a'                                   || ''                   | 'baz'      | 'qux' | 'sha256:abc' | 'abc'
     }
 
 }


### PR DESCRIPTION
It is allowed to specify the `image` of a `DeploymentConfig` without a registry. The check (introduced in #334) in `OpenShiftService` was too restrictive and did not allow that.

Further, the quickstarter pipeline exposes the registry now so that quickstarter jobs can use the value in OpenShift Templates to render images with registry if they want to.