### PR TITLE
Re-integrate release branches into main branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ codenarc {
     configFile = file('codenarc.groovy')
     maxPriority1Violations = 0
     maxPriority2Violations = 0
-    maxPriority3Violations = 738
+    maxPriority3Violations = 731
     reportFormat = 'html'
 }
 

--- a/src/org/ods/orchestration/BuildStage.groovy
+++ b/src/org/ods/orchestration/BuildStage.groovy
@@ -39,7 +39,7 @@ class BuildStage extends Stage {
             if (project.isAssembleMode
                 && repo.type?.toLowerCase() == MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_CODE) {
                 def data = [ : ]
-                def resultsResurrected = !!repo.data?.odsBuildArtifacts?.resurrected
+                def resultsResurrected = !!repo.data.openshift.resurrectedBuild
                 if (!resultsResurrected) {
                     data << [tests: [unit: getTestResults(steps, repo) ]]
                     jira.reportTestResultsForComponent(
@@ -49,7 +49,7 @@ class BuildStage extends Stage {
                     )
                 } else {
                     logger.info("[${repo.id}] Resurrected tests from run " +
-                        "${repo.data?.odsBuildArtifacts?.resurrected} " +
+                        "${repo.data.openshift.resurrectedBuild} " +
                         "- no unit tests results will be reported")
                 }
 

--- a/src/org/ods/orchestration/DeployStage.groovy
+++ b/src/org/ods/orchestration/DeployStage.groovy
@@ -1,7 +1,6 @@
 package org.ods.orchestration
 
 import org.ods.services.ServiceRegistry
-import org.ods.services.GitService
 import org.ods.services.OpenShiftService
 import org.ods.orchestration.scheduler.LeVADocumentScheduler
 import org.ods.orchestration.util.MROPipelineUtil
@@ -24,7 +23,6 @@ class DeployStage extends Stage {
         def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
         def os = ServiceRegistry.instance.get(OpenShiftService)
         def util = ServiceRegistry.instance.get(MROPipelineUtil)
-        def git = ServiceRegistry.instance.get(GitService)
         ILogger logger = ServiceRegistry.instance.get(Logger)
 
         def phase = MROPipelineUtil.PipelinePhases.DEPLOY
@@ -115,15 +113,6 @@ class DeployStage extends Stage {
                     }
             }
             executeInParallel(executeRepos, generateDocuments)
-
-            // record release manager repo state
-            if (project.isPromotionMode) {
-                if (git.remoteTagExists(project.targetTag)) {
-                    logger.debug('Skipping tag because it already exists.')
-                } else {
-                    util.tagAndPush(project.targetTag)
-                }
-            }
         }
 
         levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -8,8 +8,11 @@ import org.ods.services.BitbucketService
 import org.ods.services.OpenShiftService
 import org.ods.services.GitService
 import org.ods.util.PipelineSteps
+import org.ods.util.IPipelineSteps
 import org.ods.util.Logger
 import org.ods.util.ILogger
+
+import groovy.json.JsonOutput
 
 class FinalizeStage extends Stage {
 
@@ -26,6 +29,7 @@ class FinalizeStage extends Stage {
         def os = ServiceRegistry.instance.get(OpenShiftService)
         def util = ServiceRegistry.instance.get(MROPipelineUtil)
         def bitbucket = ServiceRegistry.instance.get(BitbucketService)
+        def git = ServiceRegistry.instance.get(GitService)
         ILogger logger = ServiceRegistry.instance.get(Logger)
 
         def phase = MROPipelineUtil.PipelinePhases.FINALIZE
@@ -51,23 +55,28 @@ class FinalizeStage extends Stage {
         def agentCondition = project.isAssembleMode && repos.size() > 0
         runOnAgentPod(agentCondition) {
             // Execute phase for each repository - here in parallel, all repos
-            Map allRepos = [ : ]
+            Map repoFinalizeTasks = [ : ]
             util.prepareExecutePhaseForReposNamedJob(
                 phase, repos, preExecuteRepo, postExecuteRepo).each { group ->
-                allRepos << group
+                repoFinalizeTasks << group
             }
+            repoFinalizeTasks.failFast = true
+            script.parallel(repoFinalizeTasks)
 
-            allRepos.failFast = true
-            script.parallel(allRepos)
-
-            // record release manager repo state
             if (project.isAssembleMode && !project.isWorkInProgress) {
-                util.tagAndPushBranch(project.gitReleaseBranch, project.targetTag)
+                integrateIntoMainBranch(steps, git)
             }
+
+            gatherCreatedExecutionCommits(steps, git)
+
+            if (!project.buildParams.rePromote) {
+                pushRepos(steps, git)
+                recordAndPushEnvState(steps, logger, git)
+            }
+
             // add the tag commit that was created for traceability ..
-            GitService gitUtl = ServiceRegistry.instance.get(GitService)
             logger.debug "Current release manager commit: ${project.gitData.commit}"
-            project.gitData.createdExecutionCommit = gitUtl.commitSha
+            project.gitData.createdExecutionCommit = git.commitSha
         }
 
         if (project.isAssembleMode && !project.isWorkInProgress) {
@@ -112,6 +121,109 @@ class FinalizeStage extends Stage {
                 bitbucket.setBuildStatus (steps.env.BUILD_URL, project.gitData.commit,
                     "SUCCESSFUL", "Release Manager for commit: ${project.gitData.commit}")
             }
+        }
+    }
+
+    private void pushRepos(IPipelineSteps steps, GitService git) {
+        def flattenedRepos = repos.flatten()
+        def repoPushTasks = flattenedRepos.collectEntries { repo ->
+            [
+                (repo.id): {
+                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                        if (project.isWorkInProgress) {
+                            git.pushRef(repo.branch)
+                        } else if (project.isAssembleMode) {
+                            git.createTag(project.targetTag)
+                            git.pushBranchWithTags(project.gitReleaseBranch)
+                        } else {
+                            git.createTag(project.targetTag)
+                            git.pushRef(project.targetTag)
+                        }
+                    }
+                }
+            ]
+        }
+        repoPushTasks.failFast = true
+        script.parallel(repoPushTasks)
+    }
+
+    private void gatherCreatedExecutionCommits(IPipelineSteps steps, GitService git) {
+        def flattenedRepos = repos.flatten()
+        def gatherCommitTasks = flattenedRepos.collectEntries { repo ->
+            [
+                (repo.id): {
+                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                        repo.data.git.createdExecutionCommit = git.commitSha
+                    }
+                }
+            ]
+        }
+        gatherCommitTasks.failFast = true
+        script.parallel(gatherCommitTasks)
+    }
+
+    private void integrateIntoMainBranch(IPipelineSteps steps, GitService git) {
+        def flattenedRepos = repos.flatten()
+        def repoIntegrateTasks = flattenedRepos.collectEntries { repo ->
+            [
+                (repo.id): {
+                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                        def filesToCheckout = []
+                        if (steps.fileExists('openshift')) {
+                            filesToCheckout = ['openshift/ods-deployments.json']
+                        } else {
+                            filesToCheckout = [
+                                'openshift-exported/ods-deployments.json',
+                                'openshift-exported/template.yml'
+                            ]
+                        }
+                        git.mergeIntoMainBranch(project.gitReleaseBranch, repo.branch, filesToCheckout)
+                    }
+                }
+            ]
+        }
+        repoIntegrateTasks.failFast = true
+        script.parallel(repoIntegrateTasks)
+    }
+
+    private void recordAndPushEnvState(IPipelineSteps steps, ILogger logger, GitService git) {
+        // record release manager repo state
+        logger.debug "Finalize: Recording HEAD commits from repos ..."
+        logger.debug "On release manager commit ${git.commitSha}"
+        def gitHeads = repos.flatten().collectEntries { repo ->
+            logger.debug "HEAD of repo '${repo.id}': ${repo.data.git.createdExecutionCommit}"
+            [(repo.id): (repo.data.git.createdExecutionCommit ?: '')]
+        }
+        def envState = [
+            version: project.buildParams.version,
+            changeId: project.buildParams.changeId,
+            repositories: gitHeads
+        ]
+        steps.writeFile(
+            file: project.envStateFileName,
+            text: JsonOutput.prettyPrint(JsonOutput.toJson(envState))
+        )
+        git.commit(
+            [project.envStateFileName],
+            "ODS: Record commits deployed into ${project.buildParams.targetEnvironmentToken}"
+        )
+
+        if (project.isWorkInProgress) {
+            git.pushRef('master')
+        } else {
+            // We don't need to merge, we simply commit the env file. That
+            // avoids unnecessary merge conflicts.
+            git.switchToOriginTrackingBranch('master')
+            git.checkoutAndCommitFiles(
+                project.gitReleaseBranch,
+                [project.envStateFileName],
+                "ODS: Update ${project.buildParams.targetEnvironmentToken} env state"
+            )
+            git.pushRef('master')
+            git.switchToExistingBranch(project.gitReleaseBranch)
+
+            git.createTag(project.targetTag)
+            git.pushBranchWithTags(project.gitReleaseBranch)
         }
     }
 

--- a/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
@@ -1,0 +1,171 @@
+package org.ods.orchestration.phases
+
+import org.ods.util.IPipelineSteps
+import org.ods.util.ILogger
+import org.ods.services.GitService
+import org.ods.services.OpenShiftService
+import org.ods.services.JenkinsService
+import org.ods.services.ServiceRegistry
+import org.ods.services.GitService
+import org.ods.orchestration.util.DeploymentDescriptor
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.Project
+
+// Deploy ODS comnponent (code or service) to 'qa' or 'prod'.
+class DeployOdsComponent {
+
+    private Project project
+    private IPipelineSteps steps
+    private GitService git
+    private ILogger logger
+    private OpenShiftService os
+
+    DeployOdsComponent(Project project, IPipelineSteps steps, GitService git, ILogger logger) {
+        this.project = project
+        this.steps = steps
+        this.git = git
+        this.logger = logger
+    }
+
+    public void run(Map repo, String baseDir) {
+        this.os = ServiceRegistry.instance.get(OpenShiftService)
+
+        steps.dir(baseDir) {
+            def openShiftDir = computeOpenShiftDir()
+
+            DeploymentDescriptor deploymentDescriptor
+            steps.dir(openShiftDir) {
+                deploymentDescriptor = DeploymentDescriptor.readFromFile(steps)
+            }
+            if (!repo.data.openshift.deployments) {
+                repo.data.openshift.deployments = [:]
+            }
+
+            def originalDeploymentVersions = gatherOriginalDeploymentVersions(deploymentDescriptor.deployments)
+
+            applyTemplates(openShiftDir, "app=${project.key}-${repo.id}")
+
+            deploymentDescriptor.deployments.each { deploymentName, deployment ->
+
+                importImages(deployment, deploymentName, computeSourceProject())
+
+                def replicationController = os.rollout(
+                    deploymentName,
+                    originalDeploymentVersions[deploymentName],
+                    project.environmentConfig?.openshiftRolloutTimeoutMinutes ?: 10
+                )
+
+                def pod = os.getPodDataForDeployment(replicationController)
+
+                verifyImageShas(deployment, pod.containers)
+
+                repo.data.openshift.deployments << [(deploymentName): pod]
+            }
+
+            if (deploymentDescriptor.createdByBuild) {
+                def createdByBuildKey = DeploymentDescriptor.CREATED_BY_BUILD_STR
+                repo.data.openshift[createdByBuildKey] = deploymentDescriptor.createdByBuild
+            }
+        }
+    }
+
+    private String computeOpenShiftDir() {
+        def openShiftDir = 'openshift-exported'
+        if (steps.fileExists('openshift')) {
+            openShiftDir = 'openshift'
+        }
+        openShiftDir
+    }
+
+    private void computeSourceProject() {
+        def sourceEnv = Project.getConcreteEnvironment(
+            project.sourceEnv,
+            project.buildParams.version,
+            project.versionedDevEnvsEnabled
+        )
+        "${project.key}-${sourceEnv}"
+    }
+
+    private Map gatherOriginalDeploymentVersions(Map deployments) {
+        deployments.collectEntries { deploymentName, deployment ->
+            def dcExists = os.resourceExists('DeploymentConfig', deploymentName)
+            def latestVersion = dcExists ? os.getLatestVersion(deploymentName) : 0
+            [(deploymentName): latestVersion]
+        }
+    }
+
+    private void applyTemplates(String openShiftDir, String componentSelector) {
+        def jenkins = ServiceRegistry.instance.get(JenkinsService)
+        steps.dir(openShiftDir) {
+            logger.info(
+                "Applying desired OpenShift state defined in " +
+                "${openShiftDir}@${project.baseTag} to ${project.targetProject}."
+            )
+            def applyFunc = { pkeyFile ->
+                os.tailorApply(
+                        [selector: componentSelector, exclude: 'bc'],
+                        project.environmentParamsFile,
+                        [], // no params
+                        [], // no preserve flags
+                        pkeyFile,
+                        true // verify
+                    )
+            }
+            jenkins.maybeWithPrivateKeyCredentials(project.tailorPrivateKeyCredentialsId) { pkeyFile ->
+                applyFunc(pkeyFile)
+            }
+        }
+    }
+
+    private void importImages(Map deployment, String deploymentName, String sourceProject) {
+        deployment.containers?.each {containerName, imageRaw ->
+            importImage(deploymentName, containerName, imageRaw, sourceProject)
+        }
+    }
+
+    private void importImage(String deploymentName, String containerName, String imageRaw, String sourceProject) {
+        // skip excluded images from defined image streams!
+        //def imageInfo = os.imageInfoWithShaForImageStreamUrl(imageRaw)
+        logger.info(
+            "Importing images - deployment: ${deploymentName}, " +
+            "container: ${containerName}, image: ${imageRaw}, source: ${sourceProject}"
+        )
+        def imageParts = imageRaw.split('/')
+        if (MROPipelineUtil.EXCLUDE_NAMESPACES_FROM_IMPORT.contains(imageParts.first())) {
+            logger.debug(
+                "Skipping import of '${imageInfo.name}', " +
+                "because it is defined as excluded: ${MROPipelineUtil.EXCLUDE_NAMESPACES_FROM_IMPORT}"
+            )
+        } else {
+            def imageInfo = imageParts.last().split('@')
+            def imageName = imageInfo.first()
+            def imageSha = imageInfo.last()
+            if (project.targetClusterIsExternal) {
+                os.importImageFromSourceRegistry(
+                    imageName,
+                    project.sourceRegistrySecretName,
+                    sourceProject,
+                    imageSha,
+                    project.targetTag
+                )
+            } else {
+                os.importImageFromProject(
+                    imageName,
+                    sourceProject,
+                    imageSha,
+                    project.targetTag
+                )
+            }
+            // tag with latest, which might trigger rollout
+            os.setImageTag(imageName, project.targetTag, 'latest')
+        }
+    }
+
+    private void verifyImageShas(Map deployment, Map podContainers) {
+        deployment.containers?.each { containerName, imageRaw ->
+            if (!os.verifyImageSha(containerName, imageRaw, podContainers[containerName])) {
+                throw new RuntimeException("Error: Image verification for container '${containerName}' failed.")
+            }
+        }
+    }
+}

--- a/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
@@ -1,0 +1,160 @@
+package org.ods.orchestration.phases
+
+import org.ods.util.IPipelineSteps
+import org.ods.util.ILogger
+import org.ods.services.GitService
+import org.ods.services.OpenShiftService
+import org.ods.services.ServiceRegistry
+import org.ods.services.GitService
+import org.ods.orchestration.util.DeploymentDescriptor
+import org.ods.orchestration.util.Project
+import org.ods.orchestration.util.MROPipelineUtil
+
+// Finalize ODS comnponent (code or service) in 'dev'.
+class FinalizeOdsComponent {
+
+    private Project project
+    private IPipelineSteps steps
+    private GitService git
+    private ILogger logger
+    private OpenShiftService os
+
+    FinalizeOdsComponent(Project project, IPipelineSteps steps, GitService git, ILogger logger) {
+        this.project = project
+        this.steps = steps
+        this.git = git
+        this.logger = logger
+    }
+
+    public void run(Map repo, String baseDir) {
+        this.os = ServiceRegistry.instance.get(OpenShiftService)
+
+        def componentSelector = "app=${project.key}-${repo.id}"
+
+        verifyDeploymentsBuiltByODS(repo, componentSelector)
+
+        def envParamsFile = project.environmentParamsFile
+        def envParams = project.getEnvironmentParams(envParamsFile)
+
+        steps.dir(baseDir) {
+            def openshiftDir = findOrCreateOpenShiftDir()
+            steps.dir(openshiftDir) {
+                def filesToStage = []
+                def commitMessage = ''
+                if (openshiftDir == 'openshift-exported') {
+                    commitMessage = 'ODS: Export OpenShift configuration ' +
+                        "\r${steps.currentBuild.description}\r${steps.env.BUILD_URL}"
+                    logger.debugClocked(
+                        "export-ocp-${repo.id}",
+                        "Exporting current OpenShift state to folder '${openshiftDir}'."
+                    )
+                    os.tailorExport(
+                        componentSelector,
+                        envParams,
+                        OpenShiftService.EXPORTED_TEMPLATE_FILE
+                    )
+                    filesToStage << OpenShiftService.EXPORTED_TEMPLATE_FILE
+                    logger.debugClocked("export-ocp-${repo.id}")
+                } else {
+                    commitMessage = "ODS: Export Openshift deployment state " +
+                        "\r${steps.currentBuild.description}\r${steps.env.BUILD_URL}"
+                    // TODO: Display drift?
+                }
+
+                writeDeploymentDescriptor(repo)
+
+                logger.debugClocked("export-ocp-git-${repo.id}")
+                filesToStage << DeploymentDescriptor.FILE_NAME
+                git.commit(filesToStage, "${commitMessage} [ci skip]")
+                logger.debugClocked("export-ocp-git-${repo.id}")
+            }
+        }
+    }
+
+    private String findOrCreateOpenShiftDir() {
+        def openshiftDir = 'openshift-exported'
+        if (steps.fileExists('openshift')) {
+            logger.info(
+                '''Found 'openshift' folder, current OpenShift state ''' +
+                '''will not be exported into 'openshift-exported'.'''
+            )
+            openshiftDir = 'openshift'
+        } else {
+            steps.sh(
+                script: "mkdir -p ${openshiftDir}",
+                label: "Ensure ${openshiftDir} exists"
+            )
+        }
+        openshiftDir
+    }
+
+    private void writeDeploymentDescriptor(Map repo) {
+        def strippedDeployments = DeploymentDescriptor.stripDeployments(repo.data.openshift.deployments)
+        def createdByBuild = repo.data.openshift[DeploymentDescriptor.CREATED_BY_BUILD_STR]
+        if (!createdByBuild) {
+            if (repo.data.openshift.resurrectedBuild) {
+                createdByBuild = repo.data.openshift.resurrectedBuild
+            } else {
+                throw new RuntimeException(
+                    "Could not determine value for ${DeploymentDescriptor.CREATED_BY_BUILD_STR}"
+                )
+            }
+        }
+        new DeploymentDescriptor(strippedDeployments, createdByBuild).writeToFile(steps)
+    }
+
+    private void verifyDeploymentsBuiltByODS(Map repo, String componentSelector) {
+        def os = ServiceRegistry.instance.get(OpenShiftService)
+        def util = ServiceRegistry.instance.get(MROPipelineUtil)
+        logger.debugClocked("export-ocp-verify-${repo.id}")
+        // Verify that all DCs are managed by ODS
+        def odsBuiltDeploymentInformation = repo.data.openshift.deployments ?: [:]
+        def odsBuiltDeployments = odsBuiltDeploymentInformation.keySet()
+        def allComponentDeployments = os.getDeploymentConfigsForComponent(componentSelector)
+        logger.debug(
+            "ODS created deployments for ${repo.id}: " +
+            "${odsBuiltDeployments}, all deployments: ${allComponentDeployments}"
+        )
+
+        odsBuiltDeployments.each { odsBuiltDeploymentName ->
+            allComponentDeployments.remove(odsBuiltDeploymentName)
+        }
+
+        if (allComponentDeployments.size() > 0 ) {
+            def message = "DeploymentConfigs (component: '${repo.id}') found that are not ODS managed: " +
+                "'${allComponentDeployments}'!\r" +
+                "Please fix by rolling them out through 'odsComponentStageRolloutOpenShiftDeployment()'!"
+            if (project.isWorkInProgress) {
+                util.warnBuild(message)
+            } else {
+                throw new RuntimeException(message)
+            }
+        }
+
+        def imagesFromOtherProjectsFail = []
+        odsBuiltDeploymentInformation.each { odsBuiltDeploymentName, odsBuiltDeployment ->
+            odsBuiltDeployment.containers?.each { containerName, containerImage ->
+                def owningProject = os.imageInfoWithShaForImageStreamUrl(containerImage).repository
+                if (project.targetProject != owningProject
+                    && !EXCLUDE_NAMESPACES_FROM_IMPORT.contains(owningProject)) {
+                    def msg = "Deployment: ${odsBuiltDeploymentName} / " +
+                        "Container: ${containerName} / Owner: ${owningProject}"
+                    logger.warn "! Image out of scope! ${msg}"
+                    imagesFromOtherProjectsFail << msg
+                }
+            }
+        }
+
+        if (imagesFromOtherProjectsFail.size() > 0 ) {
+            def message = "Containers (component: '${repo.id}') found " +
+                "that will NOT be transferred to other environments - please fix!! " +
+                "\rOffending: ${imagesFromOtherProjectsFail}"
+            if (project.isWorkInProgress) {
+                util.warnBuild(message)
+            } else {
+                throw new RuntimeException(message)
+            }
+        }
+        logger.debugClocked("export-ocp-verify-${repo.id}")
+    }
+}

--- a/src/org/ods/orchestration/usecase/DocGenUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/DocGenUseCase.groovy
@@ -149,12 +149,12 @@ abstract class DocGenUseCase {
 
     @SuppressWarnings(['AbcMetric'])
     Map resurrectAndStashDocument(String documentType, Map repo, boolean stash = true) {
-        if (!repo.data?.odsBuildArtifacts || !repo.data.odsBuildArtifacts?.deployments) {
+        if (!repo.data.openshift.deployments) {
             return [found: false]
         }
         String resurrectedBuild
-        if (!!repo.data.odsBuildArtifacts.resurrected) {
-            resurrectedBuild = repo.data.odsBuildArtifacts.resurrected
+        if (!!repo.data.openshift.resurrectedBuild) {
+            resurrectedBuild = repo.data.openshift.resurrectedBuild
             this.steps.echo "Using ${documentType} from jenkins build: ${resurrectedBuild}" +
                 " for repo: ${repo.id}"
         } else {

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1155,17 +1155,11 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         def watermarkText = this.getWatermarkText(documentType, this.project.hasWipJiraIssues())
 
-        if (!repo.data.openshift && repo.data.odsBuildArtifacts) {
-            repo.data['openshift'] = [:]
-            repo.data.openshift << repo.data.odsBuildArtifacts.subMap (['builds','deployments'])
-            this.steps.echo("Fetched openshift data from build for repo: ${repo.id} \r${repo.data.openshift}")
-        }
-
         def deploynoteData = 'Components were built & deployed during installation.'
-        if (!!repo.data.odsBuildArtifacts?.resurrected) {
+        if (repo.data.openshift.resurrectedBuild) {
             deploynoteData = "Components were found, and are 'up to date' with version control -no deployments happend!\r" +
-                " SCRR was restored from the corresponding creation build (${repo.data.odsBuildArtifacts?.resurrected})"
-        } else if (!repo.data.openshift?.builds) {
+                " SCRR was restored from the corresponding creation build (${repo.data.openshift.resurrectedBuild})"
+        } else if (!repo.data.openshift.builds) {
             deploynoteData = 'NO Components were built during installation, existing components (created in Dev) were deployed.'
         }
 
@@ -1173,10 +1167,10 @@ class LeVADocumentUseCase extends DocGenUseCase {
             metadata     : this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType], repo),
             deployNote   : deploynoteData,
             openShiftData: [
-                builds      : repo.data.openshift?.builds ?: '',
-                deployments : repo.data.openshift?.deployments ?: ''
+                builds     : repo.data.openshift.builds ?: '',
+                deployments: repo.data.openshift.deployments ?: ''
             ],
-            data         : [
+            data: [
                 repo    : repo,
                 sections: sections
             ]

--- a/src/org/ods/orchestration/util/DeploymentDescriptor.groovy
+++ b/src/org/ods/orchestration/util/DeploymentDescriptor.groovy
@@ -1,0 +1,83 @@
+package org.ods.orchestration.util
+
+import org.ods.util.IPipelineSteps
+
+import groovy.json.JsonOutput
+
+class DeploymentDescriptor {
+
+    static final String FILE_NAME = 'ods-deployments.json'
+    static final String CREATED_BY_BUILD_STR = 'CREATED_BY_BUILD'
+
+    private final String createdByBuild
+    private Map deployments
+
+    DeploymentDescriptor(Map deployments, String createdByBuild) {
+        this.deployments = deployments ?: [:]
+        this.createdByBuild = createdByBuild ?: ''
+    }
+
+    static Map stripDeployments(Map deployments) {
+        def strippedDownDeployments = [:]
+        deployments.each { dn, d ->
+            def strippedDownContainers = [:]
+            d.containers.each { cn, image ->
+                def imageParts = image.split('/')[-2..-1]
+                if (MROPipelineUtil.EXCLUDE_NAMESPACES_FROM_IMPORT.contains(imageParts.first())) {
+                    strippedDownContainers[cn] = imageParts.join('/')
+                } else {
+                    strippedDownContainers[cn] = imageParts.last()
+                }
+            }
+            strippedDownDeployments[dn] = [containers: strippedDownContainers]
+        }
+        strippedDownDeployments
+    }
+
+    static DeploymentDescriptor readFromFile(IPipelineSteps steps) {
+        if (!steps.fileExists(FILE_NAME)) {
+            throw new RuntimeException("No such file: ${FILE_NAME}")
+        }
+        def dd = steps.readJSON(file: FILE_NAME)
+        // Backwards compatibility layer for master
+        def deployments = dd.deployments
+        if (!deployments) {
+            deployments = [:]
+            dd.each { deploymentName, deployment ->
+                if (deploymentName != CREATED_BY_BUILD_STR) {
+                    deployments[deploymentName] = deployment
+                }
+            }
+        }
+        new DeploymentDescriptor(deployments, dd[CREATED_BY_BUILD_STR])
+    }
+
+    Map getDeployments() {
+        deployments
+    }
+
+    List<String> getDeploymentNames() {
+        deployments.collect { k, v -> k }
+    }
+
+    String getCreatedByBuild() {
+        createdByBuild
+    }
+
+    boolean buildValidForVersion(String version) {
+        def buildParts = createdByBuild.split('/')
+        buildParts.size() == 2 && buildParts.first() == version
+    }
+
+    void writeToFile(IPipelineSteps steps) {
+        def content = [
+            deployments: deployments,
+            (CREATED_BY_BUILD_STR): createdByBuild,
+        ]
+        steps.writeFile(
+            file: FILE_NAME,
+            text: JsonOutput.prettyPrint(JsonOutput.toJson(content))
+        )
+    }
+
+}

--- a/src/org/ods/orchestration/util/GitTag.groovy
+++ b/src/org/ods/orchestration/util/GitTag.groovy
@@ -4,32 +4,29 @@ import org.ods.services.GitService
 
 class GitTag {
 
-    private String version
-    private String changeId
-    private int buildNumber
-    private String envToken
+    // Major version, e.g. 1, 2, 3, etc.
+    private final String version
+    // Change ID (referring to an external change tracking system)
+    private final String changeId
+    // Iteration is a number automatically increased by the orchestration pipeline.
+    // This is part of the Git tag as the Jenkins build number alone is not reliable
+    // enough (it might reset when the persistent volume is deleted).
+    private final int iteration
+    // Build number is the Jenkins build number. This is part of the Git tag as
+    // the iteration alone is not reliable enough (errors during the pipeline
+    // run might prevent the next assembly). Note that the build number
+    // referenced here is always the build number of the assembling pipeline run.
+    private final String buildNumber
+    // envToken signifies the environment which was targeted by the
+    // orchestration pipeline. One of D, Q or P.
+    private final String envToken
 
-    GitTag(String version, String changeId, int buildNumber, String envToken) {
+    GitTag(String version, String changeId, int iteration, String buildNumber, String envToken) {
         this.version = version
         this.changeId = changeId
+        this.iteration = iteration
         this.buildNumber = buildNumber
         this.envToken = envToken
-    }
-
-    String toString() {
-        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v${version}-${changeId}-${buildNumber}-${envToken}"
-    }
-
-    GitTag withNextBuildNumber() {
-        withBuildNumber(this.buildNumber + 1)
-    }
-
-    GitTag withBuildNumber(int buildNumber) {
-        new GitTag(this.version, this.changeId, buildNumber, this.envToken)
-    }
-
-    GitTag withEnvToken(String envToken) {
-        new GitTag(this.version, this.changeId, this.buildNumber, envToken)
     }
 
     static GitTag readLatestBaseTag(String tagList, String version, String changeId, String envToken) {
@@ -37,26 +34,57 @@ class GitTag {
         if (envToken == 'P') {
             previousEnvToken = 'Q'
         }
-        def highestBuildNumber = -1
         if (tagList) {
-            def buildNumbers = tagList.split("\n").collect {
-                extractBuildNumber(it, version, changeId, previousEnvToken)
-            }.sort()
-            highestBuildNumber = buildNumbers.last()
-            return new GitTag(version, changeId, highestBuildNumber, previousEnvToken)
+            def tags = tagList.split("\n")
+
+            def highestIteration = -1
+            def highestBuildNumber = '0'
+            tags.each {
+                def iterationInfo = extractIterationInfo(it, version, changeId, previousEnvToken)
+                if (iterationInfo) {
+                    def iterationCandidate = iterationInfo.first().toInteger()
+                    def buildNumberCandidate = iterationInfo.last()
+                    if (iterationCandidate > highestIteration) {
+                        highestIteration = iterationCandidate
+                        highestBuildNumber = buildNumberCandidate
+                    }
+                }
+            }
+            if (highestIteration > -1 ) {
+                return new GitTag(version, changeId, highestIteration, highestBuildNumber, previousEnvToken)
+            }
         }
         return null
     }
 
-    static int extractBuildNumber(String tag, String version, String changeId, String envToken) {
-        def buildNumber = -1
+    static List<String> extractIterationInfo(String tag, String version, String changeId, String envToken) {
+        List<String> iterationParts = []
         if (tag && tag.contains('-') && tag.size() > 4) {
-            buildNumber = tag
+            iterationParts = tag
                 .replace("${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v${version}-${changeId}-", '')
                 .replace("-${envToken}", '')
-                .toInteger()
+                .split('b')
         }
-        buildNumber
+        if (iterationParts.size() == 1) {
+            iterationParts.push('0')
+        }
+        iterationParts
+    }
+
+    String toString() {
+        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v${version}-${changeId}-${iteration}b${buildNumber}-${envToken}"
+    }
+
+    GitTag nextIterationWithBuildNumber(String buildNumber) {
+        withIterationAndBuildNumber(this.iteration + 1, buildNumber)
+    }
+
+    GitTag withIterationAndBuildNumber(int iteration, String buildNumber) {
+        new GitTag(this.version, this.changeId, iteration, buildNumber, this.envToken)
+    }
+
+    GitTag withEnvToken(String envToken) {
+        new GitTag(this.version, this.changeId, this.iteration, this.buildNumber, envToken)
     }
 
 }

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -66,4 +66,5 @@ interface IContext {
 
     // alias for odsGitRef
     String getGitBranch()
+
 }

--- a/src/org/ods/quickstarter/Stage.groovy
+++ b/src/org/ods/quickstarter/Stage.groovy
@@ -30,4 +30,5 @@ abstract class Stage {
     protected String stageLabel() {
         STAGE_NAME
     }
+
 }

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -2,6 +2,7 @@ package org.ods.services
 
 import org.ods.util.ILogger
 
+@SuppressWarnings('MethodCount')
 class GitService {
 
     @SuppressWarnings('NonFinalPublicField')
@@ -141,25 +142,54 @@ class GitService {
         )
     }
 
+    def commit(List files, String msg, boolean allowEmpty = true) {
+        def allowEmptyFlag = allowEmpty ? '--allow-empty' : ''
+        script.sh(
+            script: """
+                git add ${files.join(' ')}
+                git commit -m "${msg}" ${allowEmptyFlag}
+            """,
+            label: 'Commit'
+        )
+    }
+
     def createTag(String name) {
         script.sh(
-          script: """git tag -a -m "${name}" ${name}""",
+            script: """git tag -f -a -m "${name}" ${name}""",
             label: "tag with ${name}"
         )
     }
 
-    def pushTag(String name) {
+    def pushRef(String name) {
         script.sh(
             script: "git push origin ${name}",
-            label: "push tag ${name}"
+            label: "Push ref ${name}"
         )
     }
 
     def pushBranchWithTags(String name) {
         script.sh(
             script: "git push --tags origin ${name}",
-            label: "push branch ${name} with tags"
+            label: "Push branch ${name} with tags"
         )
+    }
+
+    def tagAndPush(String tag) {
+        if (remoteTagExists(tag)) {
+            logger.info("Skipping tag '${tag}' because it already exists.")
+        } else {
+            createTag(tag)
+            pushRef(tag)
+        }
+    }
+
+    def tagAndPushBranch(String branch, String tag) {
+        if (remoteTagExists(tag)) {
+            logger.info("Skipping tag '${tag}' because it already exists.")
+        } else {
+            createTag(tag)
+            pushBranchWithTags(branch)
+        }
     }
 
     def checkout(
@@ -211,40 +241,48 @@ class GitService {
         return branchCheckStatus == 0
     }
 
-    @SuppressWarnings('UnnecessaryElseStatement')
-    boolean otherFilesChangedAfterCommitOfFile(String fileName, String openshiftDir) {
-        if (!script.fileExists(fileName)) {
-            return true
+    // isAncestor returns true if maybeAncestorCommit is an ancestor of
+    // descendantCommit, or, in other words, if descendantCommit contains
+    // everything of maybeAncestorCommit (and potentially more).
+    boolean isAncestor(String maybeAncestorCommit, String descendantCommit) {
+        script.sh(
+            script: "git merge-base --is-ancestor ${maybeAncestorCommit} ${descendantCommit}",
+            returnStatus: true,
+            label: "Check if ${descendantCommit} is descendant of ${maybeAncestorCommit}"
+        ) == 0
+    }
+
+    void switchToExistingBranch(String branch) {
+        script.sh(
+            script: "git checkout ${branch}",
+            label: "Checkout branch ${branch}"
+        )
+    }
+
+    void switchToOriginTrackingBranch(String branch) {
+        if (localBranchExists(branch)) {
+            script.sh(
+                script: "git branch -D ${branch}",
+                label: "Delete local ${branch} branch"
+            )
         }
-        try {
-            def commitOfFile = script.sh(
-                script: """git log -1 --format=%H ${fileName}""",
-                    returnStdout: true,
-                    label: "Get commit of ${fileName}"
-                ).trim()
-            if (!commitOfFile) {
-                return true
-            }
-            def filesChanged = script.sh(
-                script: """git diff ${commitOfFile} HEAD --name-only""",
-                    returnStdout: true,
-                    label: "Get changes after commit ${commitOfFile}"
-                ).trim()
-            List files = filesChanged.normalize().readLines()
-            // remove with ${} does not work .. wtf..
-            def templateYml = openshiftDir + '/template.yml'
-            files.remove(templateYml)
-            if (files.size() == 0) {
-                logger.debug ('Clean tree, no changes')
-                return false
-            } else {
-                logger.info ("Found modified files other than '${fileName}' " +
-                    "after commit '${commitOfFile}'\rFiles modified: '${files}'")
-                return true
-            }
-        } catch (err) {
-            return true
-        }
+        script.sh(
+            script: "git checkout -b ${branch} origin/${branch}",
+            label: "Checkout new branch based on origin/${branch}"
+        )
+    }
+
+    void checkoutAndCommitFiles(String branchToCheckoutFrom, List<String> filesToCheckout, String msg) {
+        script.sh("git checkout ${branchToCheckoutFrom} -- ${filesToCheckout.join(' ')}")
+        commit(filesToCheckout, msg)
+    }
+
+    void mergeIntoMainBranch(String branchToMerge, String mainBranch, List<String> filesToCheckout) {
+        switchToOriginTrackingBranch(mainBranch)
+        checkoutAndCommitFiles(branchToMerge, filesToCheckout, "Checkout ${branchToMerge}")
+        script.sh("git merge ${branchToMerge}")
+        pushRef(mainBranch)
+        script.sh("git checkout ${branchToMerge}")
     }
 
     def checkoutNewLocalBranch(String name) {
@@ -267,7 +305,7 @@ class GitService {
         if (envToken == 'P') {
             previousEnvToken = 'Q'
         }
-        def tagPattern = "${ODS_GIT_TAG_BRANCH_PREFIX}v${version}-${changeId}-[0-9]*-${previousEnvToken}"
+        def tagPattern = "${ODS_GIT_TAG_BRANCH_PREFIX}v${version}-${changeId}-*-${previousEnvToken}"
         script.sh(
             script: "git tag --list '${tagPattern}'",
             returnStdout: true,

--- a/src/org/ods/services/JenkinsService.groovy
+++ b/src/org/ods/services/JenkinsService.groovy
@@ -4,7 +4,6 @@ import org.ods.util.ILogger
 
 class JenkinsService {
 
-    public static final String CREATED_BY_BUILD_STR = 'CREATED_BY_BUILD'
     private static final String XUNIT_SYSTEM_RESULT_DIR = 'build/test-results/test'
 
     private final def script

--- a/src/org/ods/util/GitCredentialStore.groovy
+++ b/src/org/ods/util/GitCredentialStore.groovy
@@ -21,4 +21,5 @@ class GitCredentialStore {
             label: 'setup git credential store'
         )
     }
+
 }

--- a/test/groovy/org/ods/orchestration/usecase/DocGenUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/DocGenUseCaseSpec.groovy
@@ -433,7 +433,7 @@ class DocGenUseCaseSpec extends SpecHelper {
         def build = "0815"
         def repo = project.repositories.first()
   
-        repo.data.odsBuildArtifacts = [ : ]
+        repo.data.openshift = [:]
         when:
         def result = usecase.resurrectAndStashDocument(documentType, repo)
   

--- a/test/groovy/org/ods/orchestration/util/GitTagSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/GitTagSpec.groovy
@@ -11,22 +11,22 @@ class GitTagSpec extends SpecHelper {
 
     def "serializes to string"() {
         expect:
-        new GitTag("1", "A", 0, "D").toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D"
+        new GitTag("1", "A", 0, "156", "D").toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0b156-D"
     }
 
-    def "withNextBuildNumber increases build number"() {
+    def "nextIterationWithBuildNumber increases iteration and replaces build number"() {
         expect:
-        new GitTag("1", "A", 0, "D").withNextBuildNumber().toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"
+        new GitTag("1", "A", 0, "156", "D").nextIterationWithBuildNumber("157").toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1b157-D"
     }
 
-    def "withBuildNumber replaces build number"() {
+    def "withIterationAndBuildNumber replaces iteration and build number"() {
         expect:
-        new GitTag("1", "A", 0, "D").withBuildNumber(2).toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-2-D"
+        new GitTag("1", "A", 0, "156", "D").withIterationAndBuildNumber(2, "157").toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-2b157-D"
     }
 
     def "withEnvToken replaces env token"() {
         expect:
-        new GitTag("1", "A", 0, "D").withEnvToken('Q').toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-Q"
+        new GitTag("1", "A", 0, "156", "D").withEnvToken('Q').toString() == "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0b156-Q"
     }
 
     def "reads latest tag of previous environment"() {
@@ -34,12 +34,13 @@ class GitTagSpec extends SpecHelper {
         GitTag.readLatestBaseTag(tagList, version, changeId, envToken).toString() == result
 
         where:
-        tagList                                                                                     | version | changeId | envToken      || result
-        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D"                                               | "1"     | "A"      | "Q"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D"
-        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"  | "1"     | "A"      | "Q"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"
-        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"  | "1"     | "A"      | "D"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"
-        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-Q\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-Q"  | "1"     | "A"      | "P"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-Q"
-        ""                                                                                          | "1"     | "A"      | "P"           || "null"
+        tagList                                                                                               | version | changeId | envToken      || result
+        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D"                                                     | "1"     | "A"      | "Q"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0b0-D"
+        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"    | "1"     | "A"      | "Q"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1b0-D"
+        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-D"    | "1"     | "A"      | "D"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1b0-D"
+        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-Q\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1-Q"    | "1"     | "A"      | "P"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1b0-Q"
+        "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-0-D\n${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1b99-D" | "1"     | "A"      | "Q"           || "${GitService.ODS_GIT_TAG_BRANCH_PREFIX}v1-A-1b99-D"
+        ""                                                                                                    | "1"     | "A"      | "P"           || "null"
     }
 
 }

--- a/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
@@ -1159,7 +1159,7 @@ class ProjectSpec extends SpecHelper {
         def expected = new Yaml().load(new File(Project.METADATA_FILE_NAME).text)
         expected.repositories.each { repo ->
             repo.branch = "master"
-            repo.data = [ documents: [:] ]
+            repo.data = [ documents: [:], openshift: [:] ]
             repo.url = "https://github.com/my-org/net-${repo.id}.git"
         }
 

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -1,5 +1,7 @@
 package org.ods.services
 
+import groovy.json.JsonSlurperClassic
+
 import spock.lang.*
 
 import util.*
@@ -59,7 +61,7 @@ class OpenShiftServiceSpec extends SpecHelper {
         def file = new FixtureHelper().getResource("pod.json")
 
         when:
-        def result = service.extractPodData(file.text, "deployment 'bar'")
+        def result = service.extractPodData(new JsonSlurperClassic().parseText(file.text))
 
         then:
         result == [


### PR DESCRIPTION
In the finalize stage (assembly), we merge back into the main branch.
That ensures master has all changes of the release branch, ensuring that
newer releases do not accidentally loose changes done on earlier release
branches. However, if two concurrent releases are being worked on, then
it can still happen that the newer release branch does not contain
changes done in the older release branch. This is mitigated by a check
at the pipeline start (init stage). Every promotion to Q or P checks if
the commits that are to be deployed are descendants of commits already
deployed to Q and P. In case of Q, this might be OK (concurrent releases
fighting over Q are allowed), so the build is marked only as unstable.
In case of P, the build fails.

To enable the functionality described above, there is now a directory
"ods-state" in the release manager repository, which, on the master
branch, contains up-to-date information which version, change and
repository commits are deployed in which environment at the moment.

Apart from those changes, there are quite a few other improvements / bug
fixes which were identified in the process:

* Remove repo.data.odsBuildArtifact in favour of repo.data.openshift
* Only run resurrection logic in assemble mode
* Change resurrection detection to look at latest deployed commit in environment
  instead of looking for diff since last deployment descriptor commit.
  It also does not check for deployment version anymore. The better
  check would be to compare the exports, but that proved to be difficult
  with the agent setup we have right now. In any case, the export is
  always happening in the finalize stage, even when the component was
  resurrected so skipping this check seems fine to me.
* Change format of deployment descriptor (new top-level “deployments” key)
* Extracted logic of deployment descriptor in its own class
* Extract logic of deploying/finalizing ODS components in its own class
* Move more Git tasks into GitService
* Move hardcoded name of image puller secret to project to make it easier in the
  future to cusomtize this
* Speed up retrieval of pod data (previously it needed at least two API
  calls, now just one)
* Push all commits together in the finalize stage - this helps to
  prevent inconsistent tags between repositories. However, it still
  isn't an atomic transaction. To prevent pipelines from getting stuck
  (as the tag of a repository is not writable because it already
  exists), the Git tag used for promotion now includes the Jenkins build
  number of the assembling job.
* Introduce new pipeline parameter 'rePromote'. Using this flag it is
  possible to promote a tag to Q again that was previously already
  deployed. Re-deployment to P is never possible.

Closes #367.