### PR TITLE
Expose DOCKER_REGISTRY

### DIFF
--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -26,6 +26,8 @@ interface IContext {
 
     String getGitUrlHttp()
 
+    String getDockerRegistry()
+
     String getOdsNamespace()
 
     String getOdsImageTag()


### PR DESCRIPTION
The getter is already present in the implementation (Context.groovy) but
was missing in the interface.

E.g. needed for the release-manager quickstarter to set a proper image.