### PR TITLE
Do not fail when secret cannot be created

### DIFF
--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -296,10 +296,14 @@ class BitbucketService {
             file: BB_TOKEN_SECRET,
             text: secretYml
         )
-        script.sh """
-            oc -n ${openShiftCdProject} create -f ${BB_TOKEN_SECRET};
-            rm ${BB_TOKEN_SECRET}
+        try {
+            script.sh """
+                oc -n ${openShiftCdProject} create -f ${BB_TOKEN_SECRET};
+                rm ${BB_TOKEN_SECRET}
             """
+        } catch (Exception ex) {
+            logger.warn "Could not create secret ${tokenSecretName}. Error was: ${ex}"
+        }
     }
 
     private boolean basicAuthCredentialsIdExists(String credentialsId) {


### PR DESCRIPTION
We might not be able to create it because it has been created already by
another job at the same time. This is super unlikely to happen in real
life, but does happen during parallel tests.

Fixes #432.

The script errors later anyway if the Jenkins credential cannot be
found (see https://github.com/opendevstack/ods-jenkins-shared-library/blob/e63d0976d42aad08fddfebfbd8fbdbad34effbf0/src/org/ods/services/BitbucketService.groovy#L240-L248).