### PR TITLE
Check openshift resources

### DIFF
--- a/src/org/ods/component/BuildOpenShiftImageStage.groovy
+++ b/src/org/ods/component/BuildOpenShiftImageStage.groovy
@@ -85,6 +85,12 @@ class BuildOpenShiftImageStage extends Stage {
 
         def imageLabels = assembleImageLabels()
         writeReleaseFile(imageLabels, config)
+
+        if (!buildConfigExists()) {
+            script.error "BuildConfig '${config.resourceName}' does not exist. " +
+                'Verify that you have setup the OpenShift resource correctly ' +
+                'and/or set the "resourceName" option of the pipeline stage appropriately.'
+        }
         patchBuildConfig(imageLabels)
 
         // Start and follow build of container image.
@@ -121,6 +127,10 @@ class BuildOpenShiftImageStage extends Stage {
             return "${STAGE_NAME} (${config.resourceName})"
         }
         STAGE_NAME
+    }
+
+    private boolean buildConfigExists() {
+        openShift.resourceExists('BuildConfig', config.resourceName)
     }
 
     private String getImageReference() {

--- a/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
+++ b/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
@@ -79,7 +79,9 @@ class RolloutOpenShiftDeploymentStage extends Stage {
         }
 
         if (!dcExists) {
-            script.error "DeploymentConfig '${config.resourceName}' does not exist."
+            script.error "DeploymentConfig '${config.resourceName}' does not exist. " +
+                'Verify that you have setup the OpenShift resource correctly ' +
+                'and/or set the "resourceName" option of the pipeline stage appropriately.'
         }
 
         def ownedImageStreams = openShift
@@ -88,7 +90,9 @@ class RolloutOpenShiftDeploymentStage extends Stage {
         def missingStreams = missingImageStreams(ownedImageStreams)
         if (missingStreams) {
             script.error "The following ImageStream resources  for DeploymentConfig '${config.resourceName}' " +
-                """do not exist: '${missingStreams.collect { "${it.repository}/${it.name}" }}'."""
+                """do not exist: '${missingStreams.collect { "${it.repository}/${it.name}" }}'. """ +
+                'Verify that you have setup the OpenShift resources correctly ' +
+                'and/or set the "resourceName" option of the pipeline stage appropriately.'
         }
 
         setImageTagLatest(ownedImageStreams)

--- a/test/groovy/vars/OdsComponentStageBuildOpenShiftImageSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageBuildOpenShiftImageSpec.groovy
@@ -33,6 +33,7 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
     def c = config + [environment: 'dev']
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Mock(OpenShiftService.class)
+    openShiftService.resourceExists(*_) >> true
     openShiftService.startAndFollowBuild(_, _) >> 'bar-123'
     openShiftService.getLastBuildVersion(_) >> 123
     openShiftService.getBuildStatus(_) >> 'complete'
@@ -84,6 +85,7 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
     def c = config + [environment: 'dev', projectId: 'foo']
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Mock(OpenShiftService.class)
+    openShiftService.resourceExists(*_) >> true
     openShiftService.startAndFollowBuild(*_) >> 'bar-123'
     openShiftService.getLastBuildVersion(*_) >> 123
     openShiftService.getBuildStatus(*_) >> 'complete'
@@ -125,6 +127,7 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
     def c = config + [environment: 'dev', "globalExtensionImageLabels" : [ "globalext": "extG" ]]
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Stub(OpenShiftService.class)
+    openShiftService.resourceExists(*_) >> true
     openShiftService.startAndFollowBuild(*_) >> 'overwrite-123'
     openShiftService.getLastBuildVersion(*_) >> 123
     openShiftService.getBuildStatus(*_) >> 'complete'


### PR DESCRIPTION
Improves error messages and adds a check for the build config. This is helpful in case sth goes wrong - which is the "standard" case if you try out the prov app quickstarter which doesn't ship the resources required. Users have to do that manually.