### PR TITLE
Extract issue ID also from commit message

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -166,7 +166,7 @@ The `context` object contains the following properties:
 | Git commit time in RFC 3399.
 
 | issueId
-| Jira issue ID if any present in the branch name (e.g. `123` from branch `feature/FOO-123-bar-baz`).
+| Jira issue ID if any present in either commit message or branch name (e.g. `123` from commit message `FOO-123: Bar` or branch `feature/FOO-123-bar`). If the issue ID is present in both, the branch name has precedence.
 
 | openshiftHost
 | OpenShift host - value taken from `OPENSHIFT_API_URL`.

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -397,7 +397,14 @@ class Context implements IContext {
     }
 
     String getIssueId() {
-        GitService.issueIdFromBranch(config.gitBranch, config.projectId)
+        if (!config.containsKey("issueId")) {
+            config.issueId = GitService.issueIdFromBranch(
+                config.gitBranch, config.projectId
+            ) ?: GitService.issueIdFromCommit(
+                config.gitCommitMessage, config.projectId
+            )
+        }
+        config.issueId
     }
 
     // This logic must be consistent with what is described in README.md.

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -16,6 +16,8 @@ class GitService {
         this.logger = logger
     }
 
+    // mergedIssueId gets the issue ID from the merged branch.
+    // This only works on merge commits.
     static String mergedIssueId(String project, String repository, String commitMessage) {
         def b = mergedBranch(project, repository, commitMessage)
         if (b) {
@@ -34,6 +36,19 @@ class GitService {
         ''
     }
 
+    // Looks for an issue ID of form "PROJ-123" in the commit message.
+    // If multiple such issue IDs are present, the first one is returned.
+    static String issueIdFromCommit(String commitMessage, String projectId) {
+        def uppercaseProject = projectId.toUpperCase()
+        def msgMatcher = commitMessage =~ /${uppercaseProject}-([0-9]+)/
+        if (msgMatcher) {
+            return msgMatcher[0][1]
+        }
+        return ''
+    }
+
+    // Looks for an issue ID of form "PROJ-123" in the branch name.
+    // If multiple such issue IDs are present, the first one is returned.
     static String issueIdFromBranch(String branchName, String projectId) {
         def tokens = extractBranchCode(branchName).split('-')
         def pId = tokens[0]

--- a/test/groovy/org/ods/component/ContextSpec.groovy
+++ b/test/groovy/org/ods/component/ContextSpec.groovy
@@ -13,6 +13,36 @@ class ContextSpec extends Specification {
     def noEnv = []
 
     @Unroll
+    def "IssueID: when branch is #branch and commit is #commit issueId should be #expectedIssueId"(branch, commit, expectedIssueId) {
+        given:
+        def config = [
+            projectId: 'foo',
+            gitBranch: branch,
+            gitCommitMessage: commit
+        ]
+
+        when:
+        def uut = new Context(script, config, logger)
+
+        then:
+        uut.getIssueId() == expectedIssueId
+
+        where:
+        branch                | commit                     || expectedIssueId
+        'develop'             | 'Some text'                || ''
+        'develop'             | 'FOO-123: Some text'       || '123'
+        'develop'             | 'FOO-123 Some text'        || '123'
+        'develop'             | 'Some text (FOO-123)'      || '123'
+        'develop'             | 'Some text (FOOBAR-123)'   || ''
+        'develop'             | 'FOO 123 bar'              || ''
+        'feature/foo-123-bar' | 'FOO-456: Todo'            || '123'
+        'develop'             | 'FOO-456 replaces FOO-123' || '456'
+        'feature/foo-123-bar' | 'Todo'                     || '123'
+        'feature/foo-123-bar' | 'Todo'                     || '123'
+        'release/1.0.0'       | 'Todo'                     || ''
+    }
+
+    @Unroll
     def "Gitflow: when branch is #branch and existingEnv is #existingEnv expectedEnv should be #expectedEnv"(branch, existingEnv, expectedEnv) {
         given:
         def config = [


### PR DESCRIPTION
The Jira issue ID can be given in either branch name or commit message.
Putting the ID into the commit message has the advantage that it is
still accessible when the commit is accessed from a different branch,
and that it is possible that every commit is connected to a Jira ticket.

~As the change made in this commit prefers the commit message over the
branch name, it is a breaking change in so far if users expect the
branch name to overrule any issue references in commit messages.~

*Update: reversed the order, which makes the change non-breaking.*

@gerardcl @henrjk @renedupont What are your thoughts regarding which piece of information should "win"? I've implemented my suggestion but happy to change if you think otherwise.