### PR TITLE
Bugfix/mask credentials

### DIFF
--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -164,12 +164,14 @@ class BitbucketService {
                   ${bitbucketUrl}/rest/access-tokens/1.0/users/${script.USERNAME.replace('@', '_')}
                 """
             ).trim()
-        }
-        try {
-            def js = script.readJSON(text: res)
-            tokenMap['password'] = js['token']
-        } catch (Exception ex) {
-            script.echo "WARN: Could not understand API response. Error was: ${ex}"
+            try {
+                // call readJSON inside of withCredentials block,
+                // otherwise token will be displayed in output
+                def js = script.readJSON(text: res)
+                tokenMap['password'] = js['token']
+            } catch (Exception ex) {
+                script.echo "WARN: Could not understand API response. Error was: ${ex}"
+            }
         }
         return tokenMap
     }

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -30,12 +30,12 @@ class SnykService {
         // write snyk auth command into file to avoid displaying the auth code in the output log
         script.writeFile file: 'snykauth.sh', text: "snyk auth ${authCode} | tee -a ${reportFile}"
         script.sh(
-            script: """
+            script: '''
               set -e
               set -o pipefail
               chmod +x snykauth.sh
               ./snykauth.sh
-            """,
+            ''',
             returnStatus: true,
             label: 'Authenticate with Snyk server'
         ) == 0

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -27,11 +27,14 @@ class SnykService {
     }
 
     boolean auth(String authCode) {
+        // write snyk auth command into file to avoid displaying the auth code in the output log
+        script.writeFile file: 'snykauth.sh', text: "snyk auth " + authCode + " | tee -a ${reportFile}"
         script.sh(
             script: """
               set -e
               set -o pipefail
-              snyk auth ${authCode} | tee -a ${reportFile}
+              chmod +x snykauth.sh
+              ./snykauth.sh
             """,
             returnStatus: true,
             label: 'Authenticate with Snyk server'

--- a/src/org/ods/services/SnykService.groovy
+++ b/src/org/ods/services/SnykService.groovy
@@ -28,7 +28,7 @@ class SnykService {
 
     boolean auth(String authCode) {
         // write snyk auth command into file to avoid displaying the auth code in the output log
-        script.writeFile file: 'snykauth.sh', text: "snyk auth " + authCode + " | tee -a ${reportFile}"
+        script.writeFile file: 'snykauth.sh', text: "snyk auth ${authCode} | tee -a ${reportFile}"
         script.sh(
             script: """
               set -e


### PR DESCRIPTION
Fixes #212 

While I was not able to reproduce the issue that credentials inside withCredential blocks were displayed in blue ocean (as mentioned in the [issue](https://github.com/opendevstack/ods-jenkins-shared-library/issues/212#issuecomment-609644690)) anymore, I found next to the Snyk issue another one when receiving bitbucket token via the API. The response (with the token) is read by readJSON outside of a withCredentials block which prints it in the output log. I just moved it inside, I don't see any change in the logic doing that.