### PR TITLE
Lazily set OpenShift app domain

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -1,9 +1,11 @@
 package org.ods.component
 
 import org.ods.util.Logger
+import org.ods.services.ServiceRegistry
 import org.ods.services.BitbucketService
 import org.ods.services.GitService
 import org.ods.services.NexusService
+import org.ods.services.OpenShiftService
 import com.cloudbees.groovy.cps.NonCPS
 import groovy.json.JsonSlurperClassic
 import groovy.json.JsonOutput
@@ -22,6 +24,8 @@ class Context implements IContext {
 
     // is the library checking out the code again, or relying on check'd out source?
     private final boolean localCheckoutEnabled
+
+    private String appDomain
 
     Context(def script, Map config, Logger logger, boolean localCheckoutEnabled = true) {
         this.script = script
@@ -488,14 +492,16 @@ class Context implements IContext {
         }
     }
 
-    // set the application domain
-    void setOpenshiftApplicationDomain (String domain) {
-        config.domain = domain
-    }
-
-    // get the application domain
     String getOpenshiftApplicationDomain () {
-        return config.domain
+        if (!config.environment) {
+            return ''
+        }
+        if (!this.appDomain) {
+            logger.startClocked("${config.componentId}-get-oc-app-domain")
+            this.appDomain = ServiceRegistry.instance.get(OpenShiftService).applicationDomain
+            logger.debugClocked("${config.componentId}-get-oc-app-domain")
+        }
+        this.appDomain
     }
 
     private String retrieveGitUrl() {

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -173,9 +173,6 @@ interface IContext {
     // set and add image labels
     void setExtensionImageLabels (Map <String, String> extensionLabels)
 
-    // set the application domain
-    void setOpenshiftApplicationDomain (String domain)
-
     // get the application domain
     String getOpenshiftApplicationDomain ()
 

--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -157,9 +157,6 @@ class Pipeline implements Serializable {
                         if (autoCloneEnabled) {
                             createOpenShiftEnvironment(context)
                         }
-                        logger.startClocked("${context.componentId}-get-oc-app-domain")
-                        context.setOpenshiftApplicationDomain(openShiftService.applicationDomain)
-                        logger.debugClocked("${context.componentId}-get-oc-app-domain")
                     }
                 }
             } catch (err) {


### PR DESCRIPTION
Most pipelines won't need that value so we can avoid doing the work
until we are actually asked for that value (e.g. in https://github.com/opendevstack/ods-quickstarters/blob/master/e2e-spock-geb/Jenkinsfile.template#L26).