### PR TITLE
Fix rollout race condition and display events in Jenkins log

### DIFF
--- a/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
+++ b/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
@@ -23,7 +23,7 @@ class RolloutOpenShiftDeploymentStage extends Stage {
             config.resourceName = context.componentId
         }
         if (!config.deployTimeoutMinutes) {
-            config.deployTimeoutMinutes = context.openshiftRolloutTimeout
+            config.deployTimeoutMinutes = context.openshiftRolloutTimeout ?: 5
         }
         if (!config.openshiftDir) {
             config.openshiftDir = 'openshift'
@@ -60,7 +60,7 @@ class RolloutOpenShiftDeploymentStage extends Stage {
         }
 
         def dcExists = deploymentConfigExists()
-        def originalDeploymentVersion = dcExists ? getLatestVersion() : 0
+        def originalDeploymentVersion = dcExists ? openShift.getLatestVersion(config.resourceName) : 0
 
         if (script.fileExists(config.openshiftDir)) {
             script.dir(config.openshiftDir) {
@@ -100,28 +100,18 @@ class RolloutOpenShiftDeploymentStage extends Stage {
 
         setImageTagLatest(ownedImageStreams)
 
-        def latestVersion = getLatestVersion()
-        if (latestVersion > originalDeploymentVersion) {
-            logger.info "Rollout of deployment for '${config.resourceName}' has been triggered automatically."
-        } else {
-            startRollout(latestVersion)
+        String replicationController
+        try {
+            replicationController = openShift.rollout(
+                config.resourceName,
+                originalDeploymentVersion,
+                config.deployTimeoutMinutes
+            )
+        } catch (ex) {
+            script.error ex.message
         }
-        script.timeout(time: config.deployTimeoutMinutes) {
-            logger.startClocked("${config.resourceName}-deploy")
-            watchRollout()
-            logger.debugClocked("${config.resourceName}-deploy")
-        }
-        latestVersion = getLatestVersion()
 
-        def replicationController = "${config.resourceName}-${latestVersion}"
-        def rolloutStatus = getRolloutStatus(replicationController)
-        if (rolloutStatus != 'complete') {
-            script.error "Deployment #${latestVersion} failed with status '${rolloutStatus}', " +
-                'please check the error in the OpenShift web console.'
-        } else {
-            logger.info "Deployment #${latestVersion} of '${config.resourceName}' successfully rolled out."
-        }
-        def pod = getPodDataForRollout(replicationController)
+        def pod = openShift.getPodDataForDeployment(replicationController)
         context.addDeploymentToArtifactURIs(config.resourceName, pod)
 
         return pod
@@ -144,26 +134,6 @@ class RolloutOpenShiftDeploymentStage extends Stage {
 
     private void setImageTagLatest(List<Map<String, String>> imageStreams) {
         imageStreams.each { openShift.setImageTag(it.name, context.tagversion, 'latest') }
-    }
-
-    private void startRollout(int version) {
-        openShift.startRollout(config.resourceName, version)
-    }
-
-    private void watchRollout() {
-        openShift.watchRollout(config.resourceName)
-    }
-
-    private int getLatestVersion() {
-        openShift.getLatestVersion(config.resourceName)
-    }
-
-    private String getRolloutStatus(String replicationController) {
-        openShift.getRolloutStatus(replicationController)
-    }
-
-    private Map getPodDataForRollout(String replicationController) {
-        openShift.getPodDataForDeployment(replicationController)
     }
 
 }

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -233,7 +233,7 @@ class MROPipelineUtil extends PipelineUtil {
 
             def originalDeploymentVersions = [:]
             deployments.each { deploymentName, deployment ->
-                if (!deploymentName == JenkinsService.CREATED_BY_BUILD_STR) {
+                if (deploymentName != JenkinsService.CREATED_BY_BUILD_STR) {
                     def dcExists = os.resourceExists('DeploymentConfig', deploymentName)
                     originalDeploymentVersions[deploymentName] = dcExists ? os.getLatestVersion(deploymentName) : 0
                 }

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -301,16 +301,16 @@ class MROPipelineUtil extends PipelineUtil {
                 }
 
                 // Verify that deployment is being rolled out and that the defined image sha is running
-                if (os.getLatestVersion(deploymentName) > originalDeploymentVersions[deploymentName]) {
+                def latestVersion = os.getLatestVersion(deploymentName)
+                if (latestVersion > originalDeploymentVersions[deploymentName]) {
                     logger.info "Rollout of '${deploymentName}' has been triggered automatically."
                 } else {
-                    os.startRollout(deploymentName)
+                    os.startRollout(deploymentName, latestVersion)
                 }
                 steps.timeout(time: openshiftRolloutTimeoutMinutes) {
                     os.watchRollout(deploymentName)
                 }
-
-                def latestVersion = os.getLatestVersion(deploymentName)
+                latestVersion = os.getLatestVersion(deploymentName)
 
                 def pod = os.getPodDataForDeployment("${deploymentName}-${latestVersion}")
                 deployment.containers?.each { containerName, imageRaw ->

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -138,6 +138,42 @@ class OpenShiftService {
         doTailorExport(project, "-l ${selector}", envParams, targetFile)
     }
 
+    String rollout(String name, int priorVersion, int timeoutMinutes) {
+        def latestVersion = getLatestVersion(name)
+        if (latestVersion > priorVersion) {
+            logger.info "Rollout of deployment for '${name}' has been triggered automatically."
+        } else {
+            startRollout(name, latestVersion)
+        }
+        try {
+            steps.timeout(time: timeoutMinutes) {
+                logger.startClocked("${name}-watch-rollout")
+                watchRollout(name)
+                logger.debugClocked("${name}-watch-rollout")
+            }
+        } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
+            latestVersion = getLatestVersion(name)
+            def replicationController = "${name}-${latestVersion}"
+            throw new RuntimeException(
+                "Deployment timed out. " +
+                "Observed related event messages:\n${getEventMessages(replicationController)}"
+            )
+        }
+
+        latestVersion = getLatestVersion(name)
+        def replicationController = "${name}-${latestVersion}"
+        def rolloutStatus = getRolloutStatus(replicationController)
+        if (rolloutStatus != 'complete') {
+            throw new RuntimeException(
+                "Deployment #${latestVersion} failed with status '${rolloutStatus}'. " +
+                "Observed related event messages:\n${getEventMessages(replicationController)}"
+            )
+        } else {
+            logger.info "Deployment #${latestVersion} of '${name}' successfully rolled out."
+        }
+        replicationController
+    }
+
     void startRollout(String name, int version) {
         try {
             steps.sh(
@@ -318,6 +354,62 @@ class OpenShiftService {
             """,
             label: "Import image ${sourceImage} into ${project}/${name}:${imageTag}"
         )
+    }
+
+    String getEventMessages(String rc) {
+        String rcEventMessages
+        try {
+            rcEventMessages = steps.sh(
+                script: """
+                    oc -n ${project} get events \
+                        --field-selector involvedObject.kind=ReplicationController,involvedObject.name=${rc} \
+                        -o custom-columns=MESSAGE:.message --no-headers
+                """,
+                returnStdout: true,
+                label: "Get event messages for replication controller ${rc}"
+            ).trim()
+        } catch (ex) {
+            logger.debug("Error when retrieving events for replication controller ${rc}:\n${ex}")
+        }
+        if (!rcEventMessages) {
+            return "Could not find any events for replication controller ${rc}."
+        }
+        rcEventMessages = "=== Events from ReplicationController '${rc}' ===\n${rcEventMessages}"
+        String pod
+        try {
+            pod = steps.sh(
+                script: """
+                    oc -n ${project} get pod \
+                        -l deployment=${rc} \
+                        -o custom-columns=NAME:.metadata.name --no-headers | head -1
+                """,
+                returnStdout: true,
+                label: "Get first pod name of replication controller ${rc}"
+            ).trim()
+        } catch (ex) {
+            logger.debug("Error when retrieving pod for replication controller ${rc}:\n${ex}")
+        }
+        if (!pod) {
+            return "${rcEventMessages}\nCould not find any pod for replication controller ${rc}."
+        }
+        String podEventMessages
+        try {
+            podEventMessages = steps.sh(
+                script: """
+                    oc -n ${project} get events \
+                        --field-selector involvedObject.kind=Pod,involvedObject.name=${pod} \
+                        -o custom-columns=MESSAGE:.message --no-headers
+                """,
+                returnStdout: true,
+                label: "Get event messages for pod ${pod}"
+            ).trim()
+        } catch (ex) {
+            logger.debug("Error when retrieving events for pod ${pod}:\n${ex}")
+        }
+        if (!podEventMessages) {
+            return "${rcEventMessages}\nCould not find any events for pod for ${pod}."
+        }
+        "${rcEventMessages}\n=== Events from Pod '${pod}' ===\n${podEventMessages}"
     }
 
     // Gets pod of deployment

--- a/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
@@ -34,9 +34,9 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Stub(OpenShiftService.class)
     openShiftService.resourceExists(*_) >> true
-    openShiftService.getLatestVersion(*_) >>> [123, 124]
-    openShiftService.getRolloutStatus(*_) >> 'complete'
-    openShiftService.getPodDataForDeployment(*_) >> [ deploymentId: "${config.componentId}-123" ]
+    openShiftService.getLatestVersion(*_) >> 123
+    openShiftService.rollout(*_) >> "${config.componentId}-124"
+    openShiftService.getPodDataForDeployment(*_) >> [ deploymentId: "${config.componentId}-124" ]
     openShiftService.getImagesOfDeploymentConfig (*_) >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
@@ -49,10 +49,8 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
 
     then:
     printCallStack()
-    assertCallStackContains('''Rollout of deployment for 'bar' has been triggered automatically.''')
-    assertCallStackContains('''Deployment #124 of 'bar' successfully rolled out.''')
     assertJobStatusSuccess()
-    deploymentInfo.deploymentId == "${config.componentId}-123"
+    deploymentInfo.deploymentId == "${config.componentId}-124"
 
     // test artifact URIS
     def buildArtifacts = context.getBuildArtifactURIs()
@@ -67,9 +65,9 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Mock(OpenShiftService.class)
     openShiftService.resourceExists(*_) >> true
-    openShiftService.getLatestVersion(*_) >>> [123, 124]
-    openShiftService.getRolloutStatus(*_) >> 'complete'
-    openShiftService.getPodDataForDeployment(*_) >> [ deploymentId: "${config.componentId}-123" ]
+    openShiftService.getLatestVersion(*_) >> 123
+    openShiftService.rollout(*_) >> "${config.componentId}-124"
+    openShiftService.getPodDataForDeployment(*_) >> [ deploymentId: "${config.componentId}-124" ]
     openShiftService.getImagesOfDeploymentConfig (*_) >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
     JenkinsService jenkinsService = Stub(JenkinsService.class)
@@ -85,10 +83,8 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
 
     then:
     printCallStack()
-    assertCallStackContains('''Rollout of deployment for 'bar' has been triggered automatically.''')
-    assertCallStackContains('''Deployment #124 of 'bar' successfully rolled out.''')
     assertJobStatusSuccess()
-    deploymentInfo.deploymentId == "${config.componentId}-123"
+    deploymentInfo.deploymentId == "${config.componentId}-124"
 
     // test artifact URIS
     def buildArtifacts = context.getBuildArtifactURIs()
@@ -116,7 +112,9 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     openShiftService.resourceExists({ it == 'ImageStream' }, _) >> isExists
     openShiftService.getImagesOfDeploymentConfig (*_) >> images
     openShiftService.getLatestVersion(*_) >> latestVersion
-    openShiftService.getRolloutStatus(*_) >> rolloutStatus
+    openShiftService.rollout(*_) >> { x, y, z ->
+            throw new RuntimeException('Boom!')
+        }
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
     when:
@@ -132,10 +130,10 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     assertJobStatusFailure()
 
     where:
-    dcExists | isExists | images                                 | latestVersion | rolloutStatus || errorMessage
-    false    | true     | []                                     | 0             | ''            || "DeploymentConfig 'bar' does not exist."
-    true     | false    | [[repository: 'foo-dev', name: 'baz']] | 0             | ''            || "The following ImageStream resources  for DeploymentConfig 'bar' do not exist: '[foo-dev/baz]'."
-    true     | true     | [[repository: 'foo-dev', name: 'bar']] | 123           | 'stopped'     || "Deployment #123 failed with status 'stopped', please check the error in the OpenShift web console."
+    dcExists | isExists | images                                 | latestVersion || errorMessage
+    false    | true     | []                                     | 0             || "DeploymentConfig 'bar' does not exist."
+    true     | false    | [[repository: 'foo-dev', name: 'baz']] | 0             || "The following ImageStream resources  for DeploymentConfig 'bar' do not exist: '[foo-dev/baz]'."
+    true     | true     | [[repository: 'foo-dev', name: 'bar']] | 123           || "Boom!"
   }
 
   def "skip when no environment given"() {


### PR DESCRIPTION
Fixes #382.

If there is an error while starting a rollout, we check if the version has advanced, and simply do not start a rollout.

Further, this PR introduces a new feature which I believe will help users a lot to debug issues. When something goes wrong with a deployment the cause can usually be found in either the events of the replication controller (some error prevents pod creation) or the events of the pod (some error prevents the pod from becoming active). Unfortunately, many people don't know where to look or don't have the rights to do so. To improve this situation, we now query for the events and display them in the Jenkins log when something prevents a successful rollout. It may look like this:
```
WARN: Error: hudson.AbortException: Deployment timed out. Observed related event messages:
=== Events from ReplicationController 'foo-20' ===
Created pod: foo-20-b6wmt
=== Events from Pod 'foo-20-b6wmt' ===
Successfully assigned myproject/foo-20-b6wmt to ip-172-31-52-140.eu-east-1.compute.internal
pulling image "172.30.21.193:5000/myproject/foo@sha256:ca88cd1ff2572cee6b74f7efdc5afc6f6d649a1e1616394a80da18dbe9601f4c"
Successfully pulled image "172.30.21.193:5000/myproject foo@sha256: ca88cd1ff2572cee6b74f7efdc5afc6f6d649a1e1616394a80da18dbe9601f4c"
Created container
Started container
Readiness probe failed: rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:235: starting container process caused "exec: \"exit 1\": executable file not found in $PATH"
```

I have also reduced the code duplication between component and orchestration pipeline. I have done a basic test of the orchestration pipeline, but am planning to do more extensive testing anyway as I am working on #367 which requires a fair amount of refactoring.
