### PR TITLE
add variable based lookup to env map in case $ is used in key

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -409,7 +409,7 @@ class Context implements IContext {
             return
         }
         // Fixed name
-        def env = config.branchToEnvironmentMapping[config.gitBranch]
+        def env = config.branchToEnvironmentMapping.get("${config.gitBranch}")
         if (env) {
             config.environment = env
             config.cloneSourceEnv = environmentExists(env)

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -409,12 +409,17 @@ class Context implements IContext {
             return
         }
         // Fixed name
-        def env = config.branchToEnvironmentMapping.get("${config.gitBranch}")
+        def env = config.branchToEnvironmentMapping[config.gitBranch]
+        // this is for cases where we set a $key into the map - e.g. prov app / doc gen
+        if (!env) {
+            env = config.branchToEnvironmentMapping.get("${config.gitBranch}")
+        }
         if (env) {
             config.environment = env
             config.cloneSourceEnv = environmentExists(env)
                 ? false
                 : config.autoCloneEnvironmentsFromSourceMapping[env]
+            logger.debug("Target env: ${env}, clone src: ${cloneSourceEnv}")
             return
         }
 


### PR DESCRIPTION
In case a $variable is the key for the branch2env mapping  table - the lookup logic does not work,... :(
This combo is used e.g. in https://github.com/opendevstack/ods-document-generation-svc/blob/master/Jenkinsfile#L14-L17

The pr fixes this.