### PR TITLE
add relogin to current cluster during tailor export operations - master

### DIFF
--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -602,6 +602,25 @@ class OpenShiftService {
         true
     }
 
+    void reloginToCurrentClusterIfNeeded () {
+        def kubeUrl = steps.env.KUBERNETES_MASTER ?: 'https://kubernetes.default:443'
+        def logDetails = logger.debugMode ? '' : 'set +x'
+        def success = steps.sh(
+            script: """
+                ${logDetails}
+                oc login ${kubeUrl} --insecure-skip-tls-verify=true \
+                --token=\$(cat /run/secrets/kubernetes.io/serviceaccount/token) &> /dev/null
+            """,
+            returnStatus: true,
+            label: 'Check if OCP session exists'
+        ) == 0
+        if (!success) {
+            throw new RuntimeException(
+                'Could not (re)login to cluster, this is a systemic failure'
+            )
+        }
+    }
+
     private void importImageFromProject(String sourceProject, String sourceImageRef, String targetImageRef) {
         steps.sh(
             script: """oc -n ${project} tag ${sourceProject}/${sourceImageRef} ${targetImageRef}""",
@@ -659,6 +678,7 @@ class OpenShiftService {
     }
 
     private void doTailorApply(String tailorParams) {
+        reloginToCurrentClusterIfNeeded()
         steps.sh(
             script: """tailor \
               ${tailorVerboseFlag()} \
@@ -675,6 +695,7 @@ class OpenShiftService {
         Map<String,
         String> envParams,
         String targetFile) {
+        reloginToCurrentClusterIfNeeded()
         // Export
         steps.sh(
             script: "tailor ${tailorVerboseFlag()} -n ${exportProject} export ${tailorParams} > ${targetFile}",

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -678,7 +678,6 @@ class OpenShiftService {
     }
 
     private void doTailorApply(String tailorParams) {
-        reloginToCurrentClusterIfNeeded()
         steps.sh(
             script: """tailor \
               ${tailorVerboseFlag()} \


### PR DESCRIPTION
closes #460 
@michaelsauter  - this was the simplest way to do it - maybe you have a testcase to try it quickly at BI X - I am wondering if that works with the `apply to another cluster` usecase ... here I need your help