### PR TITLE
Remove naming reference to jira unexecuted tests.

### DIFF
--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -75,19 +75,19 @@ class FinalizeStage extends Stage {
         levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
 
         // Fail the build in case of failing tests.
-        if (project.hasFailingTests() || project.hasUnexecutedJiraTests()) {
+        if (project.hasFailingTests() || project.hasUnexecutedTests()) {
             def message = 'Error: '
 
             if (project.hasFailingTests()) {
                 message += 'found failing tests'
             }
 
-            if (project.hasFailingTests() && project.hasUnexecutedJiraTests()) {
+            if (project.hasFailingTests() && project.hasUnexecutedTests()) {
                 message += ' and '
             }
 
-            if (project.hasUnexecutedJiraTests()) {
-                message += 'found unexecuted Jira tests'
+            if (project.hasUnexecutedTests()) {
+                message += 'found unexecuted tests'
             }
 
             message += "."

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -237,7 +237,7 @@ class JiraUseCase {
         this.util.warnBuildIfTestResultsContainFailure(testResults)
         this.matchTestIssuesAgainstTestResults(testIssues, testResults, null) { unexecutedJiraTests ->
             if (!unexecutedJiraTests.isEmpty()) {
-                this.util.warnBuildAboutUnexecutedJiraTests(unexecutedJiraTests)
+                this.util.warnBuildAboutUnexecutedTests(unexecutedJiraTests.collect { it.key })
             }
         }
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -12,7 +12,6 @@ import org.ods.services.OpenShiftService
 import org.ods.services.JenkinsService
 import org.ods.services.ServiceRegistry
 import org.ods.services.GitService
-import org.ods.orchestration.util.Project
 import org.yaml.snakeyaml.Yaml
 
 import groovy.json.JsonOutput
@@ -690,10 +689,9 @@ class MROPipelineUtil extends PipelineUtil {
         }
     }
 
-    void warnBuildAboutUnexecutedJiraTests(List unexecutedJiraTests) {
-        this.project.setHasUnexecutedJiraTests(true)
-        def unexecutedJiraTestKeys = unexecutedJiraTests.collect { it.key }.join(", ")
-        this.warnBuild("Warning: found unexecuted Jira tests: ${unexecutedJiraTestKeys}.")
+    void warnBuildAboutUnexecutedTests(List unexecutedTestKeys) {
+        this.project.setHasUnexecutedTests(true)
+        this.warnBuild("Warning: found unexecuted tests: ${unexecutedTestKeys.join(", ")}.")
     }
 
     void warnBuildIfTestResultsContainFailure(Map testResults) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -221,7 +221,7 @@ class Project {
 
         this.data.build = [
             hasFailingTests: false,
-            hasUnexecutedJiraTests: false
+            hasUnexecutedTests: false
         ]
     }
 
@@ -722,8 +722,8 @@ class Project {
         return this.data.build.hasFailingTests
     }
 
-    boolean hasUnexecutedJiraTests() {
-        return this.data.build.hasUnexecutedJiraTests
+    boolean hasUnexecutedTests() {
+        return this.data.build.hasUnexecutedTests
     }
 
     static boolean isTriggeredByChangeManagementProcess(steps) {
@@ -1039,8 +1039,8 @@ class Project {
         this.data.build.hasFailingTests = status
     }
 
-    void setHasUnexecutedJiraTests(boolean status) {
-        this.data.build.hasUnexecutedJiraTests = status
+    void setHasUnexecutedTests(boolean status) {
+        this.data.build.hasUnexecutedTests = status
     }
 
     String toString() {

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -5,7 +5,6 @@ import org.ods.orchestration.service.JiraService
 import org.ods.util.IPipelineSteps
 import org.ods.orchestration.util.MROPipelineUtil
 import org.ods.orchestration.util.Project
-import spock.lang.Ignore
 import util.SpecHelper
 
 import static util.FixtureHelper.*
@@ -282,7 +281,7 @@ class JiraUseCaseSpec extends SpecHelper {
         then:
         1 * support.applyXunitTestResults(testIssues, testResults)
         1 * util.warnBuildIfTestResultsContainFailure(testResults)
-        1 * util.warnBuildAboutUnexecutedJiraTests(_)
+        1 * util.warnBuildAboutUnexecutedTests(_)
     }
 
     def "report test results for component with unexecuted Jira tests"() {
@@ -297,6 +296,7 @@ class JiraUseCaseSpec extends SpecHelper {
 
         // Stubbed Method Responses
         def testIssues = createJiraTestIssues()
+        def testIssueKeys = testIssues.collect { it.key }
 
         when:
         usecase.reportTestResultsForComponent(componentName, testTypes, testResults)
@@ -305,7 +305,7 @@ class JiraUseCaseSpec extends SpecHelper {
         1 * project.getAutomatedTests(componentName, testTypes) >> testIssues
 
         then:
-        1 * util.warnBuildAboutUnexecutedJiraTests(testIssues)
+        1 * util.warnBuildAboutUnexecutedTests(testIssueKeys)
     }
 
     def "report test results for component in QA"() {

--- a/test/groovy/org/ods/orchestration/util/MROPipelineUtilSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/MROPipelineUtilSpec.groovy
@@ -1,14 +1,10 @@
 package org.ods.orchestration.util
 
-import java.nio.file.Files
+
 import java.nio.file.Paths
 
-import org.ods.orchestration.parser.JUnitParser
 import org.ods.util.IPipelineSteps
-import org.ods.orchestration.util.Project
 import org.ods.services.GitService
-
-import spock.lang.*
 
 import static util.FixtureHelper.*
 
@@ -564,14 +560,14 @@ class MROPipelineUtilSpec extends SpecHelper {
         ]
 
         when:
-        util.warnBuildAboutUnexecutedJiraTests(unexecutedJiraTests)
+        util.warnBuildAboutUnexecutedTests(unexecutedJiraTests.collect { it.key })
 
         then:
-        project.hasUnexecutedJiraTests() == true
+        project.hasUnexecutedTests() == true
 
         then:
         steps.currentBuild.result == "UNSTABLE"
-        1 * steps.echo("Warning: found unexecuted Jira tests: KEY-1, KEY-2, KEY-3.")
+        1 * steps.echo("Warning: found unexecuted tests: KEY-1, KEY-2, KEY-3.")
 
         then:
         noExceptionThrown() // pipeline does not stop here


### PR DESCRIPTION
The mandatory tests could be defined elsewhere other than Jira, so the naming of the methods should not contain any reference.