### PR TITLE
Allow DeploymentConfigs with containers pointing to remote images

### DIFF
--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -487,9 +487,10 @@ class OpenShiftService {
         def urlParts = url.split('/').toList()
 
         if (urlParts.size() < 2) {
-            throw new RuntimeException(
-                "ERROR: Image URL ${url} must have at least two parts (repository/reference)"
-            )
+            logger.debug "Image URL ${url} does not define the repository explicitly."
+            imageInfo.repository = ''
+        } else {
+            imageInfo.repository = urlParts[-2]
         }
 
         if (urlParts.size() > 2) {
@@ -498,8 +499,6 @@ class OpenShiftService {
             logger.debug "Image URL ${url} does not define the registry explicitly."
             imageInfo.registry = ''
         }
-
-        imageInfo.repository = urlParts[-2]
 
         if (urlParts[-1].contains('@')) {
             def shaParts = urlParts[-1].split('@').toList()

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -26,6 +26,8 @@ class OpenShiftServiceSpec extends SpecHelper {
         '172.30.21.196:5000/baz/qux@sha256:abc' || '172.30.21.196:5000' | 'baz'      | 'qux'
         'baz/qux@sha256:abc'                    || ''                   | 'baz'      | 'qux'
         'foo/bar:2-3ec425bc'                    || ''                   | 'foo'      | 'bar'
+        'qux@sha256:abc'                        || ''                   | ''         | 'qux'
+        'bar:2-3ec425bc'                        || ''                   | ''         | 'bar'
     }
 
     def "image info with SHA for image stream URL"() {


### PR DESCRIPTION
For a component, that is OK and should not fail. The orchestration
pipeline still has a check that all images are owned, which is unrelated
to the fixed check here.

Fixes #407.

FYI @georgfedermann @clemensutschig This is the error you ran into when you named the component `golang`. While in that case, you did not actually want to deploy an image from DockerHub, generally it is a valid use-case to deploy something from DockerHub. In that case, you just want to rollout, but not touch the image (e.g. not tag it with `latest`). Therefore the fix here is needed.