### PR TITLE
Disable UnnecessaryGString rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ codenarc {
     configFile = file('codenarc.groovy')
     maxPriority1Violations = 0
     maxPriority2Violations = 0
-    maxPriority3Violations = 732
+    maxPriority3Violations = 336
     reportFormat = 'html'
 }
 

--- a/codenarc.groovy
+++ b/codenarc.groovy
@@ -393,7 +393,7 @@ ruleset {
     UnnecessaryElseStatement
     UnnecessaryFinalOnPrivateMethod
     UnnecessaryFloatInstantiation
-    UnnecessaryGString
+    UnnecessaryGString(enabled: false) // disabled as to not distract by thinking about the differences to String
     UnnecessaryGetter(enabled: false) // disabled to make grepping through files easier
     UnnecessaryIfStatement
     UnnecessaryInstanceOfCheck


### PR DESCRIPTION
Even though we have already spent quite a lot of time to satisfy the
rule, I've come to the conclusion to disable it:

* As mentioned in https://github.com/opendevstack/ods-jenkins-shared-library/pull/363#issuecomment-637396751,
  many people have used double quotes to avoid thinking about this
* This rule accounts for over half the violations right now, and
  therefore is a constant source of pain when developing. This is made
  worse by the fact that CodeNarc does not auto-correct.
* Enforcing single quotes leads to unnecessary Git diff when e.g. a
  variable needs to be interpolated later on
* The reasoning of CodeNarc to have this rule is not really convincing:
  "String objects should be created with single quotes, and GString
  objects created with double quotes. Creating normal String objects with
  double quotes is confusing to readers."

To make things simple, less annoying for people, and get us closer to
zero violations, I propose to disable the rule.