### PR TITLE
Extend deployTimeoutMinutes documentation

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -15,7 +15,7 @@ Available options:
 | Name of `DeploymentConfig` to use (defaults to `context.componentId`).
 
 | deployTimeoutMinutes
-| Adjust timeout of rollout (defaults to 5 minutes). Needs to be kept in sync with the OpenShift rollout timeouts and summarized health-check timeouts.
+| Adjust timeout of rollout (defaults to 5 minutes). Caution: This needs to be aligned with the deployment strategy timeout (timeoutSeconds) and the readiness probe timeouts (initialDelaySeconds + failureThreshold * periodSeconds).
 
 | openshiftDir
 | Directory with OpenShift templates (defaults to `openshift`).

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -15,7 +15,7 @@ Available options:
 | Name of `DeploymentConfig` to use (defaults to `context.componentId`).
 
 | deployTimeoutMinutes
-| Adjust timeout of rollout (defaults to 5 minutes).
+| Adjust timeout of rollout (defaults to 5 minutes). Needs to be kept in sync with the OpenShift rollout timeouts and summarized health-check timeouts.
 
 | openshiftDir
 | Directory with OpenShift templates (defaults to `openshift`).


### PR DESCRIPTION
Parameter needs to be kept in sync with the OCP parameters. Otherwise the health checks could take longer than the ODS timeout and ODS would cancel the deployment.