### PR TITLE
Allow general fork

### DIFF
--- a/src/org/ods/quickstarter/PushToRemoteStage.groovy
+++ b/src/org/ods/quickstarter/PushToRemoteStage.groovy
@@ -8,9 +8,6 @@ class PushToRemoteStage extends Stage {
 
     PushToRemoteStage(def script, IContext context, Map config = [:]) {
         super(script, context, config)
-        if (!config.branch) {
-            config.branch = 'master'
-        }
     }
 
     def run() {
@@ -59,9 +56,7 @@ class PushToRemoteStage extends Stage {
             }
             script.echo("Pushing quickstarter git repo to ${context.gitUrlHttp}")
             script.sh(
-                script: """
-                  git push -u origin ${config.branch}
-                  """,
+                script: 'git push -u origin $(git rev-parse --abbrev-ref HEAD)',
                 label: 'Push to remote'
             )
         }


### PR DESCRIPTION
* Makes testing a little easier as one can point the quickstarter to a repository on the Bitbucket instance
* Pushes the branch that exists locally, instead of the one given as a param. The stage to push to the remote is not exposed, so users can't set the branch anyway ... better to just take the branch that has been created.