### PR TITLE
Add OpenShift project name to token name

### DIFF
--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -143,7 +143,7 @@ class BitbucketService {
     private Map<String, String> createUserToken() {
         def tokenMap = [username: '', password: '']
         def res = ''
-        def payload = '{"name": "ods-jenkins-shared-library", "permissions": ["PROJECT_WRITE", "REPO_WRITE"]}'
+        def payload = """{"name": "ods-jenkins-shared-library-${openShiftCdProject}", "permissions": ["PROJECT_WRITE", "REPO_WRITE"]}"""
         script.withCredentials(
             [script.usernamePassword(
                 credentialsId: passwordCredentialsId,


### PR DESCRIPTION
When one user is used in multiple ODS projects, it is easier to
identify for which project the token was created.

The PAT name has only informational character, so nothing should be
affected by this change.