### PR TITLE
Remove special tagging logic for ods-test type

### DIFF
--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -126,22 +126,24 @@ class FinalizeStage extends Stage {
 
     private void pushRepos(IPipelineSteps steps, GitService git) {
         def flattenedRepos = repos.flatten()
-        def repoPushTasks = flattenedRepos.collectEntries { repo ->
-            [
-                (repo.id): {
-                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
-                        if (project.isWorkInProgress) {
-                            git.pushRef(repo.branch)
-                        } else if (project.isAssembleMode) {
-                            git.createTag(project.targetTag)
-                            git.pushBranchWithTags(project.gitReleaseBranch)
-                        } else {
-                            git.createTag(project.targetTag)
-                            git.pushRef(project.targetTag)
+        def repoPushTasks = flattenedRepos
+            .findAll { it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST }
+            .collectEntries { repo ->
+                [
+                    (repo.id): {
+                        steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                            if (project.isWorkInProgress) {
+                                git.pushRef(repo.branch)
+                            } else if (project.isAssembleMode) {
+                                git.createTag(project.targetTag)
+                                git.pushBranchWithTags(project.gitReleaseBranch)
+                            } else {
+                                git.createTag(project.targetTag)
+                                git.pushRef(project.targetTag)
+                            }
                         }
                     }
-                }
-            ]
+                ]
         }
         repoPushTasks.failFast = true
         script.parallel(repoPushTasks)
@@ -164,23 +166,25 @@ class FinalizeStage extends Stage {
 
     private void integrateIntoMainBranch(IPipelineSteps steps, GitService git) {
         def flattenedRepos = repos.flatten()
-        def repoIntegrateTasks = flattenedRepos.collectEntries { repo ->
-            [
-                (repo.id): {
-                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
-                        def filesToCheckout = []
-                        if (steps.fileExists('openshift')) {
-                            filesToCheckout = ['openshift/ods-deployments.json']
-                        } else {
-                            filesToCheckout = [
-                                'openshift-exported/ods-deployments.json',
-                                'openshift-exported/template.yml'
-                            ]
+        def repoIntegrateTasks = flattenedRepos
+            .findAll { it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST }
+            .collectEntries { repo ->
+                [
+                    (repo.id): {
+                        steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                            def filesToCheckout = []
+                            if (steps.fileExists('openshift')) {
+                                filesToCheckout = ['openshift/ods-deployments.json']
+                            } else {
+                                filesToCheckout = [
+                                    'openshift-exported/ods-deployments.json',
+                                    'openshift-exported/template.yml'
+                                ]
+                            }
+                            git.mergeIntoMainBranch(project.gitReleaseBranch, repo.branch, filesToCheckout)
                         }
-                        git.mergeIntoMainBranch(project.gitReleaseBranch, repo.branch, filesToCheckout)
                     }
-                }
-            ]
+                ]
         }
         repoIntegrateTasks.failFast = true
         script.parallel(repoIntegrateTasks)

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -126,24 +126,22 @@ class FinalizeStage extends Stage {
 
     private void pushRepos(IPipelineSteps steps, GitService git) {
         def flattenedRepos = repos.flatten()
-        def repoPushTasks = flattenedRepos
-            .findAll { it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST }
-            .collectEntries { repo ->
-                [
-                    (repo.id): {
-                        steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
-                            if (project.isWorkInProgress) {
-                                git.pushRef(repo.branch)
-                            } else if (project.isAssembleMode) {
-                                git.createTag(project.targetTag)
-                                git.pushBranchWithTags(project.gitReleaseBranch)
-                            } else {
-                                git.createTag(project.targetTag)
-                                git.pushRef(project.targetTag)
-                            }
+        def repoPushTasks = flattenedRepos.collectEntries { repo ->
+            [
+                (repo.id): {
+                    steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
+                        if (project.isWorkInProgress) {
+                            git.pushRef(repo.branch)
+                        } else if (project.isAssembleMode) {
+                            git.createTag(project.targetTag)
+                            git.pushBranchWithTags(project.gitReleaseBranch)
+                        } else {
+                            git.createTag(project.targetTag)
+                            git.pushRef(project.targetTag)
                         }
                     }
-                ]
+                }
+            ]
         }
         repoPushTasks.failFast = true
         script.parallel(repoPushTasks)

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -337,16 +337,6 @@ class MROPipelineUtil extends PipelineUtil {
                     } else if (repo.type?.toLowerCase() == PipelineConfig.REPO_TYPE_ODS_TEST) {
                         if (name == PipelinePhases.TEST) {
                             executeODSComponent(repo, baseDir)
-                        } else if (this.project.isPromotionMode && name == PipelinePhases.FINALIZE) {
-                            if (!this.project.buildParams.rePromote) {
-                                this.steps.dir(baseDir) {
-                                    git.tagAndPush(this.project.targetTag)
-                                }
-                            }
-                        } else if (this.project.isAssembleMode && !this.project.isWorkInProgress && name == PipelinePhases.FINALIZE) {
-                            this.steps.dir(baseDir) {
-                                git.tagAndPushBranch(this.project.gitReleaseBranch, this.project.targetTag)
-                            }
                         } else {
                             this.logger.debug("Repo '${repo.id}' is of type ODS Test Component. Nothing to do in phase '${name}' for target environment'${targetEnvToken}'.")
                         }

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -357,17 +357,7 @@ class MROPipelineUtil extends PipelineUtil {
                                 }
                             }
                         } else {
-                            // Ignore undefined phases
-                        }
-
-                        if (this.project.isPromotionMode && !this.project.buildParams.rePromote && name == PipelinePhases.FINALIZE) {
-                            this.steps.dir(baseDir) {
-                                git.tagAndPush(this.project.targetTag)
-                            }
-                        } else if (this.project.isAssembleMode && !this.project.isWorkInProgress && name == PipelinePhases.FINALIZE) {
-                            this.steps.dir(baseDir) {
-                                git.tagAndPushBranch(this.project.gitReleaseBranch, this.project.targetTag)
-                            }
+                            this.logger.debug("Repo '${repo.id}' is of type '${repo.type}'. Nothing to do in phase '${name}' for target environment'${targetEnvToken}'.")
                         }
                     }
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -338,7 +338,7 @@ class MROPipelineUtil extends PipelineUtil {
                         if (name == PipelinePhases.TEST) {
                             executeODSComponent(repo, baseDir)
                         } else {
-                            this.logger.debug("Repo '${repo.id}' is of type ODS Test Component. Nothing to do in phase '${name}' for target environment'${targetEnvToken}'.")
+                            this.logger.debug("Repo '${repo.id}' is of type ODS Test Component. Nothing to do in phase '${name}' for target environment '${targetEnvToken}'.")
                         }
                     } else {
                         def phaseConfig = repo.pipelineConfig.phases ? repo.pipelineConfig.phases[name] : null
@@ -357,7 +357,7 @@ class MROPipelineUtil extends PipelineUtil {
                                 }
                             }
                         } else {
-                            this.logger.debug("Repo '${repo.id}' is of type '${repo.type}'. Nothing to do in phase '${name}' for target environment'${targetEnvToken}'.")
+                            this.logger.debug("Repo '${repo.id}' is of type '${repo.type}'. Nothing to do in phase '${name}' for target environment '${targetEnvToken}'.")
                         }
                     }
 

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -174,24 +174,6 @@ class GitService {
         )
     }
 
-    def tagAndPush(String tag) {
-        if (remoteTagExists(tag)) {
-            logger.info("Skipping tag '${tag}' because it already exists.")
-        } else {
-            createTag(tag)
-            pushRef(tag)
-        }
-    }
-
-    def tagAndPushBranch(String branch, String tag) {
-        if (remoteTagExists(tag)) {
-            logger.info("Skipping tag '${tag}' because it already exists.")
-        } else {
-            createTag(tag)
-            pushBranchWithTags(branch)
-        }
-    }
-
     def checkout(
         String gitRef,
         def extensions,


### PR DESCRIPTION
Alternative to #430, which should achieve the same thing, with the following differences:

* It will fail if the tag exists already on the remote. This is the same behaviour as for `ods` components then. It should fail as the tag is unique per pipeline run so if it already exists, something is fishy.
* We apply the same fix for the make/shell type components
* Log if make/shell does nothing
* We end up with less code as we treat `ods-test` not as a special case, but the same as `ods` components, and can delete two methods from `GitService`