### PR TITLE
Fix credentials handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ trim_trailing_whitespace = false ; trimming trailing whitespace may break Markdo
 tab_width = 4
 indent_style = tab
 
+[*.yml]
+indent_size = 2
+

--- a/codenarc.groovy
+++ b/codenarc.groovy
@@ -268,7 +268,7 @@ ruleset {
     ExplicitStackInstantiation
     ExplicitTreeSetInstantiation
     GStringAsMapKey
-    GStringExpressionWithinString(enabled: false) // TODO: Could this be enabled without triggering false positives?
+    GStringExpressionWithinString
     GetterMethodCouldBeProperty
     GroovyLangImmutable
     UseCollectMany

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -231,7 +231,9 @@ class Context implements IContext {
 
     @NonCPS
     String getNexusUrlWithBasicAuth() {
-        config.nexusUrl.replace('://', "://${config.nexusUsername}:${config.nexusPassword}@")
+        String un = URLEncoder.encode(config.nexusUsername as String, 'UTF-8')
+        String pw = URLEncoder.encode(config.nexusPassword as String, 'UTF-8')
+        config.nexusUrl.replace('://', "://${un}:${pw}@")
     }
 
     @NonCPS

--- a/src/org/ods/orchestration/Stage.groovy
+++ b/src/org/ods/orchestration/Stage.groovy
@@ -8,6 +8,7 @@ import org.ods.services.BitbucketService
 import org.ods.services.GitService
 import org.ods.services.JenkinsService
 
+import org.ods.util.GitCredentialStore
 import org.ods.util.PipelineSteps
 
 import org.ods.util.Logger
@@ -147,17 +148,10 @@ class Stage {
                         passwordVariable: 'BITBUCKET_PW'
                     )]
                 ) {
-                    def bbUser = URLEncoder.encode(script.env.BITBUCKET_USER, 'UTF-8')
-                    def bbPwd = URLEncoder.encode(script.env.BITBUCKET_PW, 'UTF-8')
-                    def urlWithCredentials = bitbucket.url.replace('://', "://${bbUser}:${bbPwd}@")
-                    script.writeFile(
-                        file: "${script.env.HOME}/.git-credentials",
-                        text: urlWithCredentials
-                    )
-                    script.sh(
-                        script: 'git config --global credential.helper store',
-                        label: 'setup credential helper'
-                    )
+                    GitCredentialStore.configureAndStore(
+                        script, bitbucket.url as String,
+                        script.env.BITBUCKET_USER as String,
+                        script.env.BITBUCKET_PW as String)
                 }
                 block()
             }

--- a/src/org/ods/quickstarter/ForkFromGithubODSStage.groovy
+++ b/src/org/ods/quickstarter/ForkFromGithubODSStage.groovy
@@ -1,5 +1,7 @@
 package org.ods.quickstarter
 
+import org.ods.util.GitCredentialStore
+
 class ForkFromGithubODSStage extends Stage {
 
     protected String STAGE_NAME = 'Fork from ODS Github'
@@ -23,10 +25,10 @@ class ForkFromGithubODSStage extends Stage {
                 usernameVariable: 'user'
             )]
         ) {
-            script.writeFile(
-                file: '/home/jenkins/.netrc',
-                text: "machine ${config.gitHost} login ${script.user} password ${script.pass}"
-            )
+            GitCredentialStore.configureAndStore(script,
+                context.bitbucketUrl as String,
+                script.env.user as String,
+                script.env.pass as String)
         }
 
         def githubRepoUrl = "https://github.com/opendevstack/${config.odsComponent}.git"

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -59,7 +59,6 @@ class Pipeline implements Serializable {
         }
 
         // vars from jenkins master
-        def gitHost
         script.node {
             config.jobName = script.env.JOB_NAME
             config.buildNumber = script.env.BUILD_NUMBER
@@ -67,8 +66,6 @@ class Pipeline implements Serializable {
             config.buildTime = new Date()
             config.dockerRegistry = script.env.DOCKER_REGISTRY
             config << BitbucketService.readConfigFromEnv(script.env)
-            def bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
-            gitHost =  bitbucketHost.split(':').first()
             config << NexusService.readConfigFromEnv(script.env)
         }
 
@@ -79,7 +76,7 @@ class Pipeline implements Serializable {
             // Execute user-defined stages.
             block(context)
 
-            new PushToRemoteStage(script, context, [gitHost: gitHost]).execute()
+            new PushToRemoteStage(script, context).execute()
         }
     }
 

--- a/src/org/ods/quickstarter/PushToRemoteStage.groovy
+++ b/src/org/ods/quickstarter/PushToRemoteStage.groovy
@@ -1,5 +1,7 @@
 package org.ods.quickstarter
 
+import org.ods.util.GitCredentialStore
+
 class PushToRemoteStage extends Stage {
 
     protected String STAGE_NAME = 'Push to remote'
@@ -19,9 +21,11 @@ class PushToRemoteStage extends Stage {
                 usernameVariable: 'user'
             )]
         ) {
-            script.writeFile(
-                file: '/home/jenkins/.netrc',
-                text: "machine ${config.gitHost} login ${script.user} password ${script.pass}"
+            GitCredentialStore.configureAndStore(
+                script,
+                context.bitbucketUrl as String,
+                script.env.user as String,
+                script.env.pass as String
             )
         }
 

--- a/src/org/ods/util/AuthUtil.groovy
+++ b/src/org/ods/util/AuthUtil.groovy
@@ -1,0 +1,61 @@
+package org.ods.util
+
+import com.cloudbees.groovy.cps.NonCPS
+import groovy.transform.TypeChecked
+import org.apache.http.client.utils.URIBuilder
+
+@TypeChecked
+class AuthUtil {
+
+    public static final String HEADER_AUTHORIZATION = 'Authorization'
+    public static final String SCHEME_BASIC = 'Basic'
+    public static final String SCHEME_BEARER = 'Bearer'
+
+    @NonCPS
+    static String base64(String str) {
+        Base64.getEncoder().encodeToString((str).getBytes())
+    }
+
+    @NonCPS
+    static String basicSchemeAuthValue(String username, String password) {
+        base64(username + ':' + password)
+    }
+
+    @NonCPS
+    static String header(String scheme, String username, String password) {
+        "${HEADER_AUTHORIZATION}: ${headerValue(scheme, username, password)}"
+    }
+
+    @NonCPS
+    static String headerValue(String scheme, String username, String password) {
+        "${scheme} ${basicSchemeAuthValue(username, password)}"
+    }
+
+    @NonCPS
+    // useful to feed into `git credential-store store`
+    static String[] gitCredentialLines(String url, String username, String password) {
+        String proto = url.startsWith('http://') ? 'http' :
+            (url.startsWith('https://') ? 'https' : null)
+        if (proto == null) {
+            throw new IllegalArgumentException("Protocol of ${url} must be 'http' or 'https'")
+        }
+
+        URI baseURL
+        try {
+            baseURL = new URIBuilder(url).build()
+        } catch (e) {
+            throw new IllegalArgumentException("'${url}' is not a valid URI."
+            ).initCause(e)
+        }
+        String host = baseURL.host
+
+        [
+            "protocol=${proto}",
+            "host=${host}",
+            "username=${username}",
+            "password=${password}",
+            '',
+        ] as String[]
+    }
+
+}

--- a/src/org/ods/util/GitCredentialStore.groovy
+++ b/src/org/ods/util/GitCredentialStore.groovy
@@ -1,0 +1,24 @@
+package org.ods.util
+
+class GitCredentialStore {
+
+    static void configureAndStore(
+        def script, String gitServerUrl, String username, String password) {
+        String[] lines = AuthUtil.gitCredentialLines(gitServerUrl, username, password)
+        String inputFile = "${script.env.HOME}/.git-credentials-input"
+        script.writeFile(
+            file: "${inputFile}",
+            text: lines.join('\n')
+        )
+        script.echo "wrote $inputFile with credentials for $username on $gitServerUrl"
+        script.sh(
+            script: 'git config --global credential.helper store',
+            label: 'setup git credential helper'
+        )
+        // this way we do not need to deal with encodings or how to update an entry
+        script.sh(
+            script: "cat ${inputFile} | git credential-store store",
+            label: 'setup git credential store'
+        )
+    }
+}

--- a/test/groovy/org/ods/services/BitbucketServiceSpec.groovy
+++ b/test/groovy/org/ods/services/BitbucketServiceSpec.groovy
@@ -1,10 +1,7 @@
 package org.ods.services
 
-import spock.lang.*
-import vars.test_helper.PipelineSpockTestBase
-
-import util.*
 import org.ods.util.Logger
+import vars.test_helper.PipelineSpockTestBase
 
 class BitbucketServiceSpec extends PipelineSpockTestBase {
 
@@ -32,5 +29,20 @@ class BitbucketServiceSpec extends PipelineSpockTestBase {
         jsonFixture             | branch        || expected
         'pull-requests.json'    | 'feature/foo' || [key: 1, base: 'master']
         'no-pull-requests.json' | 'feature/foo' || [:]
+    }
+
+    def "check user token secret yml"() {
+        expect:
+        BitbucketService.userTokenSecretYml("my-secret", username, password) == expected
+        where:
+        username | password | expected
+        "test@example.com" | "\$1 2 3\u00a3" | readResource('user-token-secret-1.yml')
+
+    }
+
+    protected String readResource(String name) {
+        def classLoader = getClass().getClassLoader();
+        def file = new File(classLoader.getResource(name).getFile());
+        file.text
     }
 }

--- a/test/groovy/org/ods/util/AuthUtilSpec.groovy
+++ b/test/groovy/org/ods/util/AuthUtilSpec.groovy
@@ -1,0 +1,70 @@
+package org.ods.util
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AuthUtilSpec extends Specification {
+
+    @Unroll
+    def "check gitCredentialLines works for #url, #username, #password"() {
+        expect:
+        AuthUtil.gitCredentialLines(url, username, password) == expected
+        where:
+        url | username | password | expected
+        "https://hi:pw@git.com" | "one@example.com" | "123 \u00a3" | ["protocol=https", "host=git.com", "username=one@example.com", "password=123 £", ""]
+
+    }
+
+    @Unroll
+    def "auth value is as expected for Basic with #username, #password"() {
+        expect:
+        AuthUtil.headerValue(AuthUtil.SCHEME_BASIC, username, password) == expected
+        where:
+        username | password | expected
+//      first two form https://tools.ietf.org/html/rfc7617#page-3
+        "Aladdin" | "open sesame" | "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+        "test" | "123\u00a3" | "Basic dGVzdDoxMjPCow=="
+        "one@example.com" | "123" | "Basic b25lQGV4YW1wbGUuY29tOjEyMw=="
+        "one@example.com" | "" | "Basic b25lQGV4YW1wbGUuY29tOg=="
+        "two" | '''@!|\\*$foo''' | "Basic dHdvOkAhfFwqJGZvbw=="
+        "three" | "'" | "Basic dGhyZWU6Jw=="
+        "four" | '"hi"' | "Basic Zm91cjoiaGki"
+    }
+
+    @Unroll
+    def "basic auth header is #expected" () {
+        expect:
+        AuthUtil.header(AuthUtil.SCHEME_BASIC, username, password) == expected
+        where:
+        username | password | expected
+        "test" | "123\u00a3" | "Authorization: Basic dGVzdDoxMjPCow=="
+    }
+
+    @Unroll
+    def "bearer auth header is #expected" () {
+        expect:
+        AuthUtil.header(AuthUtil.SCHEME_BEARER, username, password) == expected
+        where:
+        username | password | expected
+        "test" | "123\u00a3" | "Authorization: Bearer dGVzdDoxMjPCow=="
+    }
+
+
+    @Unroll
+    def "custom auth header is #expected" () {
+        expect:
+        AuthUtil.header("Custom", username, password) == expected
+        where:
+        username | password | expected
+        "test" | "123\u00a3" | "Authorization: Custom dGVzdDoxMjPCow=="
+    }
+
+    @Unroll
+    def "alternative custom auth header in lowercase is #expected" () {
+        expect:
+        "authorization: Custom ${AuthUtil.basicSchemeAuthValue(username, password)}" == expected
+        where:
+        username | password | expected
+        "test" | "123\u00a3" | "authorization: Custom dGVzdDoxMjPCow=="
+    }
+}

--- a/test/resources/user-token-secret-1.yml
+++ b/test/resources/user-token-secret-1.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  username: dGVzdEBleGFtcGxlLmNvbQ==
+  password: JDEgMiAzwqM=
+kind: Secret
+type: kubernetes.io/basic-auth
+metadata:
+  name: my-secret
+  labels:
+    credential.sync.jenkins.openshift.io: 'true'

--- a/vars/odsOrchestrationPipeline.groovy
+++ b/vars/odsOrchestrationPipeline.groovy
@@ -107,6 +107,7 @@ def call(Map config) {
     }
 }
 
+@SuppressWarnings('GStringExpressionWithinString')
 private withPodTemplate(String odsImageTag, IPipelineSteps steps, boolean alwaysPullImage, Closure block) {
     ILogger logger = ServiceRegistry.instance.get(Logger)
     def podLabel = "mro-jenkins-agent-${env.BUILD_NUMBER}"


### PR DESCRIPTION
closes #112 

This must be delivered with an associated PR in ods-core to keep auto cloning working. 

Here a summary of the changes:

- Use `curl --header "Authorization:..."` instead of `--user` to avoid issues with quoting and escaping. I did not have the time to move this to Unirest now.  

- Instead of using `oc create secret` with `--from-literal=password=${password}` the yaml template is written as a file so that there cannot be any issues with weird usernames and passwords as the in the yaml these are base64 encoded.

- Before invoking clone scripts setup a git credential helper with access to the credentials. The details are handled by `git credential-store < file-with-credentials` ,  which handle all details in how these are store and updated. The git code updates or adds an entry and leaves unrelated entries alone. 

Additional notes:
- Credential helpers are also set in another area. I considered changing these to use `GitCredentialStore.setup` but think it should be delivered in a separate PR. Also I am not sure how to test mro scenarios.
- Similar I would propose to consider moving code which uses netrc to enable git operations to instead use `GitCredentialStore.setup`.   
