### PR TITLE
Add stage to import image and automatically import if possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ codenarc {
     configFile = file('codenarc.groovy')
     maxPriority1Violations = 0
     maxPriority2Violations = 0
-    maxPriority3Violations = 731
+    maxPriority3Violations = 732
     reportFormat = 'html'
 }
 

--- a/docs/modules/jenkins-shared-library/pages/component-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/component-pipeline.adoc
@@ -12,18 +12,18 @@ Load the shared library in your `Jenkinsfile` like this:
 
 odsComponentPipeline(
   imageStreamTag: 'ods/jenkins-agent-golang:3.x',
-  projectId: 'foo',
-  componentId: 'bar',
   branchToEnvironmentMapping: [
     'master': 'dev',
     // 'release/*': 'test'
   ]
 ) { context ->
-  stage('Build') {
+  odsComponentStageImportOpenShiftImageOrElse(context) {
+    stage('Build') {
       // custom stage
+    }
+    odsComponentStageScanWithSonar(context)
+    odsComponentStageBuildOpenShiftImage(context)
   }
-  odsComponentStageScanWithSonar(context)
-  odsComponentStageBuildOpenShiftImage(context)
   odsComponentStageRolloutOpenShiftDeployment(context)
 }
 ----
@@ -57,6 +57,14 @@ include::partial$odsComponentStageScanWithSnyk.adoc[leveloffset=+2]
 === odsComponentStageBuildOpenShiftImage
 
 include::partial$odsComponentStageBuildOpenShiftImage.adoc[leveloffset=+2]
+
+=== odsComponentStageImportOpenShiftImage
+
+include::partial$odsComponentStageImportOpenShiftImage.adoc[leveloffset=+2]
+
+=== odsComponentStageImportOpenShiftImageOrElse
+
+include::partial$odsComponentStageImportOpenShiftImageOrElse.adoc[leveloffset=+2]
 
 === odsComponentStageRolloutOpenShiftDeployment
 

--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -65,13 +65,16 @@ Available options are:
 | Component ID, e.g. `be-auth-service`.
 
 | environmentLimit
-| Number of environments to allow.
+| Number of environments to allow when auto-cloning environments.
 
 | dockerDir
 | The docker directory to use when building the image in openshift. Defaults to `docker`.
 
+| imagePromotionSequences
+| Sequence of environments between which images can be promoted in `odsComponentStageImportOpenShiftImageOrElse`. Defaults to `['dev->test', 'test->prod']`.
+
 | sonarQubeBranch
-| Deprecated in 3.x! Please use option `branch` on `odsComponentStageScanWithSonar`.
+| Please use option `branch` on `odsComponentStageScanWithSonar`.
 
 | failOnSnykScanVulnerabilities
 | Deprecated in 3.x! Please use option `failOnVulnerabilities` on `odsComponentStageScanWithSnyk`.
@@ -147,6 +150,9 @@ The `context` object contains the following properties:
 | gitCommit
 | Git commit SHA to build.
 
+| shortGitCommit
+| Short Git commit SHA (first 8 chars) to build.
+
 | gitCommitAuthor
 | Git commit author.
 
@@ -170,6 +176,9 @@ The `context` object contains the following properties:
 
 | dockerDir
 | The docker directory to use when building the image in openshift. Defaults to `docker`.
+
+| imagePromotionSequences
+| Sequence of environments between which images can be promoted. Used e.g. in `odsComponentStageImportOpenShiftImageOrElse`. Defaults to `['dev->test', 'test->prod']`.
 |===
 
 == Git Workflow / Branch to Environment Mapping

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageBuildOpenShiftImage.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageBuildOpenShiftImage.adoc
@@ -1,7 +1,7 @@
 Triggers (and follows) a build in the `BuildConfig` related to the repository
 being built.
 
-The resulting image is tagged with `context.tagversion` (`<JOB_NUMBER>-<GIT_SHA>`).
+The resulting image is tagged with `context.shortGitCommit`.
 
 If the directory referenced by `openshiftDir` exists, the templates in there will be applied using https://github.com/opendevstack/tailor[Tailor]. In addition to the configuration options below, one can use e.g. a `Tailorfile` to adjust the behaviour of Tailor as needed.
 
@@ -13,6 +13,9 @@ Available options:
 
 | resourceName
 | Name of `BuildConfig`/`ImageStream` to use (defaults to `context.componentId`).
+
+| imageTag
+| Image tag to apply (defaults to `context.shortGitCommit`).
 
 | buildArgs
 | Pass build arguments to the image build process.

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageImportOpenShiftImage.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageImportOpenShiftImage.adoc
@@ -1,0 +1,22 @@
+Imports an image from another namespace.
+
+By default, the source image is identified using the commit which triggered the pipeline run.
+
+Available options:
+
+[cols="1,2"]
+|===
+| Option | Description
+
+| resourceName
+| Name of `ImageStream` to use (defaults to `context.componentId`).
+
+| sourceProject
+| OpenShift project from which to import the image identified by `resourceName`.
+
+| sourceTag
+| Image tag to look for in the `sourceProject` (defaults to `context.shortGitCommit`).
+
+| targetTag
+| Image tag to apply to the imported image in the target project (defaults to `sourceTag`).
+|===

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageImportOpenShiftImageOrElse.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageImportOpenShiftImageOrElse.adoc
@@ -1,0 +1,40 @@
+Imports an image from another namespace if possible,
+otherwise execute the given closure.
+
+The stage takes the exact same options as `odsComponentStageImportOpenShiftImage`.
+
+Before running the image import, it checks whether the image (identified by the
+`sourceTag`) is present in a suitable project. This is the current
+target project, and potentially one or more specified by the pipeline option
+`imagePromotionSequences`. For example, if `imagePromotionSequences` is
+`['dev->test', 'test->prod']` (which is the default setting), then, given the
+current target environment is `test`, suitable environments are `dev` (based on
+`dev->test`), and `test` itself.
+
+If the image is not present in a suitable project, the given closure is executed.
+
+Using this "stage" allows you to avoid building a container image for the same
+Git commit multiple times, reducing build times and increasing reliability as
+you can promote the exact same image from one environment to another. Keep in
+mind that image lookup works by finding an image tagged with the current Git
+commit. If you merge a branch into another using a merge commit, the current Git
+commit will differ from the previously built image tag, even if the actual
+contents of the repository are the same. To ensure image importing kicks in, use
+the `--ff-only` option on `git merge` (this can also be enabled for pull
+requests in Bitbucket under "Merge strategies"). There are a few consequences
+when doing so, which should be kept in mind:
+
+* No merge commit is created, which has the downside that you do not see when
+  a PR was merged, and that the merge commit is a convenient way to find the
+  associated PR. However, it has the upside that your Git history is not
+  polluted by merge commits.
+* Enforcing a fast-forward merge prevents you from merging a branch which is
+  not up-to-date with the target branch. This has the downside that before
+  merging, you may need to rebase your branch or merge the target branch into
+  your branch if someone else updated the target branch in the meantime. While
+  this may cause extra work, it has the upside that you cannot accidentally
+  break the target branch (e.g. tests on your branch may work based on the
+  outdated target branch, but fail after the merge).
+
+In summary, using `git merge --ff-only` provides safety, a clean history and
+allows to promote the exact same image between environments.

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -14,6 +14,9 @@ Available options:
 | resourceName
 | Name of `DeploymentConfig` to use (defaults to `context.componentId`).
 
+| imageTag
+| Image tag on which to apply the `latest` tag (defaults to `context.shortGitCommit`).
+
 | deployTimeoutMinutes
 | Adjust timeout of rollout (defaults to 5 minutes). Caution: This needs to be aligned with the deployment strategy timeout (timeoutSeconds) and the readiness probe timeouts (initialDelaySeconds + failureThreshold * periodSeconds).
 

--- a/docs/modules/jenkins-shared-library/partials/update-to-3x.adoc
+++ b/docs/modules/jenkins-shared-library/partials/update-to-3x.adoc
@@ -112,3 +112,14 @@ use `context.bitbucketHostWithoutScheme`.
 
 TIP: A notable addition to the `context` object is a new property `issueId`, which
 exposes the Jira issue ID (such as `123` from branch `feature/FOO-123-bar-baz`).
+
+=== Different image tags
+
+Previously, images produced by `odsComponentStageBuildOpenShiftImage` where
+tagged with `context.tagversion`, which consisted of the Jenkins build number
+and the (shortened) Git commit (e.g. `7-cd3e9082`). This made it difficult
+for other processes (unaware of the Jenkins build number) to find those images.
+
+The images are now tagged with just the (shortened) Git commit (e.g. `cd3e9082`).
+This change also has the huge benefit that it allows to promote images between
+environments (avoiding to rebuild them) using the new stage xref:jenkins-shared-library:component-pipeline.adoc#_odscomponentstageimportopenshiftimageorelse[odsComponentStageImportOpenShiftImageOrElse].

--- a/src/org/ods/component/BuildOpenShiftImageStage.groovy
+++ b/src/org/ods/component/BuildOpenShiftImageStage.groovy
@@ -23,6 +23,9 @@ class BuildOpenShiftImageStage extends Stage {
         if (!config.resourceName) {
             config.resourceName = context.componentId
         }
+        if (!config.imageTag) {
+            config.imageTag = context.shortGitCommit
+        }
         if (!config.imageLabels) {
             config.imageLabels = [:]
         }
@@ -141,7 +144,7 @@ class BuildOpenShiftImageStage extends Stage {
     }
 
     private String getImageReference() {
-        openShift.getImageReference(config.resourceName, context.tagversion)
+        openShift.getImageReference(config.resourceName, config.imageTag)
     }
 
     private String startAndFollowBuild() {
@@ -159,7 +162,7 @@ class BuildOpenShiftImageStage extends Stage {
     private String patchBuildConfig(Map imageLabels) {
         openShift.patchBuildConfig(
             config.resourceName,
-            context.tagversion,
+            config.imageTag,
             config.buildArgs,
             imageLabels
         )

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -114,6 +114,9 @@ class Context implements IContext {
         if (!config.containsKey('openshiftRolloutTimeout')) {
             config.openshiftRolloutTimeout = 5 // minutes
         }
+        if (!config.containsKey('imagePromotionSequences')) {
+            config.imagePromotionSequences = ['dev->test', 'test->prod']
+        }
         if (!config.groupId) {
             config.groupId = "org.opendevstack.${config.projectId}"
         }
@@ -125,7 +128,7 @@ class Context implements IContext {
         config.gitCommitAuthor = retrieveGitCommitAuthor()
         config.gitCommitMessage = retrieveGitCommitMessage()
         config.gitCommitTime = retrieveGitCommitTime()
-        config.tagversion = "${config.buildNumber}-${config.gitCommit.take(8)}"
+        config.tagversion = "${config.buildNumber}-${getShortGitCommit()}"
 
         if (!config.containsKey('testResults')) {
             config.testResults = ''
@@ -250,6 +253,11 @@ class Context implements IContext {
         config.branchToEnvironmentMapping
     }
 
+    @NonCPS
+    List<String> getImagePromotionSequences() {
+        config.imagePromotionSequences
+    }
+
     String getAutoCloneEnvironmentsFromSourceMapping() {
         config.autoCloneEnvironmentsFromSourceMapping
     }
@@ -294,8 +302,14 @@ class Context implements IContext {
         config.repoName
     }
 
+    @NonCPS
     String getGitCommit() {
         config.gitCommit
+    }
+
+    @NonCPS
+    String getShortGitCommit() {
+        config.gitCommit.take(8)
     }
 
     String getGitCommitAuthor() {

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -60,6 +60,8 @@ interface IContext {
     // Define which environments are cloned from which source environments.
     String getAutoCloneEnvironmentsFromSourceMapping()
 
+    List<String> getImagePromotionSequences()
+
     // The environment which was chosen as the clone source.
     String getCloneSourceEnv()
 
@@ -100,6 +102,9 @@ interface IContext {
 
     // Git commit SHA to build.
     String getGitCommit()
+
+    // Shortened Git commit SHA to build.
+    String getShortGitCommit()
 
     // Git commit author.
     String getGitCommitAuthor()

--- a/src/org/ods/component/ImportOpenShiftImageStage.groovy
+++ b/src/org/ods/component/ImportOpenShiftImageStage.groovy
@@ -1,0 +1,70 @@
+package org.ods.component
+
+import org.ods.services.OpenShiftService
+import org.ods.util.ILogger
+
+class ImportOpenShiftImageStage extends Stage {
+
+    public final String STAGE_NAME = 'Import OpenShift image'
+    private final OpenShiftService openShift
+
+    ImportOpenShiftImageStage(
+        def script,
+        IContext context,
+        Map config,
+        OpenShiftService openShift,
+        ILogger logger) {
+        super(script, context, config, logger)
+        if (!config.resourceName) {
+            config.resourceName = context.componentId
+        }
+        if (!config.sourceTag) {
+            config.sourceTag = context.shortGitCommit
+        }
+        if (!config.targetTag) {
+            config.targetTag = config.sourceTag
+        }
+        this.openShift = openShift
+    }
+
+    protected run() {
+        if (!context.environment) {
+            logger.warn('Skipping image import because of empty (target) environment ...')
+            return
+        }
+
+        if (!config.sourceProject) {
+            script.error '''Param 'sourceProject' is required'''
+            return
+        }
+
+        if (config.imagePullerSecret) {
+            openShift.importImageTagFromSourceRegistry(
+                config.resourceName,
+                config.imagePullerSecret,
+                config.sourceProject,
+                config.sourceTag,
+                config.targetTag
+            )
+        } else {
+            openShift.importImageTagFromProject(
+                config.resourceName,
+                config.sourceProject,
+                config.sourceTag,
+                config.targetTag
+            )
+        }
+        logger.info(
+            "Imported image '${config.sourceProject}/${config.resourceName}:${config.sourceTag}' into " +
+            "'${context.targetProject}/${config.resourceName}:${config.targetTag}'."
+        )
+    }
+
+    protected String stageLabel() {
+        if (config.resourceName != context.componentId) {
+            return "${STAGE_NAME} (${config.resourceName})"
+        }
+        STAGE_NAME
+    }
+
+}

--- a/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
+++ b/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
@@ -22,6 +22,9 @@ class RolloutOpenShiftDeploymentStage extends Stage {
         if (!config.resourceName) {
             config.resourceName = context.componentId
         }
+        if (!config.imageTag) {
+            config.imageTag = context.shortGitCommit
+        }
         if (!config.deployTimeoutMinutes) {
             config.deployTimeoutMinutes = context.openshiftRolloutTimeout ?: 5
         }
@@ -133,7 +136,7 @@ class RolloutOpenShiftDeploymentStage extends Stage {
     }
 
     private void setImageTagLatest(List<Map<String, String>> imageStreams) {
-        imageStreams.each { openShift.setImageTag(it.name, context.tagversion, 'latest') }
+        imageStreams.each { openShift.setImageTag(it.name, config.imageTag, 'latest') }
     }
 
 }

--- a/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
@@ -141,7 +141,7 @@ class DeployOdsComponent {
             def imageName = imageInfo.first()
             def imageSha = imageInfo.last()
             if (project.targetClusterIsExternal) {
-                os.importImageFromSourceRegistry(
+                os.importImageShaFromSourceRegistry(
                     imageName,
                     project.sourceRegistrySecretName,
                     sourceProject,
@@ -149,7 +149,7 @@ class DeployOdsComponent {
                     project.targetTag
                 )
             } else {
-                os.importImageFromProject(
+                os.importImageShaFromProject(
                     imageName,
                     sourceProject,
                     imageSha,

--- a/test/groovy/vars/OdsComponentStageBuildOpenShiftImageSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageBuildOpenShiftImageSpec.groovy
@@ -213,7 +213,7 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
 
   def "skip when no environment given"() {
     given:
-    def config = [environment: null]
+    def config = [environment: null, gitCommit: 'cd3e9082d7466942e1de86902bb9e663751dae8e']
     def context = new Context(null, config, logger)
 
     when:

--- a/test/groovy/vars/OdsComponentStageImportOpenShiftImageSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageImportOpenShiftImageSpec.groovy
@@ -1,0 +1,67 @@
+package vars
+
+import org.ods.component.Context
+import org.ods.component.IContext
+import org.ods.services.OpenShiftService
+import org.ods.services.JenkinsService
+import org.ods.services.ServiceRegistry
+import org.ods.util.Logger
+import vars.test_helper.PipelineSpockTestBase
+import util.PipelineSteps
+import spock.lang.*
+
+class OdsComponentStageImportOpenShiftImageSpec extends PipelineSpockTestBase {
+
+  private Logger logger = new Logger (new PipelineSteps(), true)
+
+  @Shared
+  def config = [
+      gitUrl: 'https://example.com/scm/foo/bar.git',
+      gitCommit: 'cd3e9082d7466942e1de86902bb9e663751dae8e',
+      gitCommitMessage: """Foo\n\nSome "explanation".""",
+      gitCommitAuthor: "John O'Hare",
+      gitCommitTime: '2020-03-23 12:27:08 +0100',
+      gitBranch: 'master',
+      buildUrl: 'https://jenkins.example.com/job/foo-cd/job/foo-cd-bar-master/11/console',
+      buildTime: '2020-03-23 12:27:08 +0100',
+      odsSharedLibVersion: '2.x',
+      projectId: 'foo',
+      componentId: 'bar'
+  ]
+
+  def "run successfully"() {
+    given:
+    def c = config + [environment: 'test', targetProject: 'foo-test']
+    IContext context = new Context(null, c, logger)
+    OpenShiftService openShiftService = Mock(OpenShiftService.class)
+    openShiftService.importImageTagFromProject(*_) >> {}
+    ServiceRegistry.instance.add(OpenShiftService, openShiftService)
+
+    when:
+    def script = loadScript('vars/odsComponentStageImportOpenShiftImage.groovy')
+//    helper.registerAllowedMethod('echo', [ String ]) {String args -> }
+    def buildInfo = script.call(context, [sourceProject: 'foo-dev'])
+
+    then:
+    printCallStack()
+    assertCallStackContains('''Imported image 'foo-dev/bar:cd3e9082' into 'foo-test/bar:cd3e9082'.''')
+    assertJobStatusSuccess()
+    //1 * openShiftService.importImageTagFromProject(*_)
+  }
+
+  def "skip when no environment given"() {
+    given:
+    def config = [environment: null, gitCommit: 'cd3e9082d7466942e1de86902bb9e663751dae8e']
+    def context = new Context(null, config, logger)
+
+    when:
+    def script = loadScript('vars/odsComponentStageImportOpenShiftImage.groovy')
+    script.call(context)
+
+    then:
+    printCallStack()
+    assertCallStackContains("WARN: Skipping image import because of empty (target) environment ...")
+    assertJobStatusSuccess()
+  }
+
+}

--- a/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
@@ -138,7 +138,7 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
 
   def "skip when no environment given"() {
     given:
-    def config = [environment: null]
+    def config = [environment: null, gitCommit: 'cd3e9082d7466942e1de86902bb9e663751dae8e']
     def context = new Context(null, config, logger)
 
     when:

--- a/vars/odsComponentStageImportOpenShiftImage.groovy
+++ b/vars/odsComponentStageImportOpenShiftImage.groovy
@@ -1,0 +1,24 @@
+import org.ods.component.ImportOpenShiftImageStage
+import org.ods.component.IContext
+
+import org.ods.services.OpenShiftService
+import org.ods.services.ServiceRegistry
+import org.ods.util.Logger
+import org.ods.util.ILogger
+
+def call(IContext context, Map config = [:]) {
+    ILogger logger = ServiceRegistry.instance.get(Logger)
+    // this is only for testing, because we need access to the script context :(
+    if (!logger) {
+        logger = new Logger (this, !!env.DEBUG)
+    }
+    def stage = new ImportOpenShiftImageStage(
+        this,
+        context,
+        config,
+        ServiceRegistry.instance.get(OpenShiftService),
+        logger
+    )
+    return stage.execute()
+}
+return this

--- a/vars/odsComponentStageImportOpenShiftImageOrElse.groovy
+++ b/vars/odsComponentStageImportOpenShiftImageOrElse.groovy
@@ -1,0 +1,77 @@
+import org.ods.component.ImportOpenShiftImageStage
+import org.ods.component.IContext
+
+import org.ods.services.OpenShiftService
+import org.ods.services.ServiceRegistry
+import org.ods.util.PipelineSteps
+import org.ods.util.Logger
+import org.ods.util.ILogger
+
+def call(IContext context, Map config = [:], Closure block) {
+    ILogger logger = ServiceRegistry.instance.get(Logger)
+    // this is only for testing, because we need access to the script context :(
+    if (!logger) {
+        logger = new Logger (this, !!env.DEBUG)
+    }
+
+    if (!!env.MULTI_REPO_BUILD) {
+        logger.debug(
+            '''Orchestration pipeline builds always run the 'orElse' branch ''' +
+            'as image building and importing is handled in the orchestration pipeline.'
+        )
+        return block()
+    }
+
+    if (!context.environment) {
+        logger.info('No environment determined, cannot import images.')
+        return block()
+    }
+
+    if (!config.resourceName) {
+        config.resourceName = context.componentId
+    }
+    if (!config.sourceTag) {
+        config.sourceTag = context.shortGitCommit
+    }
+    if (!config.targetTag) {
+        config.targetTag = config.sourceTag
+    }
+
+    def namespaceCandidates = [context.targetProject]
+    if (config.sourceProject) {
+        namespaceCandidates << config.sourceProject
+    } else {
+        context.imagePromotionSequences.each { sequence ->
+            def sequenceParts = sequence.split('->')
+            if (sequenceParts.last() == context.environment) {
+                namespaceCandidates << "${context.projectId}-${sequenceParts.first()}"
+            }
+        }
+    }
+    logger.info("Looking for existing '${config.resourceName}' image in: ${namespaceCandidates.join(', ')}.")
+    def namespaceWhereImageExists = namespaceCandidates.find { n ->
+        OpenShiftService.imageExists(
+            new PipelineSteps(this), n, config.resourceName, config.sourceTag
+        )
+    }
+
+    if (namespaceWhereImageExists) {
+        if (namespaceWhereImageExists == context.targetProject) {
+            logger.info("Image '${config.resourceName}' exists already in ${context.targetProject}.")
+            return
+        }
+        logger.info(
+            "Image '${config.resourceName}' exists already in ${namespaceWhereImageExists}, " +
+            'importing from there ...'
+        )
+        config.sourceProject = namespaceWhereImageExists
+        def stage = new ImportOpenShiftImageStage(
+            this, context, config, ServiceRegistry.instance.get(OpenShiftService), logger
+        )
+        return stage.execute()
+    }
+
+    logger.info("Not importing image '${config.resourceName}' ...")
+    block()
+}
+return this


### PR DESCRIPTION
* New stage `odsComponentStageImportOpenShiftImage`.
* New "special" stage `odsComponentStageImportOpenShiftImageOrElse`
  which either imports an image or executes the given closure.
* Images are now tagged with the short Git SHA, dropping the Jenkins
  build number prefix.

Example usage:
```groovy
@Library('ods-jenkins-shared-library@3.x') _

odsComponentPipeline(
  imageStreamTag: 'ods/jenkins-agent-golang:3.x',
  branchToEnvironmentMapping: [
    'develop': 'dev',
    'release/*': 'test',
    'master': 'prod'
  ]
) { context ->
  odsComponentStageImportOpenShiftImageOrElse(context) {
    stage('Build') {
      // custom stage
    }
    odsComponentStageScanWithSonar(context)
    odsComponentStageBuildOpenShiftImage(context)
  }
  odsComponentStageRolloutOpenShiftDeployment(context)
}
```

This allows users exactly which steps to skip when an image can be imported. Further, it allows to use the "import image stage" as a standalone feature as well.