### PR TITLE
Fix branch prefix matching for Snyk and Sonar Stage classes

### DIFF
--- a/src/org/ods/component/Stage.groovy
+++ b/src/org/ods/component/Stage.groovy
@@ -36,10 +36,12 @@ abstract class Stage {
             return true
         }
         // Check if prefix (e.g. "release/") is allowed
-        eligibleBranches.each { eligibleBranch ->
+        if (eligibleBranches.any { eligibleBranch ->
             if (eligibleBranch.endsWith('/') && branch.startsWith(eligibleBranch)) {
                 return true
             }
+        }) {
+            return true
         }
         // Check if specific branch is allowed
         return eligibleBranches.contains(branch)

--- a/src/org/ods/component/Stage.groovy
+++ b/src/org/ods/component/Stage.groovy
@@ -36,11 +36,7 @@ abstract class Stage {
             return true
         }
         // Check if prefix (e.g. "release/") is allowed
-        if (eligibleBranches.any { eligibleBranch ->
-            if (eligibleBranch.endsWith('/') && branch.startsWith(eligibleBranch)) {
-                return true
-            }
-        }) {
+        if (eligibleBranches.any { it.endsWith('/') && branch.startsWith(it) }) {
             return true
         }
         // Check if specific branch is allowed

--- a/test/groovy/vars/OdsComponentStageScanWithSnykSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSnykSpec.groovy
@@ -1,109 +1,149 @@
 package vars
 
- import org.ods.component.Context
- import org.ods.component.IContext
- import org.ods.services.SnykService
+import org.ods.component.Context
+import org.ods.component.IContext
+import org.ods.services.SnykService
 import org.ods.util.Logger
 import org.ods.services.ServiceRegistry
- import vars.test_helper.PipelineSpockTestBase
- import spock.lang.*
+import vars.test_helper.PipelineSpockTestBase
+import spock.lang.*
 
- class OdsComponentStageScanWithSnykSpec extends PipelineSpockTestBase {
+import static org.assertj.core.api.Assertions.assertThat
 
-   private Logger logger = Mock(Logger)
+class OdsComponentStageScanWithSnykSpec extends PipelineSpockTestBase {
 
-   @Shared
-   def config = [
-       projectId: 'foo',
-       componentId: 'bar',
-       nexusUrl: 'https://nexus.example.com',
-       nexusUsername: 'developer',
-       nexusPassword: 's3cr3t',
-       buildNumber: '42'
-   ]
+    private Logger logger = Mock(Logger)
 
-   def "run successfully"() {
-     given:
-     IContext context = new Context(null, config, logger)
-     SnykService snykService = Stub(SnykService.class)
-     snykService.version() >> true
-     snykService.auth(*_) >> true
-     snykService.monitor(*_) >> true
-     snykService.test(*_) >> true
-     ServiceRegistry.instance.add(SnykService, snykService)
+    @Shared
+    def config = [
+        projectId    : 'foo',
+        componentId  : 'bar',
+        nexusUrl     : 'https://nexus.example.com',
+        nexusUsername: 'developer',
+        nexusPassword: 's3cr3t',
+        buildNumber  : '42'
+    ]
 
-     when:
-     def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
-     helper.registerAllowedMethod('withEnv', [ List, Closure ]) { List args, Closure block -> block() }
-     helper.registerAllowedMethod('archiveArtifacts', [ Map ]) { Map args -> }
-     helper.registerAllowedMethod('stash', [ Map ]) { Map args -> }
-     script.call(context, [
-       failOnVulnerabilities: true,
-       snykAuthenticationCode: 's3cr3t'
-      ])
+    def "run successfully"() {
+        given:
+        IContext context = new Context(null, config, logger)
+        SnykService snykService = snykService()
+        ServiceRegistry.instance.add(SnykService, snykService)
 
-     then:
-     printCallStack()
-     assertJobStatusSuccess()
-   }
+        when:
+        def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
+        helper.registerAllowedMethod('withEnv', [List, Closure]) { List args, Closure block -> block() }
+        helper.registerAllowedMethod('archiveArtifacts', [Map]) { Map args -> }
+        helper.registerAllowedMethod('stash', [Map]) { Map args -> }
+        script.call(context, [
+            failOnVulnerabilities : true,
+            snykAuthenticationCode: 's3cr3t'
+        ])
 
-   @Unroll
-   def "may fail"() {
-     given:
-     IContext context = new Context(null, config, logger)
-     SnykService snykService = Stub(SnykService.class)
-     snykService.version() >> versionOk
-     snykService.auth(*_) >> authOk
-     snykService.monitor(*_) >> monitorOk
-     snykService.test(*_) >> testOk
-     ServiceRegistry.instance.add(SnykService, snykService)
+        then:
+        printCallStack()
+        assertThat(callStackDump()).doesNotContain("Skipping as branch")
+        assertJobStatusSuccess()
+    }
 
-     when:
-     def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
-     helper.registerAllowedMethod('withEnv', [ List, Closure ]) { List args, Closure block -> block() }
-     helper.registerAllowedMethod('archiveArtifacts', [ Map ]) { Map args -> }
-     helper.registerAllowedMethod('stash', [ Map ]) { Map args -> }
-     script.call(context, [
-       failOnVulnerabilities: failOnVulnerabilities,
-       snykAuthenticationCode: 's3cr3t',
-       branch: '*'
-      ])
+    def "run successfully when a branch prefix is matched"() {
+        given:
+        def config = [
+            projectId    : 'foo',
+            componentId  : 'bar',
+            nexusUrl     : 'https://nexus.example.com',
+            nexusUsername: 'developer',
+            nexusPassword: 's3cr3t',
+            buildNumber  : '42',
+            gitBranch : 'feature/foo'
+        ]
+        IContext context = new Context(null, config, logger)
+        SnykService snykService = snykService()
+        ServiceRegistry.instance.add(SnykService, snykService)
 
-     then:
-     printCallStack()
-     assertCallStackContains(message)
-     if (expectedToFail) {
-       assertJobStatusFailure()
-     } else {
-       assertJobStatusSuccess()
-     }
+        when:
+        def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
+        helper.registerAllowedMethod('withEnv', [List, Closure]) { List args, Closure block -> block() }
+        helper.registerAllowedMethod('archiveArtifacts', [Map]) { Map args -> }
+        helper.registerAllowedMethod('stash', [Map]) { Map args -> }
+        script.call(context, [
+            failOnVulnerabilities : true,
+            snykAuthenticationCode: 's3cr3t',
+            branch: 'feature/'
+        ])
 
-     where:
-     versionOk | authOk | monitorOk | testOk | failOnVulnerabilities || expectedToFail | message
-     false     | true   | true      | true   | true                  || true           | 'Snyk binary is not in $PATH'
-     true      | false  | true      | true   | true                  || true           | 'Snyk auth failed'
-     true      | true   | false     | true   | true                  || true           | 'Snyk monitor failed'
-     true      | true   | true      | true   | true                  || false          | 'No vulnerabilities detected'
-     true      | true   | true      | false  | false                 || false          | 'Snyk test detected vulnerabilities'
-     true      | true   | true      | false  | true                  || true           | 'Snyk scan stage failed'
-   }
+        then:
+        printCallStack()
+        assertThat(callStackDump()).doesNotContain("Skipping as branch 'feature/foo' is not covered by the 'branch' option.")
+        assertJobStatusSuccess()
+    }
 
-   def "skip branch should not be scanned"() {
-     given:
-     def config = [
-         branchToEnvironmentMapping: ['master': 'dev', 'release/': 'test'],
-         gitBranch: 'feature/foo'
-     ]
-     def context = new Context(null, config, logger)
+    private SnykService snykService() {
+        SnykService snykService = Stub(SnykService.class)
+        snykService.version() >> true
+        snykService.auth(*_) >> true
+        snykService.monitor(*_) >> true
+        snykService.test(*_) >> true
+        snykService
+    }
 
-     when:
-     def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
-     script.call(context, ['branch': 'master'])
+    @Unroll
+    def "may fail"() {
+        given:
+        IContext context = new Context(null, config, logger)
+        SnykService snykService = Stub(SnykService.class)
+        snykService.version() >> versionOk
+        snykService.auth(*_) >> authOk
+        snykService.monitor(*_) >> monitorOk
+        snykService.test(*_) >> testOk
+        ServiceRegistry.instance.add(SnykService, snykService)
 
-     then:
-     printCallStack()
-     assertCallStackContains("Skipping as branch 'feature/foo' is not covered by the 'branch' option.")
-     assertJobStatusSuccess()
-   }
+        when:
+        def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
+        helper.registerAllowedMethod('withEnv', [List, Closure]) { List args, Closure block -> block() }
+        helper.registerAllowedMethod('archiveArtifacts', [Map]) { Map args -> }
+        helper.registerAllowedMethod('stash', [Map]) { Map args -> }
+        script.call(context, [
+            failOnVulnerabilities : failOnVulnerabilities,
+            snykAuthenticationCode: 's3cr3t',
+            branch                : '*'
+        ])
 
- }
+        then:
+        printCallStack()
+        assertCallStackContains(message)
+        if (expectedToFail) {
+            assertJobStatusFailure()
+        } else {
+            assertJobStatusSuccess()
+        }
+
+        where:
+        versionOk | authOk | monitorOk | testOk | failOnVulnerabilities || expectedToFail | message
+        false     | true   | true      | true   | true                  || true           | 'Snyk binary is not in $PATH'
+        true      | false  | true      | true   | true                  || true           | 'Snyk auth failed'
+        true      | true   | false     | true   | true                  || true           | 'Snyk monitor failed'
+        true      | true   | true      | true   | true                  || false          | 'No vulnerabilities detected'
+        true      | true   | true      | false  | false                 || false          | 'Snyk test detected vulnerabilities'
+        true      | true   | true      | false  | true                  || true           | 'Snyk scan stage failed'
+    }
+
+    def "skip branch should not be scanned"() {
+        given:
+        def config = [
+            branchToEnvironmentMapping: ['master': 'dev', 'release/': 'test'],
+            gitBranch                 : 'feature/foo'
+        ]
+        def context = new Context(null, config, logger)
+
+        when:
+        def script = loadScript('vars/odsComponentStageScanWithSnyk.groovy')
+        script.call(context, ['branch': 'master'])
+
+        then:
+        printCallStack()
+        assertCallStackContains("Skipping as branch 'feature/foo' is not covered by the 'branch' option.")
+        assertJobStatusSuccess()
+    }
+
+}


### PR DESCRIPTION
When calling:

`odsComponentStageScanWithSnyk(context, [snykAuthenticationCode: snykAuthenticationCode, failOnVulnerabilities: false, branch: 'develop, release/, master'])`

within a `release/foo` branch, the documentation suggests, that a scan should be done but it is not.