### PR TITLE
configurable emailext recipients and default to empty list

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -50,7 +50,10 @@ Available options are:
 | Serviceaccount to use when running the pod.
 
 | notifyNotGreen
-| Whether to send notifications if the build is not successful.
+| Whether to send notifications if the build is not successful. Enabled by default.
+
+| emailextRecipients
+| Notify to this list of emails when `notifyNotGreen` is enabled. It is empty by default.
 
 | branchToEnvironmentMapping
 | Define which branches are deployed to which environments, see <<_git_workflow_branch_to_environment_mapping,Git Workflow / Branch to Environment Mapping>>

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -113,6 +113,9 @@ class Context implements IContext {
         if (!config.containsKey('imagePromotionSequences')) {
             config.imagePromotionSequences = ['dev->test', 'test->prod']
         }
+        if (!config.containsKey('emailextRecipients')) {
+            config.emailextRecipients = null
+        }
         if (!config.groupId) {
             config.groupId = "org.opendevstack.${config.projectId}"
         }
@@ -158,6 +161,10 @@ class Context implements IContext {
 
     void setDebug(def debug) {
         config.debug = debug
+    }
+
+    List<String> getEmailextRecipients() {
+        config.emailextRecipients
     }
 
     String getJobName() {

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -8,6 +8,10 @@ interface IContext {
     // Get debug mode
     boolean getDebug()
 
+    // Jenkins email extension recipients list
+    // docs: https://www.jenkins.io/doc/pipeline/steps/email-ext/
+    List<String> getEmailextRecipients()
+
     // Get the location of the xmlunit results
     String getTestResults()
 

--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -171,7 +171,7 @@ class Pipeline implements Serializable {
                 updateBuildStatus('FAILURE')
                 setBitbucketBuildStatus('FAILED')
                 if (notifyNotGreen) {
-                    doNotifyNotGreen()
+                    doNotifyNotGreen(context.emailextRecipients)
                 }
                 throw err
             }
@@ -242,7 +242,7 @@ class Pipeline implements Serializable {
                             updateBuildStatus('FAILURE')
                             setBitbucketBuildStatus('FAILED')
                             if (notifyNotGreen) {
-                                doNotifyNotGreen()
+                                doNotifyNotGreen(context.emailextRecipients)
                             }
                             if (!!script.env.MULTI_REPO_BUILD) {
                                 context.addArtifactURI('failedStage', script.env.STAGE_NAME)
@@ -306,18 +306,15 @@ class Pipeline implements Serializable {
         bitbucketService.setBuildStatus(context.buildUrl, context.gitCommit, state, buildName)
     }
 
-    private void doNotifyNotGreen() {
+    private void doNotifyNotGreen(List<String> emailextRecipients) {
         String subject = "Build $context.componentId on project $context.projectId  failed!"
         String body = "<p>$subject</p> <p>URL : <a href=\"$context.buildUrl\">$context.buildUrl</a></p> "
+        String recipients = emailextRecipients ? emailextRecipients.join(", ") : ''
 
         script.emailext(
             body: body, mimeType: 'text/html',
             replyTo: '$script.DEFAULT_REPLYTO', subject: subject,
-            to: script.emailextrecipients([
-                [$class: 'CulpritsRecipientProvider'],
-                [$class: 'RequesterRecipientProvider'],
-                [$class: 'UpstreamComitterRecipientProvider']
-            ])
+            to: recipients
         )
     }
 


### PR DESCRIPTION
fixes #449 

The conclusion is that in order to ensure that there is never an email sent to unexpected recipients we need to default to an empty list of recipients. Moreover, if users are configuring Jenkins SMTP (which is required) they will also need to define in the `odsComponentPipeline` context the list of the emails such:
```groovy
...
odsComponentPipeline(
  imageStreamTag: 'ods/jenkins-agent-base:3.x',
  emailextRecipients: ['email1@foo.bar', 'email2@foo.bar'],
  branchToEnvironmentMapping: [
    'master': 'dev',
    // 'release/': 'test'
  ]
) { context ->
...
```

Documentation of `emailextRecipients`context parameter has been added, but will add better documentation within another PR for fixing issue 346