### PR TITLE
Fix various smaller issues

### DIFF
--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -431,6 +431,7 @@ class Pipeline implements Serializable {
     }
 
     private void amendProjectAndComponentFromOrigin(Map config) {
+        logger.debug("Amending project / component based on Git origin URL")
         def block = {
             def origin
             try {
@@ -442,6 +443,7 @@ class Pipeline implements Serializable {
                 origin = (new OpenShiftService(steps, logger, projectName))
                     .getOriginUrlFromBuildConfig(bcName)
             }
+            logger.debug("Retrieved Git origin URL: ${origin}")
 
             def splittedOrigin = origin.split('/')
             def project = splittedOrigin[splittedOrigin.size() - 2]

--- a/src/org/ods/quickstarter/CreateOutputDirectoryStage.groovy
+++ b/src/org/ods/quickstarter/CreateOutputDirectoryStage.groovy
@@ -9,6 +9,9 @@ class CreateOutputDirectoryStage extends Stage {
     }
 
     def run() {
+        if (script.fileExists(context.targetDir)) {
+            script.error "Target directory '${context.targetDir}' must not exist yet"
+        }
         script.sh(
             script: "mkdir -p ${context.targetDir}",
             label: "Create directory '${context.targetDir}'"

--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -20,6 +20,8 @@ class SonarQubeService {
                 "-Dsonar.host.url=${hostUrl}",
                 "-Dsonar.auth.token=${authToken}",
                 '-Dsonar.scm.provider=git',
+                "-Dsonar.projectKey=${properties['sonar.projectKey']}",
+                "-Dsonar.projectName=${properties['sonar.projectName']}",
             ]
             if (!properties.containsKey('sonar.projectVersion')) {
                 scannerParams << "-Dsonar.projectVersion=${gitCommit.take(8)}"


### PR DESCRIPTION
* Adds debug statement when project / component is auto-resolved (there was a related failure which I could not reproduce now, but at least one would see more info when debug is enabled now)
* Makes overriding of `projectKey` and `projectName` consistent (otherwise e.g. `ods-doc-gen-svc` QS fails because the behaviour of `sonar-scanner` and `cnesreport.jar` was inconsistent). On a side note, I realised that overriding  `projectKey` is, technically speaking, a backwards incompatible change. However, my understanding is that you want to enforce it, right @clemensutschig?
* Adds a check if the target directory exists. @clemensutschig do you remember why we changed it from `out`, which is what I had initially, to the value of `componentId`? If it doesn't need to be `componentId`, then I actually propose to make a further change and switch back to `out` to be really safe.