### PR TITLE
Pass project to every method of OpenShiftService

### DIFF
--- a/src/org/ods/component/BuildOpenShiftImageStage.groovy
+++ b/src/org/ods/component/BuildOpenShiftImageStage.groovy
@@ -80,6 +80,7 @@ class BuildOpenShiftImageStage extends Stage {
             script.dir(config.openshiftDir) {
                 jenkins.maybeWithPrivateKeyCredentials(config.tailorPrivateKeyCredentialsId) { pkeyFile ->
                     openShift.tailorApply(
+                        context.targetProject,
                         [selector: config.tailorSelector, include: config.tailorInclude],
                         config.tailorParamFile,
                         config.tailorParams,
@@ -141,27 +142,28 @@ class BuildOpenShiftImageStage extends Stage {
     }
 
     private boolean buildConfigExists() {
-        openShift.resourceExists('BuildConfig', config.resourceName)
+        openShift.resourceExists(context.targetProject, 'BuildConfig', config.resourceName)
     }
 
     private String getImageReference() {
-        openShift.getImageReference(config.resourceName, config.imageTag)
+        openShift.getImageReference(context.targetProject, config.resourceName, config.imageTag)
     }
 
     private int startBuild() {
-        openShift.startBuild(config.resourceName, config.dockerDir)
+        openShift.startBuild(context.targetProject, config.resourceName, config.dockerDir)
     }
 
     private String followBuild(int version) {
-        openShift.followBuild(config.resourceName, version)
+        openShift.followBuild(context.targetProject, config.resourceName, version)
     }
 
     private String getBuildStatus(String build) {
-        openShift.getBuildStatus(build)
+        openShift.getBuildStatus(context.targetProject, build)
     }
 
     private String patchBuildConfig(Map imageLabels) {
         openShift.patchBuildConfig(
+            context.targetProject,
             config.resourceName,
             config.imageTag,
             config.buildArgs,

--- a/src/org/ods/component/ImportOpenShiftImageStage.groovy
+++ b/src/org/ods/component/ImportOpenShiftImageStage.groovy
@@ -40,6 +40,7 @@ class ImportOpenShiftImageStage extends Stage {
 
         if (config.imagePullerSecret) {
             openShift.importImageTagFromSourceRegistry(
+                context.targetProject,
                 config.resourceName,
                 config.imagePullerSecret,
                 config.sourceProject,
@@ -48,6 +49,7 @@ class ImportOpenShiftImageStage extends Stage {
             )
         } else {
             openShift.importImageTagFromProject(
+                context.targetProject,
                 config.resourceName,
                 config.sourceProject,
                 config.sourceTag,

--- a/src/org/ods/component/Pipeline.groovy
+++ b/src/org/ods/component/Pipeline.groovy
@@ -131,9 +131,7 @@ class Pipeline implements Serializable {
                         if (!registry.get(OpenShiftService)) {
                             logger.debug 'Registering OpenShiftService'
                             registry.add(OpenShiftService, new OpenShiftService(
-                                steps,
-                                logger,
-                                context.targetProject
+                                steps, logger
                             ))
                         }
                         this.openShiftService = registry.get(OpenShiftService)
@@ -474,8 +472,8 @@ class Pipeline implements Serializable {
                 def jobSplitList = script.env.JOB_NAME.split('/')
                 def projectName = jobSplitList[0]
                 def bcName = jobSplitList[1].replace("${projectName}-", '')
-                origin = (new OpenShiftService(steps, logger, projectName))
-                    .getOriginUrlFromBuildConfig(bcName)
+                origin = (new OpenShiftService(steps, logger))
+                    .getOriginUrlFromBuildConfig(projectName, bcName)
                 logger.debug("Retrieved Git origin URL from build config: ${origin}")
             }
 

--- a/src/org/ods/orchestration/DeployStage.groovy
+++ b/src/org/ods/orchestration/DeployStage.groovy
@@ -92,7 +92,7 @@ class DeployStage extends Stage {
                 }
 
                 // Check if the target environment exists in OpenShift
-                if (!os.envExists()) {
+                if (!os.envExists(targetProject)) {
                     throw new RuntimeException(
                         "Error: target environment '${targetProject}' does not exist " +
                         "in ${project.openShiftTargetApiUrl}."

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -45,7 +45,7 @@ class FinalizeStage extends Stage {
         if (project.isAssembleMode) {
             // Check if the target environment exists in OpenShift
             def targetProject = project.targetProject
-            if (!os.envExists()) {
+            if (!os.envExists(targetProject)) {
                 throw new RuntimeException(
                     "Error: target environment '${targetProject}' does not exist in OpenShift."
                 )

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -483,7 +483,7 @@ class MROPipelineUtil extends PipelineUtil {
         )
         Map deployments
         try {
-            deployments = os.getPodDataForDeployments(deploymentDescriptor.deploymentNames)
+            deployments = os.getPodDataForDeployments(project.targetProject, deploymentDescriptor.deploymentNames)
         } catch(ex) {
             logger.info(
                 "Resurrection of previous build for '${repo.id}' not possible as " +

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -514,7 +514,7 @@ class Project {
         this.data.git.baseTag
     }
 
-    def getTargetTag() {
+    String getTargetTag() {
         this.data.git.targetTag
     }
 

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -12,7 +12,7 @@ class OpenShiftServiceSpec extends SpecHelper {
     def "image info for image URL"() {
         given:
         def steps = Spy(util.PipelineSteps)
-        def service = new OpenShiftService(steps, new Logger(steps, false), 'foo')
+        def service = new OpenShiftService(steps, new Logger(steps, false))
 
         when:
         def result = service.imageInfoForImageUrl(imageUrl)
@@ -33,7 +33,7 @@ class OpenShiftServiceSpec extends SpecHelper {
     def "image info with SHA for image stream URL"() {
         given:
         def steps = Spy(util.PipelineSteps)
-        def service = GroovySpy(OpenShiftService, constructorArgs: [steps, new Logger(steps, false), 'foo'], global: true)
+        def service = GroovySpy(OpenShiftService, constructorArgs: [steps, new Logger(steps, false)], global: true)
         OpenShiftService.getImageReference(*_) >> imageReference
 
         when:
@@ -59,7 +59,7 @@ class OpenShiftServiceSpec extends SpecHelper {
     def "pod data extraction"() {
         given:
         def steps = Spy(util.PipelineSteps)
-        def service = new OpenShiftService(steps, new Logger(steps, false), 'foo')
+        def service = new OpenShiftService(steps, new Logger(steps, false))
         def file = new FixtureHelper().getResource("pod.json")
 
         when:

--- a/test/groovy/vars/OdsComponentStageBuildOpenShiftImageSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageBuildOpenShiftImageSpec.groovy
@@ -31,15 +31,14 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
 
   def "run successfully without Tailor"() {
     given:
-    def c = config + [environment: 'dev']
+    def c = config + [environment: 'dev', targetProject: 'foo-dev']
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Mock(OpenShiftService.class)
     openShiftService.resourceExists(*_) >> true
-    openShiftService.startAndFollowBuild(_, _) >> 'bar-123'
-    openShiftService.startBuild(_,_) >> 123
-    openShiftService.getLastBuildVersion(_) >> 123
-    openShiftService.getBuildStatus(_) >> 'complete'
-    openShiftService.getImageReference(_, _) >> '0daecc05'
+    openShiftService.startBuild(*_) >> 123
+    openShiftService.getLastBuildVersion(*_) >> 123
+    openShiftService.getBuildStatus(*_) >> 'complete'
+    openShiftService.getImageReference(*_) >> '0daecc05'
     
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
@@ -86,13 +85,12 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
 
   def "run successfully with Tailor"() {
     given:
-    def c = config + [environment: 'dev', projectId: 'foo']
+    def c = config + [environment: 'dev', projectId: 'foo', targetProject: 'foo-dev']
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Mock(OpenShiftService.class)
     openShiftService.resourceExists(*_) >> true
-    openShiftService.startAndFollowBuild(*_) >> 'bar-123'
     openShiftService.getLastBuildVersion(*_) >> 123
-    openShiftService.startBuild(_,_) >> 123
+    openShiftService.startBuild(*_) >> 123
     openShiftService.getBuildStatus(*_) >> 'complete'
     openShiftService.getImageReference(*_) >> '0daecc05'
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
@@ -118,6 +116,7 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
     buildInfo.image == "0daecc05"
 
     1 * openShiftService.tailorApply(
+      'foo-dev',
       [selector: 'app=foo-bar', include: 'bc,is'],
       '',
       [],
@@ -129,12 +128,15 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
 
   def "run successfully with overwrite component and image labels"() {
     given:
-    def c = config + [environment: 'dev', "globalExtensionImageLabels" : [ "globalext": "extG" ]]
+    def c = config + [
+      environment: 'dev',
+      targetProject: 'foo-dev',
+      globalExtensionImageLabels: [ "globalext": "extG" ]
+    ]
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Stub(OpenShiftService.class)
     openShiftService.resourceExists(*_) >> true
-    openShiftService.startAndFollowBuild(*_) >> 'overwrite-123'
-    openShiftService.startBuild(_,_) >> 123
+    openShiftService.startBuild(*_) >> 123
     openShiftService.getLastBuildVersion(*_) >> 123
     openShiftService.getBuildStatus(*_) >> 'complete'
     openShiftService.getImageReference(*_) >> '0daecc05'
@@ -190,11 +192,10 @@ class OdsComponentStageBuildOpenShiftImageSpec extends PipelineSpockTestBase {
     def c = config + [environment: 'dev']
     IContext context = new Context(null, c, logger)
     OpenShiftService openShiftService = Stub(OpenShiftService.class)
-    openShiftService.startAndFollowBuild(*_) >> startBuildOutput
     openShiftService.getLastBuildVersion(*_) >> lastBuildVersion
-    openShiftService.startBuild(_,_) >> lastBuildVersion
+    openShiftService.startBuild(*_) >> lastBuildVersion
     openShiftService.getBuildStatus(*_) >> buildStatus
-    openShiftService.getImageReference() >> imageReference
+    openShiftService.getImageReference(*_) >> imageReference
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
     when:

--- a/test/groovy/vars/OdsComponentStageImportOpenShiftImageSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageImportOpenShiftImageSpec.groovy
@@ -46,7 +46,6 @@ class OdsComponentStageImportOpenShiftImageSpec extends PipelineSpockTestBase {
     printCallStack()
     assertCallStackContains('''Imported image 'foo-dev/bar:cd3e9082' into 'foo-test/bar:cd3e9082'.''')
     assertJobStatusSuccess()
-    //1 * openShiftService.importImageTagFromProject(*_)
   }
 
   def "skip when no environment given"() {

--- a/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
@@ -37,7 +37,7 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     openShiftService.getLatestVersion(*_) >> 123
     openShiftService.rollout(*_) >> "${config.componentId}-124"
     // test the handover of the poddata retries
-    openShiftService.getPodDataForDeployment(_,6) >> [ deploymentId: "${config.componentId}-124" ]
+    openShiftService.getPodDataForDeployment(_, _, 6) >> [ deploymentId: "${config.componentId}-124" ]
     openShiftService.getImagesOfDeploymentConfig (*_) >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
@@ -94,6 +94,7 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo.deploymentId
 
     1 * openShiftService.tailorApply(
+      'foo-dev',
       [selector: 'app=foo-bar', exclude: 'bc,is'],
       '',
       [],
@@ -106,14 +107,14 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
   @Unroll
   def "fails when rollout info cannot be retrieved"() {
     given:
-    def c = config + [environment: 'dev', targetProject: 'foo-dev', openshiftRolloutTimeoutRetries: 5]
-    IContext context = new Context(null, c, logger)
+    def cfg = config + [environment: 'dev', targetProject: 'foo-dev', openshiftRolloutTimeoutRetries: 5]
+    IContext context = new Context(null, cfg, logger)
     OpenShiftService openShiftService = Stub(OpenShiftService.class)
-    openShiftService.resourceExists({ it == 'DeploymentConfig' }, _) >> dcExists
-    openShiftService.resourceExists({ it == 'ImageStream' }, _) >> isExists
+    openShiftService.resourceExists(_, { it == 'DeploymentConfig' }, _) >> dcExists
+    openShiftService.resourceExists(_, { it == 'ImageStream' }, _) >> isExists
     openShiftService.getImagesOfDeploymentConfig (*_) >> images
     openShiftService.getLatestVersion(*_) >> latestVersion
-    openShiftService.rollout(*_) >> { x, y, z ->
+    openShiftService.rollout(*_) >> { a, b, c, d ->
             throw new RuntimeException('Boom!')
         }
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)


### PR DESCRIPTION
* Experience shows that we do interact with more than one project
* Allows to separate build environment and deploy environment
* Paves the way to deploy to multiple projects in the same pipeline

To verify I added `@TypeChecked` annotations, ran unit tests and a quickstarter test. Anything else I should test? I'm going to cover more areas with tests when I change functionality, so if I overlooked something then it'll show up there as well.

@clemensutschig As you had it originally :) I wanted to have `project` as an instance variable so that it easy to use, but for where we're going, we need greater flexibility. So now `project` needs to passed to pretty much every method ...

FYI @fkressmann That will make your use case even easier ... and there is more to come in that area ... I'll ping you with more details.