### PR TITLE
Use URLs consistently

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ codenarc {
     configFile = file('codenarc.groovy')
     maxPriority1Violations = 0
     maxPriority2Violations = 0
-    maxPriority3Violations = 766
+    maxPriority3Violations = 738
     reportFormat = 'html'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
 
 ext {
-    nexus_url = project.findProperty('nexus_url') ?: System.getenv('NEXUS_HOST')
+    nexus_url = project.findProperty('nexus_url') ?: System.getenv('NEXUS_URL') ?: System.getenv('NEXUS_HOST')
     nexus_user = project.findProperty('nexus_user') ?: System.getenv('NEXUS_USERNAME')
     nexus_pw = project.findProperty('nexus_pw') ?: System.getenv('NEXUS_PASSWORD')
     no_nexus = (project.findProperty('no_nexus') ?: System.getenv('NO_NEXUS') ?: false).toBoolean()

--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -108,8 +108,11 @@ The `context` object contains the following properties:
 | tagversion
 | The tagversion is made up of the build number and the first 8 chars of the commit SHA.
 
+| nexusUrl
+| Nexus URL - value taken from `NEXUS_URL`. If `NEXUS_URL` is not present, it will default to `NEXUS_HOST` (which also includes the scheme).
+
 | nexusHost
-| Nexus host (with scheme).
+| Nexus host - value derived from `nexusUrl`. It does not include the scheme if `nexusUrl` was read from `NEXUS_URL`.
 
 | nexusUsername
 | Nexus username.
@@ -117,8 +120,11 @@ The `context` object contains the following properties:
 | nexusPassword
 | Nexus password.
 
+| nexusUrlWithBasicAuth
+| Nexus URL, including username and password as BasicAuth.
+
 | nexusHostWithBasicAuth
-| Nexus host (with scheme), including username and password as BasicAuth.
+| DEPRECATED. Nexus host (with scheme), including username and password as BasicAuth.
 
 | cloneSourceEnv
 | The environment which was chosen as the clone source.
@@ -166,10 +172,10 @@ The `context` object contains the following properties:
 | ODS Jenkins shared library version, taken from reference in `Jenkinsfile`.
 
 | bitbucketUrl
-| BitBucket URL - value taken from `BITBUCKET_URL`. If BITBUCKET_URL is not present, it will default to `https://<BITBUCKET_HOST>``.
+| Bitbucket URL - value taken from `BITBUCKET_URL`. If BITBUCKET_URL is not present, it will default to `https://<BITBUCKET_HOST>``.
 
 | bitbucketHost
-| BitBucket host - value derived from `bitbucketUrl`.
+| Bitbucket host - value derived from `bitbucketUrl`.
 
 | dockerDir
 | The docker directory to use when building the image in openshift. Defaults to `docker`.
@@ -282,7 +288,7 @@ you can follow the following steps:
 
 * Check this HOWTO about https://www.atlassian.com/git/tutorials/git-lfs[Git LFS]
 * Track your large files in your local clone, as explained in previous step
-* Enable Git LFS in your repository (if BitBucket: under repository's settings main page you can enable it)
+* Enable Git LFS in your repository (if Bitbucket: under repository's settings main page you can enable it)
 
 *NOTE*: if already having a repository with large files and you want to migrate it to using git LFS:
 

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -205,6 +205,11 @@ class Context implements IContext {
     }
 
     @NonCPS
+    String getNexusUrl() {
+        config.nexusUrl
+    }
+
+    @NonCPS
     String getNexusHost() {
         config.nexusHost
     }
@@ -219,8 +224,16 @@ class Context implements IContext {
         config.nexusPassword
     }
 
+    @NonCPS
+    String getNexusUrlWithBasicAuth() {
+        config.nexusUrl.replace('://', "://${config.nexusUsername}:${config.nexusPassword}@")
+    }
+
+    // To support legacy systems, also uses nexusUrl value.
+    // To be removed in ODS 4+.
+    @NonCPS
     String getNexusHostWithBasicAuth() {
-        config.nexusHost.replace('://', "://${config.nexusUsername}:${config.nexusPassword}@")
+        config.nexusUrl.replace('://', "://${config.nexusUsername}:${config.nexusPassword}@")
     }
 
     @NonCPS

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -1,7 +1,9 @@
 package org.ods.component
 
 import org.ods.util.Logger
+import org.ods.services.BitbucketService
 import org.ods.services.GitService
+import org.ods.services.NexusService
 import com.cloudbees.groovy.cps.NonCPS
 import groovy.json.JsonSlurperClassic
 import groovy.json.JsonOutput
@@ -44,18 +46,9 @@ class Context implements IContext {
         config.buildUrl = script.env.BUILD_URL
         config.buildTag = script.env.BUILD_TAG
         config.buildTime = new Date()
-        config.nexusHost = script.env.NEXUS_HOST
-        config.nexusUsername = script.env.NEXUS_USERNAME
-        config.nexusPassword = script.env.NEXUS_PASSWORD
         config.openshiftHost = script.env.OPENSHIFT_API_URL
-
-        if (script.env.BITBUCKET_URL) {
-            config.bitbucketUrl = script.env.BITBUCKET_URL
-            config.bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
-        } else if (script.env.BITBUCKET_HOST) {
-            config.bitbucketHost = script.env.BITBUCKET_HOST
-            config.bitbucketUrl = "https://${config.bitbucketHost}"
-        }
+        config << BitbucketService.readConfigFromEnv(script.env)
+        config << NexusService.readConfigFromEnv(script.env, logger)
 
         config.odsBitbucketProject = script.env.ODS_BITBUCKET_PROJECT ?: 'opendevstack'
 
@@ -79,20 +72,8 @@ class Context implements IContext {
         if (!config.buildTag) {
             throw new IllegalArgumentException('BUILD_TAG is required, but not set (usually provided by Jenkins)')
         }
-        if (!config.nexusHost) {
-            throw new IllegalArgumentException('NEXUS_HOST is required, but not set')
-        }
-        if (!config.nexusUsername) {
-            throw new IllegalArgumentException('NEXUS_USERNAME is required, but not set')
-        }
-        if (!config.nexusPassword) {
-            throw new IllegalArgumentException('NEXUS_PASSWORD is required, but not set')
-        }
         if (!config.openshiftHost) {
             throw new IllegalArgumentException('OPENSHIFT_API_URL is required, but not set')
-        }
-        if (!config.bitbucketUrl) {
-            throw new IllegalArgumentException('BITBUCKET_URL is required, but not set')
         }
         if (!config.buildUrl) {
             logger.info 'BUILD_URL is required to set a proper build status in ' +

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -45,7 +45,10 @@ interface IContext {
     // Nexus password.
     String getNexusPassword()
 
-    // Nexus host (with scheme), including username and password as BasicAuth.
+    // Nexus URL (with scheme), including username and password as BasicAuth.
+    String getNexusUrlWithBasicAuth()
+
+    // DEPRECATED. Nexus host (with scheme), including username and password as BasicAuth.
     String getNexusHostWithBasicAuth()
 
     // Define which branches are deployed to which environments.

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -33,7 +33,10 @@ interface IContext {
     // The tagversion is made up of the build number and the first 8 chars of the commit SHA.
     String getTagversion()
 
-    // Nexus host (with scheme).
+    // Nexus URL - value taken from NEXUS_URL.
+    String getNexusUrl()
+
+    // Nexus host - value derived from getNexusUrl.
     String getNexusHost()
 
     // Nexus username.
@@ -127,10 +130,10 @@ interface IContext {
     // ODS Jenkins shared library version, taken from reference in Jenkinsfile.
     String getOdsSharedLibVersion()
 
-    // BitBucket URL - value taken from BITBUCKET_URL.
+    // Bitbucket URL - value taken from BITBUCKET_URL.
     String getBitbucketUrl()
 
-    // BitBucket host - value derived from getBitbucketUrl.
+    // Bitbucket host - value derived from getBitbucketUrl.
     String getBitbucketHost()
 
     // Timeout for the OpenShift build of the container image in minutes.

--- a/src/org/ods/component/ScanWithSnykStage.groovy
+++ b/src/org/ods/component/ScanWithSnykStage.groovy
@@ -70,7 +70,10 @@ class ScanWithSnykStage extends Stage {
         boolean noVulnerabilitiesFound
 
         def envVariables = [
-            "NEXUS_HOST=${context.nexusHost}",
+            "NEXUS_URL=${context.nexusUrl}",
+            // To support legacy systems, also expose NEXUS_HOST with the URL value.
+            // To be removed in ODS 4+.
+            "NEXUS_HOST=${context.nexusUrl}",
             "NEXUS_USERNAME=${context.nexusUsername}",
             "NEXUS_PASSWORD=${context.nexusPassword}",
         ]

--- a/src/org/ods/orchestration/DeployStage.groovy
+++ b/src/org/ods/orchestration/DeployStage.groovy
@@ -70,7 +70,7 @@ class DeployStage extends Stage {
             }
         }
 
-        runOnAgentPod(project, agentPodCondition) {
+        runOnAgentPod(agentPodCondition) {
             if (project.isPromotionMode) {
                 def targetEnvironment = project.buildParams.targetEnvironment
                 def targetProject = project.targetProject

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -49,7 +49,7 @@ class FinalizeStage extends Stage {
         }
 
         def agentCondition = project.isAssembleMode && repos.size() > 0
-        runOnAgentPod(project, agentCondition) {
+        runOnAgentPod(agentCondition) {
             // Execute phase for each repository - here in parallel, all repos
             Map allRepos = [ : ]
             util.prepareExecutePhaseForReposNamedJob(

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -141,13 +141,9 @@ class InitStage extends Stage {
             }
         }
 
-        registry.add(NexusService,
-            new NexusService(
-                script.env.NEXUS_URL,
-                script.env.NEXUS_USERNAME,
-                script.env.NEXUS_PASSWORD
-            )
-        )
+
+
+        registry.add(NexusService, NexusService.newFromEnv(script.env, logger))
 
         registry.add(OpenShiftService,
             new OpenShiftService(
@@ -225,15 +221,21 @@ class InitStage extends Stage {
             )
         )
 
-        registry.add(BitbucketService, new BitbucketService(
-            registry.get(PipelineSteps).unwrap(),
-            project.releaseManagerBitbucketHostUrl,
+        def bitbucket = BitbucketService.newFromEnv(
+            steps.unwrap(),
+            steps.env,
             project.key,
+<<<<<<< HEAD
             project.services.bitbucket.credentials.id,
             logger
         ))
 
         BitbucketService bitbucket = registry.get(BitbucketService)
+=======
+            project.services.bitbucket.credentials.id
+        )
+        registry.add(BitbucketService, bitbucket)
+>>>>>>> Extract reading URL/HOST to NexusService / BitbucketService
 
         def phase = MROPipelineUtil.PipelinePhases.INIT
 

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -225,17 +225,10 @@ class InitStage extends Stage {
             steps.unwrap(),
             steps.env,
             project.key,
-<<<<<<< HEAD
             project.services.bitbucket.credentials.id,
             logger
-        ))
-
-        BitbucketService bitbucket = registry.get(BitbucketService)
-=======
-            project.services.bitbucket.credentials.id
         )
         registry.add(BitbucketService, bitbucket)
->>>>>>> Extract reading URL/HOST to NexusService / BitbucketService
 
         def phase = MROPipelineUtil.PipelinePhases.INIT
 

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -322,7 +322,7 @@ class InitStage extends Stage {
 
         // It is assumed that the pipeline runs in the same cluster as the 'D' env.
         if (project.buildParams.targetEnvironmentToken == 'D' && !os.envExists()) {
-            runOnAgentPod(project, true) {
+            runOnAgentPod(true) {
                 def sourceEnv = project.buildParams.targetEnvironment
                 os.createVersionedDevelopmentEnvironment(project.key, sourceEnv)
 

--- a/src/org/ods/orchestration/Stage.groovy
+++ b/src/org/ods/orchestration/Stage.groovy
@@ -118,7 +118,6 @@ class Stage {
                 script.stash(name: 'wholeWorkspace', includes: '**/*,**/.git', useDefaultExcludes: false)
             }
             logger.debugClocked("${project.key}-${STAGE_NAME}-stash")
-            def bitbucketHost = script.env.BITBUCKET_HOST
             def podLabel = "mro-jenkins-agent-${script.env.BUILD_NUMBER}"
             logger.debugClocked(podLabel, 'Starting orchestration pipeline slave pod')
             script.node(podLabel) {
@@ -136,7 +135,8 @@ class Stage {
                 ) {
                     def bbUser = URLEncoder.encode(script.env.BITBUCKET_USER, 'UTF-8')
                     def bbPwd = URLEncoder.encode(script.env.BITBUCKET_PW, 'UTF-8')
-                    def urlWithCredentials = "https://${bbUser}:${bbPwd}@${bitbucketHost}"
+                    def urlWithCredentials = project.releaseManagerBitbucketHostUrl
+                        .replace('://', "://${bbUser}:${bbPwd}@")
                     script.writeFile(
                         file: "${script.env.HOME}/.git-credentials",
                         text: urlWithCredentials

--- a/src/org/ods/orchestration/Stage.groovy
+++ b/src/org/ods/orchestration/Stage.groovy
@@ -110,7 +110,7 @@ class Stage {
         ]
     }
 
-    protected def runOnAgentPod(Project project, boolean condition, Closure block) {
+    protected def runOnAgentPod(boolean condition, Closure block) {
         ILogger logger = ServiceRegistry.instance.get(Logger)
         if (condition) {
             def bitbucket = ServiceRegistry.instance.get(BitbucketService)

--- a/src/org/ods/orchestration/Stage.groovy
+++ b/src/org/ods/orchestration/Stage.groovy
@@ -4,6 +4,7 @@ import org.ods.services.ServiceRegistry
 import org.ods.orchestration.util.Project
 import org.ods.orchestration.util.PipelineUtil
 import org.ods.orchestration.usecase.JUnitTestReportsUseCase
+import org.ods.services.BitbucketService
 import org.ods.services.GitService
 import org.ods.services.JenkinsService
 
@@ -112,6 +113,7 @@ class Stage {
     protected def runOnAgentPod(Project project, boolean condition, Closure block) {
         ILogger logger = ServiceRegistry.instance.get(Logger)
         if (condition) {
+            def bitbucket = ServiceRegistry.instance.get(BitbucketService)
             def git = ServiceRegistry.instance.get(GitService)
             logger.startClocked("${project.key}-${STAGE_NAME}-stash")
             script.dir(script.env.WORKSPACE) {
@@ -128,15 +130,14 @@ class Stage {
                 logger.debugClocked("${project.key}-${STAGE_NAME}-unstash")
                 script.withCredentials(
                     [script.usernamePassword(
-                        credentialsId: project.services.bitbucket.credentials.id,
+                        credentialsId: bitbucket.passwordCredentialsId,
                         usernameVariable: 'BITBUCKET_USER',
                         passwordVariable: 'BITBUCKET_PW'
                     )]
                 ) {
                     def bbUser = URLEncoder.encode(script.env.BITBUCKET_USER, 'UTF-8')
                     def bbPwd = URLEncoder.encode(script.env.BITBUCKET_PW, 'UTF-8')
-                    def urlWithCredentials = project.releaseManagerBitbucketHostUrl
-                        .replace('://', "://${bbUser}:${bbPwd}@")
+                    def urlWithCredentials = bitbucket.url.replace('://', "://${bbUser}:${bbPwd}@")
                     script.writeFile(
                         file: "${script.env.HOME}/.git-credentials",
                         text: urlWithCredentials

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -101,6 +101,11 @@ class Context implements IContext {
     }
 
     @NonCPS
+    String getNexusUrl() {
+        config.nexusUrl
+    }
+
+    @NonCPS
     String getNexusHost() {
         config.nexusHost
     }

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -42,12 +42,16 @@ interface IContext {
 
     String getCdUserCredentialsId()
 
-    // BitBucket URL - value taken from BITBUCKET_URL.
+    // Bitbucket URL - value taken from BITBUCKET_URL.
     String getBitbucketUrl()
 
-    // BitBucket host - value derived from getBitbucketUrl.
+    // Bitbucket host - value derived from getBitbucketUrl.
     String getBitbucketHost()
 
+    // Nexus URL - value taken from NEXUS_URL.
+    String getNexusUrl()
+
+    // Nexus host - value derived from getNexusUrl.
     String getNexusHost()
 
     String getNexusUsername()

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -1,5 +1,8 @@
 package org.ods.quickstarter
 
+import org.ods.services.BitbucketService
+import org.ods.services.NexusService
+
 class Pipeline implements Serializable {
 
     private final def script
@@ -58,21 +61,9 @@ class Pipeline implements Serializable {
             config.buildUrl = script.env.BUILD_URL
             config.buildTime = new Date()
             config.dockerRegistry = script.env.DOCKER_REGISTRY
-
-            // Get Bitbucket params
-            if (script.env.BITBUCKET_URL) {
-                config.bitbucketUrl = script.env.BITBUCKET_URL
-                config.bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
-            } else if (script.env.BITBUCKET_HOST) {
-                config.bitbucketHost = script.env.BITBUCKET_HOST
-                config.bitbucketUrl = "https://${config.bitbucketHost}"
-            }
+            config << BitbucketService.readConfigFromEnv(script.env)
             gitHost =  config.bitbucketHost.split(':').first()
-
-            // Get Nexus params
-            config.nexusHost = script.env.NEXUS_HOST
-            config.nexusUsername = script.env.NEXUS_USERNAME
-            config.nexusPassword = script.env.NEXUS_PASSWORD
+            config << NexusService.readConfigFromEnv(script.env, logger)
         }
 
         onAgentNode(config) { context ->

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -53,7 +53,6 @@ class Pipeline implements Serializable {
         // vars from jenkins master
         def gitHost
         script.node {
-            gitHost =  script.env.BITBUCKET_HOST.split(':')[0]
             config.jobName = script.env.JOB_NAME
             config.buildNumber = script.env.BUILD_NUMBER
             config.buildUrl = script.env.BUILD_URL
@@ -68,6 +67,7 @@ class Pipeline implements Serializable {
                 config.bitbucketHost = script.env.BITBUCKET_HOST
                 config.bitbucketUrl = "https://${config.bitbucketHost}"
             }
+            gitHost =  config.bitbucketHost.split(':').first()
 
             // Get Nexus params
             config.nexusHost = script.env.NEXUS_HOST

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -45,6 +45,33 @@ class BitbucketService {
         this.logger = logger
     }
 
+    static BitbucketService newFromEnv(def script, def env, String project, String passwordCredentialsId) {
+        def c = readConfigFromEnv(env)
+        new BitbucketService(script, c.bitbucketUrl, project, passwordCredentialsId)
+    }
+
+    static Map readConfigFromEnv(def env) {
+        def config = [:]
+        if (env.BITBUCKET_URL?.trim()) {
+            config.bitbucketUrl = env.BITBUCKET_URL.trim()
+            config.bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
+        } else if (env.BITBUCKET_HOST?.trim()) {
+            config.bitbucketHost = env.BITBUCKET_HOST.trim()
+            config.bitbucketUrl = "https://${config.bitbucketHost}"
+        } else {
+            throw new IllegalArgumentException("Environment variable 'BITBUCKET_URL' is required")
+        }
+        config
+    }
+
+    String getUrl() {
+        bitbucketUrl
+    }
+
+    String passwordCredentialsId() {
+        passwordCredentialsId
+    }
+
     // Get pull requests of "repo" in given "state" (can be OPEN, DECLINED or MERGED).
     String getPullRequests(String repo, String state = 'OPEN') {
         String res

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -68,7 +68,7 @@ class BitbucketService {
         bitbucketUrl
     }
 
-    String passwordCredentialsId() {
+    String getPasswordCredentialsId() {
         passwordCredentialsId
     }
 

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -45,9 +45,14 @@ class BitbucketService {
         this.logger = logger
     }
 
-    static BitbucketService newFromEnv(def script, def env, String project, String passwordCredentialsId) {
+    static BitbucketService newFromEnv(
+        def script,
+        def env,
+        String project,
+        String passwordCredentialsId,
+        ILogger logger) {
         def c = readConfigFromEnv(env)
-        new BitbucketService(script, c.bitbucketUrl, project, passwordCredentialsId)
+        new BitbucketService(script, c.bitbucketUrl, project, passwordCredentialsId, logger)
     }
 
     static Map readConfigFromEnv(def env) {

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -211,6 +211,7 @@ class GitService {
         return branchCheckStatus == 0
     }
 
+    @SuppressWarnings('UnnecessaryElseStatement')
     boolean otherFilesChangedAfterCommitOfFile(String fileName, String openshiftDir) {
         if (!script.fileExists(fileName)) {
             return true

--- a/src/org/ods/services/NexusService.groovy
+++ b/src/org/ods/services/NexusService.groovy
@@ -73,12 +73,11 @@ class NexusService {
         config
     }
 
-    @SuppressWarnings('SpaceAroundMapEntryColon')
     @NonCPS
     URI storeArtifact(String repository, String directory, String name, byte[] artifact, String contentType) {
         Map nexusParams = [
-            'raw.directory':directory,
-            'raw.asset1.filename':name,
+            'raw.directory': directory,
+            'raw.asset1.filename': name,
         ]
 
         return storeComplextArtifact(repository, artifact, contentType, 'raw', nexusParams)
@@ -139,7 +138,7 @@ class NexusService {
     @SuppressWarnings(['LineLength', 'JavaIoPackageAccess'])
     @NonCPS
     Map<URI, File> retrieveArtifact(String nexusRepository, String nexusDirectory, String name, String extractionPath) {
-        // https://nexus3-cd....../repository/leva-documentation/odsst-WIP/DTP-odsst-WIP-108.zip
+        // https://nexus3-ods....../repository/leva-documentation/odsst-WIP/DTP-odsst-WIP-108.zip
         String urlToDownload = "${this.baseURL}/repository/${nexusRepository}/${nexusDirectory}/${name}"
         def restCall = Unirest.get("${urlToDownload}")
             .basicAuth(this.username, this.password)

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -438,6 +438,7 @@ class OpenShiftService {
         ).trim()
     }
 
+    @SuppressWarnings('UnnecessaryElseStatement')
     boolean checkAndAmendRepoBasedOnDeploymentState (Map repo) {
         def openshiftDir = 'openshift-exported'
         if (steps.fileExists('openshift')) {

--- a/src/org/ods/services/ServiceRegistry.groovy
+++ b/src/org/ods/services/ServiceRegistry.groovy
@@ -16,4 +16,5 @@ class ServiceRegistry {
     def clear() {
         registry.clear()
     }
+
 }

--- a/src/org/ods/util/Logger.groovy
+++ b/src/org/ods/util/Logger.groovy
@@ -45,19 +45,19 @@ class Logger implements ILogger, Serializable {
         timedCall (component)
     }
 
-    @SuppressWarnings('GStringAsMapKey')
+    @SuppressWarnings(['GStringAsMapKey', 'UnnecessaryElseStatement'])
     private def timedCall (String component, String message = null) {
         if (!component) {
             throw new IllegalArgumentException ("Component can't be null!")
         }
         def startTime = clockStore.get("${component}")
-        if (!startTime) {
-            clockStore << ["${component}": System.currentTimeMillis()]
-            return "[${component}] ${message ?: ''}"
-        } else {
+        if (startTime) {
             def timeDuration = System.currentTimeMillis() - startTime
             return "[${component}] ${message ?: ''} " +
                 "(took ${timeDuration} ms)"
+        } else {
+            clockStore << ["${component}": System.currentTimeMillis()]
+            return "[${component}] ${message ?: ''}"
         }
     }
 

--- a/test/groovy/vars/OdsComponentStageScanWithSnykSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSnykSpec.groovy
@@ -16,7 +16,7 @@ import org.ods.services.ServiceRegistry
    def config = [
        projectId: 'foo',
        componentId: 'bar',
-       nexusHost: 'https;//nexus.example.com',
+       nexusUrl: 'https://nexus.example.com',
        nexusUsername: 'developer',
        nexusPassword: 's3cr3t',
        buildNumber: '42'


### PR DESCRIPTION
Replaces #183.

Implements in the shared lib what is needed to finish https://github.com/opendevstack/ods-core/issues/259 eventually.

Instead of making this a breaking change, the approach here is to support `NEXUS_HOST` as is for ODS 3. But projects created with ODS 3 will set `NEXUS_URL` instead of `NEXUS_HOST` and consequently have `nexusUrl` and `nexusHost` set to the expected values. Users of ODS have the choice during upgrade from 2 to 3 if they want to "fix" the Nexus config by setting `NEXUS_URL` in their Jenkins instance, or if they want to stick with the "broken" Nexus config by keeping `NEXUS_HOST`. I will document this in the update guide once I make the change in `ods-core`.

The PR also removes code duplication between the three pipelines, making reading of the env vars consistent. While doing that, I noticed that the orchestration pipeline assumed `NEXUS_URL` to be present, but I cannot see how that is set in the release-manager quickstarter at the moment. Now it works whether `NEXUS_URL` is set or not.

Given this PR will clash with #365, I can wait with merging after #365 is in, given that's the bigger changeset.