### PR TITLE
Fix for #429

### DIFF
--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -126,22 +126,24 @@ class FinalizeStage extends Stage {
 
     private void pushRepos(IPipelineSteps steps, GitService git) {
         def flattenedRepos = repos.flatten()
-        def repoPushTasks = flattenedRepos.collectEntries { repo ->
-            [
-                (repo.id): {
-                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
-                        if (project.isWorkInProgress) {
-                            git.pushRef(repo.branch)
-                        } else if (project.isAssembleMode) {
-                            git.createTag(project.targetTag)
-                            git.pushBranchWithTags(project.gitReleaseBranch)
-                        } else {
-                            git.createTag(project.targetTag)
-                            git.pushRef(project.targetTag)
+        def repoPushTasks = flattenedRepos
+            .findAll { it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST }
+            .collectEntries { repo ->
+                [
+                    (repo.id): {
+                        steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                            if (project.isWorkInProgress) {
+                                git.pushRef(repo.branch)
+                            } else if (project.isAssembleMode) {
+                                git.createTag(project.targetTag)
+                                git.pushBranchWithTags(project.gitReleaseBranch)
+                            } else {
+                                git.createTag(project.targetTag)
+                                git.pushRef(project.targetTag)
+                            }
                         }
                     }
-                }
-            ]
+                ]
         }
         repoPushTasks.failFast = true
         script.parallel(repoPushTasks)
@@ -164,23 +166,25 @@ class FinalizeStage extends Stage {
 
     private void integrateIntoMainBranch(IPipelineSteps steps, GitService git) {
         def flattenedRepos = repos.flatten()
-        def repoIntegrateTasks = flattenedRepos.collectEntries { repo ->
-            [
-                (repo.id): {
-                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
-                        def filesToCheckout = []
-                        if (steps.fileExists('openshift')) {
-                            filesToCheckout = ['openshift/ods-deployments.json']
-                        } else {
-                            filesToCheckout = [
-                                'openshift-exported/ods-deployments.json',
-                                'openshift-exported/template.yml'
-                            ]
+        def repoIntegrateTasks = flattenedRepos
+            .findAll { it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST }
+            .collectEntries { repo ->
+                [
+                    (repo.id): {
+                        steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                            def filesToCheckout = []
+                            if (steps.fileExists('openshift')) {
+                                filesToCheckout = ['openshift/ods-deployments.json']
+                            } else {
+                                filesToCheckout = [
+                                    'openshift-exported/ods-deployments.json',
+                                    'openshift-exported/template.yml'
+                                ]
+                            }
+                            git.mergeIntoMainBranch(project.gitReleaseBranch, repo.branch, filesToCheckout)
                         }
-                        git.mergeIntoMainBranch(project.gitReleaseBranch, repo.branch, filesToCheckout)
                     }
-                }
-            ]
+                ]
         }
         repoIntegrateTasks.failFast = true
         script.parallel(repoIntegrateTasks)


### PR DESCRIPTION
Solution found: Filtering-off the `ods-test` repos from the `pushRepos` and `integrateIntoMainBranch` closures. 

Please @michaelsauter check this out and see if it makes sense.  I've tested the official release to D and the promotion to Q and it seems to work well. Even for the git tags (where there was another bug when tried to add the same tag twice in ods-test type)

Output of release to dev
![fix-bug-rm-merge-back-test-component-1](https://user-images.githubusercontent.com/6894585/88954836-45246b80-d29b-11ea-9f74-f6cbe6ec2861.PNG)

Release manager component
![fix-bug-rm-merge-back-test-component-label-release-manager](https://user-images.githubusercontent.com/6894585/88954853-4bb2e300-d29b-11ea-8e01-436d1216a9b6.PNG)

Code component
![fix-bug-rm-merge-back-test-component-label-ods-code](https://user-images.githubusercontent.com/6894585/88954860-4eadd380-d29b-11ea-83ed-0e5c747d8b4a.PNG)

Test component
![fix-bug-rm-merge-back-test-component-label-ods-test](https://user-images.githubusercontent.com/6894585/88954865-51102d80-d29b-11ea-8b59-55af3bc03739.PNG)

Fixes #429

