### PR TITLE
Support Deployment resources in component pipeline

### DIFF
--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -53,6 +53,7 @@ class Context implements IContext {
         config.openshiftHost = script.env.OPENSHIFT_API_URL
         config << BitbucketService.readConfigFromEnv(script.env)
         config << NexusService.readConfigFromEnv(script.env)
+        config.triggeredByOrchestrationPipeline = !!script.env.MULTI_REPO_BUILD
 
         config.odsBitbucketProject = script.env.ODS_BITBUCKET_PROJECT ?: 'opendevstack'
 
@@ -351,6 +352,11 @@ class Context implements IContext {
     @NonCPS
     boolean getFailOnSnykScanVulnerabilities() {
         config.failOnSnykScanVulnerabilities
+    }
+
+    @NonCPS
+    boolean getTriggeredByOrchestrationPipeline() {
+        config.triggeredByOrchestrationPipeline
     }
 
     int getEnvironmentLimit() {

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -137,6 +137,9 @@ interface IContext {
     // snyk behaviour configuration in case it reports vulnerabilities
     boolean getFailOnSnykScanVulnerabilities()
 
+    // Whether the pipeline run has been triggered by the orchestration pipeline
+    boolean getTriggeredByOrchestrationPipeline()
+
     String getIssueId()
 
     // Number of environments to allow.

--- a/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
@@ -122,8 +122,8 @@ class FinalizeOdsComponent {
         // Verify that all DCs are managed by ODS
         def odsBuiltDeploymentInformation = repo.data.openshift.deployments ?: [:]
         def odsBuiltDeployments = odsBuiltDeploymentInformation.keySet()
-        def allComponentDeployments = os.getDeploymentConfigsForComponent(
-            project.targetProject, componentSelector
+        def allComponentDeployments = os.getResourcesForComponent(
+            project.targetProject, OpenShiftService.DEPLOYMENTCONFIG_KIND, componentSelector
         )
         logger.debug(
             "ODS created deployments for ${repo.id}: " +

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -483,7 +483,11 @@ class MROPipelineUtil extends PipelineUtil {
         )
         Map deployments
         try {
-            deployments = os.getPodDataForDeployments(project.targetProject, deploymentDescriptor.deploymentNames)
+            deployments = os.getPodDataForDeployments(
+                project.targetProject,
+                OpenShiftService.DEPLOYMENTCONFIG_KIND,
+                deploymentDescriptor.deploymentNames
+            )
         } catch(ex) {
             logger.info(
                 "Resurrection of previous build for '${repo.id}' not possible as " +

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -67,18 +67,123 @@ class OpenShiftServiceSpec extends SpecHelper {
 
         then:
         result == [
-            podName: 'bar-164-6xxbw',
-            podNamespace: 'foo-dev',
-            podMetaDataCreationTimestamp: '2020-05-18T10:43:56Z',
-            deploymentId: 'bar-164',
-            podNode: 'ip-172-31-61-82.eu-central-1.compute.internal',
-            podIp: '10.128.17.92',
-            podStatus: 'Running',
-            podStartupTimeStamp: '2020-05-18T10:43:56Z',
-            containers: [
-                bar: '172.30.21.196:5000/foo-dev/bar@sha256:07ba1778e7003335e6f6e0f809ce7025e5a8914dc5767f2faedd495918bee58a'
+            [
+                podName: 'bar-164-6xxbw',
+                podNamespace: 'foo-dev',
+                podMetaDataCreationTimestamp: '2020-05-18T10:43:56Z',
+                deploymentId: 'bar-164',
+                podNode: 'ip-172-31-61-82.eu-central-1.compute.internal',
+                podIp: '10.128.17.92',
+                podStatus: 'Running',
+                podStartupTimeStamp: '2020-05-18T10:43:56Z',
+                containers: [
+                    bar: '172.30.21.196:5000/foo-dev/bar@sha256:07ba1778e7003335e6f6e0f809ce7025e5a8914dc5767f2faedd495918bee58a'
+                ]
             ]
         ]
+    }
+
+    // test implementation to prove as much as possible without actually
+    // running against a real cluster.
+    def "rollout: just watch if triggered already"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = Spy(Logger, constructorArgs: [steps, false])
+        def service = Spy(OpenShiftService, constructorArgs: [steps, logger])
+        service.getRevision('foo', 'Deployment', 'bar') >> 2
+        service.watchRollout('foo', 'Deployment', 'bar', 5) >> 'bar-6f8db5fb69'
+
+        when:
+        def result = service.rollout('foo', 'Deployment', 'bar', 1, 5)
+
+        then:
+        1 * logger.info("Rollout of deployment for 'bar' has been triggered automatically.")
+        result == 'bar-6f8db5fb69'
+    }
+
+    // test implementation to prove as much as possible without actually
+    // running against a real cluster.
+    def "rollout: Deployment: restart if not triggered already"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = Spy(Logger, constructorArgs: [steps, false])
+        def service = Spy(OpenShiftService, constructorArgs: [steps, logger])
+        service.getRevision('foo', 'Deployment', 'bar') >> 1
+        service.watchRollout('foo', 'Deployment', 'bar', 5) >> 'bar-6f8db5fb69'
+
+        when:
+        def result = service.rollout('foo', 'Deployment', 'bar', 1, 5)
+
+        then:
+        0 * logger.info(*_)
+        0 * service.invokeMethod('startRollout')
+        1 * service.invokeMethod('restartRollout', ['foo', 'bar', 1])
+        result == 'bar-6f8db5fb69'
+    }
+
+    // test implementation to prove as much as possible without actually
+    // running against a real cluster.
+    def "rollout: DeploymentConfig: start if not triggered already"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = Spy(Logger, constructorArgs: [steps, false])
+        def service = Spy(OpenShiftService, constructorArgs: [steps, logger])
+        service.getRevision('foo', 'DeploymentConfig', 'bar') >> 1
+        service.watchRollout('foo', 'DeploymentConfig', 'bar', 5) >> 'bar-2'
+
+        when:
+        def result = service.rollout('foo', 'DeploymentConfig', 'bar', 1, 5)
+
+        then:
+        0 * logger.info(*_)
+        1 * service.invokeMethod('startRollout', ['foo', 'bar', 1])
+        0 * service.invokeMethod('restartRollout')
+        result == 'bar-2'
+    }
+
+    // test implementation to prove as much as possible without actually
+    // running against a real cluster.
+    def "rollout status: Deployment"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = new Logger(steps, false)
+        def service = Spy(OpenShiftService, constructorArgs: [steps, logger])
+        service.invokeMethod('getJSON', ['foo', 'rs', 'bar']) >> [
+            status: [
+                replicas: replicas,
+                fullyLabeledReplicas: fullyLabeledReplicas,
+                availableReplicas: availableReplicas
+            ]
+        ]
+
+        when:
+        def result = service.getRolloutStatus('foo', 'Deployment', 'bar')
+
+        then:
+        result == status
+
+        where:
+        replicas | fullyLabeledReplicas | availableReplicas || status
+        null     | null                 | null              || 'waiting'
+        1        | 0                    | 0                 || 'waiting'
+        1        | 1                    | 0                 || 'waiting'
+        1        | 1                    | 1                 || 'complete'
+    }
+
+    // test implementation to prove as much as possible without actually
+    // running against a real cluster.
+    def "rollout status: DeploymentConfig"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = new Logger(steps, false)
+        def service = Spy(OpenShiftService, constructorArgs: [steps, logger])
+        service.invokeMethod('getJSONPath', *_) >> 'complete'
+
+        when:
+        def result = service.getRolloutStatus('foo', 'DeploymentConfig', 'bar')
+
+        then:
+        result == 'complete'
     }
 
 }

--- a/vars/odsComponentStageImportOpenShiftImageOrElse.groovy
+++ b/vars/odsComponentStageImportOpenShiftImageOrElse.groovy
@@ -14,7 +14,7 @@ def call(IContext context, Map config = [:], Closure block) {
         logger = new Logger (this, !!env.DEBUG)
     }
 
-    if (!!env.MULTI_REPO_BUILD) {
+    if (context.triggeredByOrchestrationPipeline) {
         logger.debug(
             '''Orchestration pipeline builds always run the 'orElse' branch ''' +
             'as image building and importing is handled in the orchestration pipeline.'


### PR DESCRIPTION
Closes #295.

Also deals with multiple pods (replicas) in the OpenShiftService, laying
some groundwork for #390.

Note that due to `rollout restart` being introduced in Kubernetes 1.15,
Deployment resources are not supported in OpenShift 3.11 at the moment.
This could change in future PRs if we change how we trigger rollouts
(specifically, by not using the `latest` tag but instead update the pod
template to different image tags for every rollout). Further, use of
`Deployment` resources is not (yet) possible when the orchestration
pipeline is being used.

Also note that the introduction of the config option `deploymentKind` in
`odsComponentStageRolloutOpenShiftDeployment` will likely be temporary.
#496 will require to refactor the stage so that it can deal with the whole
component, not individual Deployment or DeploymentConfig resources.