### PR TITLE
add noncps to fix exception in context - master

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -547,6 +547,7 @@ class Context implements IContext {
     }
 
     // get the rollout retry
+    @NonCPS
     int getOpenshiftRolloutTimeoutRetries () {
         config.openshiftRolloutTimeoutRetries
     }


### PR DESCRIPTION
hudson.remoting.ProxyException: CpsCallableInvocation{methodName=getOpenshiftRolloutTimeoutRetries, call=com.cloudbees.groovy.cps.impl.CpsFunction@6e853666, receiver=org.ods.component.Context@5c7ab96d, arguments=[]}

