### PR TITLE
Resolve tags to SHAs

### DIFF
--- a/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
@@ -281,7 +281,6 @@ When you author templates, you can also store the secrets in the param files GPG
 
 - For versioned, separate DEV environments, pulling images from the `foo-cd` namespace is not possible (because the `foo-cd:jenkins` serviceaccount does not have admin rights in `foo-cd` and therefore can't grant access to it)
 - Tagging means we are pointing to a concrete SHA of a Git repository. This enforces that no manual editing of exported config can happen between promotion to QA and promotion to PROD, which in effect forces everything to be parameterized properly.
-- Every component must have exactly one `DeploymentConfig` with exactly one pod and one container. The `DeploymentConfig` name must match the component ID. Further, the `DeploymentConfig` must have an image trigger set on the `latest` tag of the corresonding `ImageStream`.
 - JIRA always triggers the `master` branch of the release manager, which means the `Jenkinsfile` is always taken from `master` (and NOT from the correct release branch - only `metadata.yml` etc. are read from the release branch)
 - There is only one QA namespace, preventing to test multiple releases at the same time.
 - The secret of the serviceaccount in the target cluster is known to the orchestration pipeline (as a Jenkins credential synced from OpenShift), therefore developers with edit/admin rights in the CD namespace have access to that secret

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -280,19 +280,6 @@ class OpenShiftService {
         )
     }
 
-    // getRunningImageSha returns the sha with "sha256:" prefix, e.g.
-    // sha256:eec4a4451a307bd1fa44bde6642077a3c2a722e0ad370c1c22fcebcd8d4efd33
-    String getRunningImageSha(String component, int version, index = 0) {
-        def runningImageStreamUrl = steps.sh(
-            script: """oc -n ${project} get rc/${component}-${version} \
-            -o jsonpath='{.spec.template.spec.containers[${index}].image}'
-            """,
-            label: "Get running image for rc/${component}-${version} containerIndex: ${index}",
-            returnStdout: true
-        ).trim()
-        imageInfoWithShaForImageStreamUrl(runningImageStreamUrl).sha
-    }
-
     void importImageFromProject(String name, String sourceProject, String imageSha, String imageTag) {
         steps.sh(
             script: """oc -n ${project} tag ${sourceProject}/${name}@${imageSha} ${name}:${imageTag}""",
@@ -401,7 +388,6 @@ class OpenShiftService {
     // - registry (empty if not specified)
     // - repository (= OpenShift project in case of image from ImageStream)
     // - name (= ImageStream name in case of image from ImageStream)
-    // - reference (= <name>@sha256:<sha-identifier>)
     // - sha (= sha256:<sha-identifier>)
     // - shaStripped (= <sha-identifier>)
     Map<String, String> imageInfoWithShaForImageStreamUrl(String imageStreamUrl) {
@@ -467,7 +453,11 @@ class OpenShiftService {
         pod.podStartupTimeStamp = podOCData.status?.startTime ?: 'N/A'
         pod.containers = [:]
         podOCData.spec?.containers?.each { container ->
-            pod.containers[container.name] = container.image
+            podOCData.status?.containerStatuses?.each { containerStatus ->
+                if (containerStatus.name == container.name) {
+                    pod.containers[container.name] = containerStatus.imageID - ~/^docker-pullable:\/\//
+                }
+            }
         }
         pod
     }

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -52,4 +52,29 @@ class OpenShiftServiceSpec extends SpecHelper {
         'baz/qux@sha256:abc'                    | 'n/a'                                   || ''                   | 'baz'      | 'qux' | 'sha256:abc' | 'abc'
     }
 
+    def "pod data extraction"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def service = new OpenShiftService(steps, new Logger(steps, false), 'foo')
+        def file = new FixtureHelper().getResource("pod.json")
+
+        when:
+        def result = service.extractPodData(file.text, "deployment 'bar'")
+
+        then:
+        result == [
+            podName: 'bar-164-6xxbw',
+            podNamespace: 'foo-dev',
+            podMetaDataCreationTimestamp: '2020-05-18T10:43:56Z',
+            deploymentId: 'bar-164',
+            podNode: 'ip-172-31-61-82.eu-central-1.compute.internal',
+            podIp: '10.128.17.92',
+            podStatus: 'Running',
+            podStartupTimeStamp: '2020-05-18T10:43:56Z',
+            containers: [
+                bar: '172.30.21.196:5000/foo-dev/bar@sha256:07ba1778e7003335e6f6e0f809ce7025e5a8914dc5767f2faedd495918bee58a'
+            ]
+        ]
+    }
+
 }

--- a/test/resources/pod.json
+++ b/test/resources/pod.json
@@ -1,0 +1,178 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/deployment-config.latest-version": "164",
+                    "openshift.io/deployment-config.name": "bar",
+                    "openshift.io/deployment.name": "bar-164",
+                    "openshift.io/scc": "restricted"
+                },
+                "creationTimestamp": "2020-05-18T10:43:56Z",
+                "generateName": "bar-164-",
+                "labels": {
+                    "app": "foo-bar",
+                    "deployment": "bar-164",
+                    "deploymentconfig": "bar",
+                    "env": "dev"
+                },
+                "name": "bar-164-6xxbw",
+                "namespace": "foo-dev",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicationController",
+                        "name": "bar-164",
+                        "uid": "44dc33dc-98f2-11ea-94ce-0a20b7cbe558"
+                    }
+                ],
+                "resourceVersion": "374807063",
+                "selfLink": "/api/v1/namespaces/foo-dev/pods/bar-164-6xxbw",
+                "uid": "799d51ee-98f4-11ea-94ce-0a20b7cbe558"
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "172.30.21.196:5000/foo-dev/bar:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "bar",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "requests": {
+                                "cpu": "50m",
+                                "memory": "128Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "KILL",
+                                    "MKNOD",
+                                    "NET_RAW",
+                                    "SETGID",
+                                    "SETUID"
+                                ]
+                            },
+                            "runAsUser": 1030510000
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "default-token-grgk5",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "imagePullSecrets": [
+                    {
+                        "name": "default-dockercfg-4p2tj"
+                    }
+                ],
+                "nodeName": "ip-172-31-61-82.eu-central-1.compute.internal",
+                "nodeSelector": {
+                    "type": "compute"
+                },
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "fsGroup": 1030510000,
+                    "seLinuxOptions": {
+                        "level": "s0:c175,c30"
+                    }
+                },
+                "serviceAccount": "default",
+                "serviceAccountName": "default",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "default-token-grgk5",
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "default-token-grgk5"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2020-05-18T10:43:56Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2020-05-18T10:44:00Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": null,
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2020-05-18T10:43:56Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "docker://fdfde9264910904ea0486a18d7a01d02c86b9792d6ee39357fcbb05a7e073fa9",
+                        "image": "172.30.21.196:5000/foo-dev/bar:7-9e688f0e",
+                        "imageID": "docker-pullable://172.30.21.196:5000/foo-dev/bar@sha256:07ba1778e7003335e6f6e0f809ce7025e5a8914dc5767f2faedd495918bee58a",
+                        "lastState": {},
+                        "name": "bar",
+                        "ready": true,
+                        "restartCount": 0,
+                        "state": {
+                            "running": {
+                                "startedAt": "2020-05-18T10:43:59Z"
+                            }
+                        }
+                    }
+                ],
+                "hostIP": "172.31.61.82",
+                "phase": "Running",
+                "podIP": "10.128.17.92",
+                "qosClass": "Burstable",
+                "startTime": "2020-05-18T10:43:56Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}


### PR DESCRIPTION
Fixes #343.

- Resolves to SHA before writing image to file
- Reads from `containerStatuses` to be sure to get a SHA and not a tag from the running pod
- Saves a few API requests as we already need to query the pod :)

Tested with WIP, assemble, and promote.