### PR TITLE
Set shared lib ref to value of ODS_IMAGE_TAG by default

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsQuickstarterPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsQuickstarterPipeline.adoc
@@ -100,10 +100,16 @@ The `context` object contains the following properties:
 | Central namespace where images are located, retrieved from `ODS_NAMESPACE` build parameter.
 
 | odsImageTag
-| Image tag used for the agent pod, retrieved from `ODS_IMAGE_TAG` build parameter.
+| ODS image tag. Retrieved from `ODS_IMAGE_TAG` build parameter. If not set, defaults to `latest`.
 
 | odsGitRef
-| Git ref, retrieved from `ODS_GIT_REF` build parameter.
+| ODS Git ref. Retrieved from `ODS_GIT_REF` build parameter. If not set, defaults to `master`.
+
+| agentImageTag
+| Image tag used for the agent pod, retrieved from `odsImageTag` unless the `AGENT_IMAGE_TAG` build parameter is set.
+
+| sharedLibraryRef
+| Git reference used for the Jenkins shared library, retrieved from `odsImageTag` unless the `SHARED_LIBRARY_REF` build parameter is set.
 
 | bitbucketUrl
 | Bitbucket URL - value taken from `BITBUCKET_URL`. If BITBUCKET_URL is not present, it will default to `https://<BITBUCKET_HOST>``. `bitbucketHost` is an alias for `bitbucketUrl`.

--- a/docs/modules/jenkins-shared-library/partials/odsQuickstarterStageRenderJenkinsfile.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsQuickstarterStageRenderJenkinsfile.adoc
@@ -8,6 +8,8 @@ The handled replacements are:
 - `@git_url_http@` => `context.gitUrlHttp`
 - `@ods_image_tag@` => `context.odsImageTag`
 - `@ods_git_ref@` => `context.odsGitRef`
+- `@agent_image_tag@` => `context.agentImageTag`
+- `@shared_library_ref@` => `context.sharedLibraryRef`
 
 Available options:
 

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -71,6 +71,16 @@ class Context implements IContext {
     }
 
     @NonCPS
+    String getAgentImageTag() {
+        config.agentImageTag
+    }
+
+    @NonCPS
+    String getSharedLibraryRef() {
+        config.sharedLibraryRef
+    }
+
+    @NonCPS
     String getTargetDir() {
         config.targetDir
     }

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -34,6 +34,10 @@ interface IContext {
 
     String getOdsGitRef()
 
+    String getAgentImageTag()
+
+    String getSharedLibraryRef()
+
     String getTargetDir()
 
     String getPackageName()

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -25,6 +25,8 @@ class Pipeline implements Serializable {
         config.odsNamespace = script.env.ODS_NAMESPACE ?: 'ods'
         config.odsImageTag = script.env.ODS_IMAGE_TAG ?: 'latest'
         config.odsGitRef = script.env.ODS_GIT_REF ?: 'master'
+        config.agentImageTag = script.env.AGENT_IMAGE_TAG ?: config.odsImageTag
+        config.sharedLibraryRef = script.env.SHARED_LIBRARY_REF ?: config.odsImageTag
         config.projectId = script.env.PROJECT_ID.toLowerCase()
         config.componentId = script.env.COMPONENT_ID.toLowerCase()
         config.gitUrlHttp = script.env.GIT_URL_HTTP

--- a/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
+++ b/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
@@ -20,7 +20,7 @@ class RenderJenkinsfileStage extends Stage {
         def target = "${context.targetDir}/${config.target}"
         script.sh(
             script: """
-            sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.sourceDir}|g; s|@git_url_http@|${context.gitUrlHttp}|g; s|@ods_namespace@|${context.odsNamespace}|g; s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g' ${source} > ${target}
+            sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.sourceDir}|g; s|@git_url_http@|${context.gitUrlHttp}|g; s|@ods_namespace@|${context.odsNamespace}|g; s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g s|@agent_image_tag@|${context.agentImageTag}|g; s|@shared_library_ref@|${context.sharedLibraryRef}|g' ${source} > ${target}
             """,
             label: "Render '${config.source}' to '${config.target}'"
         )


### PR DESCRIPTION
Addresses https://github.com/opendevstack/ods-core/issues/773.

It tries to be as non-invasive as possible. Going forward, quickstarters
should use `@agent_image_tag@` and `@shared_library_ref@` in their
`Jenkinsfile.template` files. Those values are filled with the value of
`ODS_IMAGE_TAG` by default, which represents the new "ODS version as
consumed by customers".

Follow-up from https://github.com/opendevstack/ods-core/pull/831.