### PR TITLE
Fix URL/host mess

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -109,10 +109,7 @@ The `context` object contains the following properties:
 | The tagversion is made up of the build number and the first 8 chars of the commit SHA.
 
 | nexusUrl
-| Nexus URL - value taken from `NEXUS_URL`. If `NEXUS_URL` is not present, it will default to `NEXUS_HOST` (which also includes the scheme).
-
-| nexusHost
-| Nexus host - value derived from `nexusUrl`. It does not include the scheme if `nexusUrl` was read from `NEXUS_URL`.
+| Nexus URL - value taken from `NEXUS_URL`. If `NEXUS_URL` is not present, it will default to `NEXUS_HOST` (which also includes the scheme). `nexusHost` is an alias for `nexusUrl`.
 
 | nexusUsername
 | Nexus username.
@@ -121,10 +118,7 @@ The `context` object contains the following properties:
 | Nexus password.
 
 | nexusUrlWithBasicAuth
-| Nexus URL, including username and password as BasicAuth.
-
-| nexusHostWithBasicAuth
-| DEPRECATED. Nexus host (with scheme), including username and password as BasicAuth.
+| Nexus URL, including username and password as BasicAuth. `nexusHostWithBasicAuth` is an alias for `nexusUrlWithBasicAuth`.
 
 | cloneSourceEnv
 | The environment which was chosen as the clone source.

--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -172,10 +172,7 @@ The `context` object contains the following properties:
 | ODS Jenkins shared library version, taken from reference in `Jenkinsfile`.
 
 | bitbucketUrl
-| Bitbucket URL - value taken from `BITBUCKET_URL`. If BITBUCKET_URL is not present, it will default to `https://<BITBUCKET_HOST>``.
-
-| bitbucketHost
-| Bitbucket host - value derived from `bitbucketUrl`.
+| Bitbucket URL - value taken from `BITBUCKET_URL`. If BITBUCKET_URL is not present, it will default to `https://<BITBUCKET_HOST>``. `bitbucketHost` is an alias for `bitbucketUrl`.
 
 | dockerDir
 | The docker directory to use when building the image in openshift. Defaults to `docker`.

--- a/docs/modules/jenkins-shared-library/partials/odsQuickstarterPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsQuickstarterPipeline.adoc
@@ -105,6 +105,9 @@ The `context` object contains the following properties:
 | odsGitRef
 | Git ref, retrieved from `ODS_GIT_REF` build parameter.
 
+| bitbucketUrl
+| Bitbucket URL - value taken from `BITBUCKET_URL`. If BITBUCKET_URL is not present, it will default to `https://<BITBUCKET_HOST>``. `bitbucketHost` is an alias for `bitbucketUrl`.
+
 | gitUrlHttp
 | URL of the Git repository to push to.
 |===

--- a/docs/modules/jenkins-shared-library/partials/update-to-3x.adoc
+++ b/docs/modules/jenkins-shared-library/partials/update-to-3x.adoc
@@ -89,5 +89,12 @@ constraints of the Jenkins agent pod). Please review
 xref:jenkins-shared-library:component-pipeline.adoc#_pipeline_context[the documentation]
 in case your authored stages make heavy use of the `context` object.
 
-A notable addition to the `context` object is a new property `issueId`, which
+CAUTION: One notable change to the `context` object is that `bitbucketHost` did
+not include the scheme previously. Now, `bitbucketHost` is an alias for
+`bitbucketUrl` which does include the scheme. This change was made to align the
+property with `nexusHost` and `nexusUrl`, which both include the scheme as well.
+If you used `context.bitbucketHost` in one of your `Jenkinsfile`s, you may now
+use `context.bitbucketHostWithoutScheme`.
+
+TIP: A notable addition to the `context` object is a new property `issueId`, which
 exposes the Jira issue ID (such as `123` from branch `feature/FOO-123-bar-baz`).

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -48,7 +48,7 @@ class Context implements IContext {
         config.buildTime = new Date()
         config.openshiftHost = script.env.OPENSHIFT_API_URL
         config << BitbucketService.readConfigFromEnv(script.env)
-        config << NexusService.readConfigFromEnv(script.env, logger)
+        config << NexusService.readConfigFromEnv(script.env)
 
         config.odsBitbucketProject = script.env.ODS_BITBUCKET_PROJECT ?: 'opendevstack'
 
@@ -211,7 +211,12 @@ class Context implements IContext {
 
     @NonCPS
     String getNexusHost() {
-        config.nexusHost
+        getNexusUrl()
+    }
+
+    @NonCPS
+    String getNexusHostWithoutScheme() {
+        getNexusUrl().minus(~/^https?:\/\//)
     }
 
     @NonCPS
@@ -229,11 +234,9 @@ class Context implements IContext {
         config.nexusUrl.replace('://', "://${config.nexusUsername}:${config.nexusPassword}@")
     }
 
-    // To support legacy systems, also uses nexusUrl value.
-    // To be removed in ODS 4+.
     @NonCPS
     String getNexusHostWithBasicAuth() {
-        config.nexusUrl.replace('://', "://${config.nexusUsername}:${config.nexusPassword}@")
+        getNexusUrlWithBasicAuth()
     }
 
     @NonCPS

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -336,7 +336,12 @@ class Context implements IContext {
     }
 
     String getBitbucketHost() {
-        config.bitbucketHost
+        getBitbucketUrl()
+    }
+
+    @NonCPS
+    String getBitbucketHostWithoutScheme() {
+        getBitbucketUrl().minus(~/^https?:\/\//)
     }
 
     @NonCPS

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -136,8 +136,11 @@ interface IContext {
     // Bitbucket URL - value taken from BITBUCKET_URL.
     String getBitbucketUrl()
 
-    // Bitbucket host - value derived from getBitbucketUrl.
+    // Bitbucket host - alias for getBitbucketUrl.
     String getBitbucketHost()
+
+    // Bitbucket host without scheme/protocol.
+    String getBitbucketHostWithoutScheme()
 
     // Timeout for the OpenShift build of the container image in minutes.
     Integer getOpenshiftBuildTimeout()

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -36,8 +36,11 @@ interface IContext {
     // Nexus URL - value taken from NEXUS_URL.
     String getNexusUrl()
 
-    // Nexus host - value derived from getNexusUrl.
+    // Nexus host - alias for getNexusUrl.
     String getNexusHost()
+
+    // Nexus host without scheme/protocol.
+    String getNexusHostWithoutScheme()
 
     // Nexus username.
     String getNexusUsername()
@@ -48,7 +51,7 @@ interface IContext {
     // Nexus URL (with scheme), including username and password as BasicAuth.
     String getNexusUrlWithBasicAuth()
 
-    // DEPRECATED. Nexus host (with scheme), including username and password as BasicAuth.
+    // Nexus host (with scheme), including username and password as BasicAuth. Alias for getNexusUrlWithBasicAuth.
     String getNexusHostWithBasicAuth()
 
     // Define which branches are deployed to which environments.

--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -141,7 +141,7 @@ class Pipeline implements Serializable {
                         if (!registry.get(NexusService)) {
                             logger.debug 'Registering NexusService'
                             registry.add(NexusService, new NexusService(
-                                context.nexusHost, context.nexusUsername, context.nexusPassword))
+                                context.nexusUrl, context.nexusUsername, context.nexusPassword))
                         }
                     }
 

--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -376,7 +376,7 @@ class Pipeline implements Serializable {
                 script.sh(
                     script: """sh clone-project.sh \
                         -o ${context.openshiftHost} \
-                        -b ${context.bitbucketHost} \
+                        -b ${context.bitbucketHostWithoutScheme} \
                         -c ${userPass} \
                         -p ${context.projectId} \
                         -s ${context.cloneSourceEnv} \

--- a/src/org/ods/component/ScanWithSnykStage.groovy
+++ b/src/org/ods/component/ScanWithSnykStage.groovy
@@ -70,10 +70,7 @@ class ScanWithSnykStage extends Stage {
         boolean noVulnerabilitiesFound
 
         def envVariables = [
-            "NEXUS_URL=${context.nexusUrl}",
-            // To support legacy systems, also expose NEXUS_HOST with the URL value.
-            // To be removed in ODS 4+.
-            "NEXUS_HOST=${context.nexusUrl}",
+            "NEXUS_HOST=${context.nexusHost}",
             "NEXUS_USERNAME=${context.nexusUsername}",
             "NEXUS_PASSWORD=${context.nexusPassword}",
         ]

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -143,7 +143,7 @@ class InitStage extends Stage {
 
 
 
-        registry.add(NexusService, NexusService.newFromEnv(script.env, logger))
+        registry.add(NexusService, NexusService.newFromEnv(script.env))
 
         registry.add(OpenShiftService,
             new OpenShiftService(

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -112,7 +112,12 @@ class Context implements IContext {
 
     @NonCPS
     String getNexusHost() {
-        config.nexusHost
+        getNexusUrl()
+    }
+
+    @NonCPS
+    String getNexusHostWithoutScheme() {
+        getNexusUrl().minus(~/^https?:\/\//)
     }
 
     @NonCPS

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -97,7 +97,12 @@ class Context implements IContext {
 
     @NonCPS
     String getBitbucketHost() {
-        config.bitbucketHost
+        getBitbucketUrl()
+    }
+
+    @NonCPS
+    String getBitbucketHostWithoutScheme() {
+        getBitbucketUrl().minus(~/^https?:\/\//)
     }
 
     @NonCPS

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -54,8 +54,11 @@ interface IContext {
     // Nexus URL - value taken from NEXUS_URL.
     String getNexusUrl()
 
-    // Nexus host - value derived from getNexusUrl.
+    // Nexus host - alias for getNexusUrl.
     String getNexusHost()
+
+    // Nexus host without scheme/protocol.
+    String getNexusHostWithoutScheme()
 
     String getNexusUsername()
 

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -45,8 +45,11 @@ interface IContext {
     // Bitbucket URL - value taken from BITBUCKET_URL.
     String getBitbucketUrl()
 
-    // Bitbucket host - value derived from getBitbucketUrl.
+    // Bitbucket host - alias for getBitbucketUrl.
     String getBitbucketHost()
+
+    // Bitbucket host without scheme/protocol.
+    String getBitbucketHostWithoutScheme()
 
     // Nexus URL - value taken from NEXUS_URL.
     String getNexusUrl()

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -62,7 +62,8 @@ class Pipeline implements Serializable {
             config.buildTime = new Date()
             config.dockerRegistry = script.env.DOCKER_REGISTRY
             config << BitbucketService.readConfigFromEnv(script.env)
-            gitHost =  config.bitbucketHost.split(':').first()
+            def bitbucketHost = context.bitbucketUrl.minus(~/^https?:\/\//)
+            gitHost =  bitbucketHost.split(':').first()
             config << NexusService.readConfigFromEnv(script.env, logger)
         }
 

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -64,7 +64,7 @@ class Pipeline implements Serializable {
             config << BitbucketService.readConfigFromEnv(script.env)
             def bitbucketHost = context.bitbucketUrl.minus(~/^https?:\/\//)
             gitHost =  bitbucketHost.split(':').first()
-            config << NexusService.readConfigFromEnv(script.env, logger)
+            config << NexusService.readConfigFromEnv(script.env)
         }
 
         onAgentNode(config) { context ->

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -62,7 +62,7 @@ class Pipeline implements Serializable {
             config.buildTime = new Date()
             config.dockerRegistry = script.env.DOCKER_REGISTRY
             config << BitbucketService.readConfigFromEnv(script.env)
-            def bitbucketHost = context.bitbucketUrl.minus(~/^https?:\/\//)
+            def bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
             gitHost =  bitbucketHost.split(':').first()
             config << NexusService.readConfigFromEnv(script.env)
         }

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -59,10 +59,8 @@ class BitbucketService {
         def config = [:]
         if (env.BITBUCKET_URL?.trim()) {
             config.bitbucketUrl = env.BITBUCKET_URL.trim()
-            config.bitbucketHost = config.bitbucketUrl.minus(~/^https?:\/\//)
         } else if (env.BITBUCKET_HOST?.trim()) {
-            config.bitbucketHost = env.BITBUCKET_HOST.trim()
-            config.bitbucketUrl = "https://${config.bitbucketHost}"
+            config.bitbucketUrl = "https://${env.BITBUCKET_HOST.trim()}"
         } else {
             throw new IllegalArgumentException("Environment variable 'BITBUCKET_URL' is required")
         }

--- a/src/org/ods/services/NexusService.groovy
+++ b/src/org/ods/services/NexusService.groovy
@@ -6,8 +6,6 @@ import com.cloudbees.groovy.cps.NonCPS
 import kong.unirest.Unirest
 import org.apache.http.client.utils.URIBuilder
 
-import org.ods.util.ILogger
-
 class NexusService {
 
     static final String NEXUS_REPO_EXISTS_KEY = 'nexusRepoExists'
@@ -41,22 +39,18 @@ class NexusService {
         this.password = password
     }
 
-    static NexusService newFromEnv(def env, ILogger logger) {
-        def c = readConfigFromEnv(env, logger)
+    static NexusService newFromEnv(def env) {
+        def c = readConfigFromEnv(env)
         new NexusService(c.nexusUrl, c.nexusUsername, c.nexusPassword)
     }
 
-    static Map readConfigFromEnv(def env, ILogger logger) {
+    static Map readConfigFromEnv(def env) {
         def config = [:]
         if (env.NEXUS_URL?.trim()) {
             config.nexusUrl = env.NEXUS_URL.trim()
-            config.nexusHost = config.nexusUrl.minus(~/^https?:\/\//)
         } else if (env.NEXUS_HOST?.trim()) {
+            // Historically, the NEXUS_HOST variable contains the scheme.
             config.nexusUrl = env.NEXUS_HOST.trim()
-            config.nexusHost = env.NEXUS_HOST.trim()
-            logger.info '''WARNING: 'NEXUS_URL' is not present. Nexus URL is read from 'NEXUS_HOST'. ''' +
-                '''Therefore, 'context.nexusUrl' and 'context.nexusHost' both include the scheme. ''' +
-                '''To avoid this, expose 'NEXUS_URL' on the Jenkins instance and adjust build code as necessary.'''
         } else {
             throw new IllegalArgumentException("Environment variable 'NEXUS_URL' is required")
         }


### PR DESCRIPTION
I thought we could transition to `URL` being with scheme, and `host` being without. This proved way too complicated in terms of backwards compatibility. I give up.

So ... to make things easy AND consistent, I think the smallest change from 2.x to 3.x is to make host/URL **aliases**, and have them include the scheme.

This results in only one, simple, breaking change, and that is that `context.bitbucketHost` returns no scheme in 2.x, but it does in 3.x. While this is technically breaking, no quickstarter boilerplates used this property, so it is unlikely to be a big issue. Still, it is noted in the update docs to ensure people pay attention. They can now use the clearly labeled `context.bitbucketHostWithoutScheme`.