### PR TITLE
Feature/add branch to sonar cnes

### DIFF
--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -138,7 +138,8 @@ class ScanWithSonarStage extends Stage {
         return [:]
     }
 
-    private generateAndArchiveReports(String projectKey, String author, String sonarBranch, String sonarQubeEdition, boolean archive) {
+    private generateAndArchiveReports(String projectKey, String author, String sonarBranch, String sonarQubeEdition,
+                                      boolean archive) {
         def targetReport = "SCRR-${projectKey}.docx"
         def targetReportMd = "SCRR-${projectKey}.md"
         sonarQube.generateCNESReport(projectKey, author, sonarBranch, sonarQubeEdition)

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -97,7 +97,7 @@ class ScanWithSonarStage extends Stage {
     private void scan(Map sonarProperties) {
         def pullRequestInfo = assemblePullRequestInfo()
         def doScan = { Map prInfo ->
-            sonarQube.scan(sonarProperties, context.gitCommit, prInfo, context.debug)
+            sonarQube.scan(sonarProperties, context.gitCommit, prInfo, context.sonarQubeEdition, context.debug)
         }
         if (pullRequestInfo) {
             bitbucket.withTokenCredentials { username, token ->

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -68,12 +68,19 @@ class ScanWithSonarStage extends Stage {
         def sonarProjectKey = "${context.projectId}-${context.componentId}"
         sonarProperties['sonar.projectKey'] = sonarProjectKey
         sonarProperties['sonar.projectName'] = sonarProjectKey
+        sonarProperties['sonar.branch.name'] = context.gitBranch
 
         logger.startClocked("${sonarProjectKey}-sq-scan")
         scan(sonarProperties)
         logger.debugClocked("${sonarProjectKey}-sq-scan")
 
-        generateAndArchiveReports(sonarProjectKey, context.buildTag, context.localCheckoutEnabled)
+        generateAndArchiveReports(
+            sonarProjectKey,
+            context.buildTag,
+            sonarProperties['sonar.branch.name'],
+            context.sonarQubeEdition,
+            context.localCheckoutEnabled
+        )
 
         if (config.requireQualityGatePass) {
             def qualityGateResult = getQualityGateResult(sonarProjectKey)
@@ -131,10 +138,10 @@ class ScanWithSonarStage extends Stage {
         return [:]
     }
 
-    private generateAndArchiveReports(String projectKey, String author, boolean archive) {
+    private generateAndArchiveReports(String projectKey, String author, String sonarBranch, String sonarQubeEdition, boolean archive) {
         def targetReport = "SCRR-${projectKey}.docx"
         def targetReportMd = "SCRR-${projectKey}.md"
-        sonarQube.generateCNESReport(projectKey, author)
+        sonarQube.generateCNESReport(projectKey, author, sonarBranch, sonarQubeEdition)
         script.sh(
             label: 'Create artifacts dir',
             script: 'mkdir -p artifacts'

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -63,6 +63,11 @@ class ScanWithSonarStage extends Stage {
             logger.info 'No long-lived branches configured.'
         }
 
+        script.echo "__________________________________"
+        script.echo "SONARQUBEEDITION"
+        script.echo context.sonarQubeEdition
+        script.echo "__________________________________"
+
         def sonarProperties = sonarQube.readProperties()
 
         def sonarProjectKey = "${context.projectId}-${context.componentId}"

--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -14,7 +14,7 @@ class SonarQubeService {
         script.readProperties(file: filename)
     }
 
-    def scan(Map properties, String gitCommit, Map pullRequestInfo = [:], boolean debug = false) {
+    def scan(Map properties, String gitCommit, Map pullRequestInfo = [:], String sonarQubeEdition, boolean debug = false) {
         withSonarServerConfig { hostUrl, authToken ->
             def scannerParams = [
                 "-Dsonar.host.url=${hostUrl}",
@@ -22,8 +22,10 @@ class SonarQubeService {
                 '-Dsonar.scm.provider=git',
                 "-Dsonar.projectKey=${properties['sonar.projectKey']}",
                 "-Dsonar.projectName=${properties['sonar.projectName']}",
-                "-Dsonar.branch.name=${properties['sonar.branch.name']}",
             ]
+            if(sonarQubeEdition != 'community') {
+                scannerParams << "-Dsonar.branch.name=${properties['sonar.branch.name']}"
+            }
             if (!properties.containsKey('sonar.projectVersion')) {
                 scannerParams << "-Dsonar.projectVersion=${gitCommit.take(8)}"
             }

--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -54,7 +54,7 @@ class SonarQubeService {
 
     def generateCNESReport(String projectKey, String author, String sonarBranch, String sonarQubeEdition) {
         withSonarServerConfig { hostUrl, authToken ->
-            def branchParam = sonarQubeEdition == 'community' ? '' : "-b $sonarBranch"
+            def branchParam = sonarQubeEdition == 'community' ? '' : "-b ${sonarBranch}"
             script.sh(
                 label: 'Generate CNES Report',
                 script: """

--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -22,6 +22,7 @@ class SonarQubeService {
                 '-Dsonar.scm.provider=git',
                 "-Dsonar.projectKey=${properties['sonar.projectKey']}",
                 "-Dsonar.projectName=${properties['sonar.projectName']}",
+                "-Dsonar.branch.name=${properties['sonar.branch.name']}",
             ]
             if (!properties.containsKey('sonar.projectVersion')) {
                 scannerParams << "-Dsonar.projectVersion=${gitCommit.take(8)}"
@@ -48,8 +49,9 @@ class SonarQubeService {
         }
     }
 
-    def generateCNESReport(String projectKey, String author) {
+    def generateCNESReport(String projectKey, String author, String sonarBranch, String sonarQubeEdition) {
         withSonarServerConfig { hostUrl, authToken ->
+            def branchParam = sonarQubeEdition != 'community' ? "-b $sonarBranch" : ''
             script.sh(
                 label: 'Generate CNES Report',
                 script: """
@@ -57,7 +59,8 @@ class SonarQubeService {
                     -s ${hostUrl} \
                     -t ${authToken} \
                     -p ${projectKey} \
-                    -a ${author}
+                    -a ${author} \
+                    ${branchParam}
                 """
             )
         }

--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -14,7 +14,8 @@ class SonarQubeService {
         script.readProperties(file: filename)
     }
 
-    def scan(Map properties, String gitCommit, Map pullRequestInfo = [:], String sonarQubeEdition, boolean debug = false) {
+    def scan(Map properties, String gitCommit, Map pullRequestInfo = [:], String sonarQubeEdition,
+             boolean debug = false) {
         withSonarServerConfig { hostUrl, authToken ->
             def scannerParams = [
                 "-Dsonar.host.url=${hostUrl}",
@@ -23,7 +24,7 @@ class SonarQubeService {
                 "-Dsonar.projectKey=${properties['sonar.projectKey']}",
                 "-Dsonar.projectName=${properties['sonar.projectName']}",
             ]
-            if(sonarQubeEdition != 'community') {
+            if (sonarQubeEdition != 'community') {
                 scannerParams << "-Dsonar.branch.name=${properties['sonar.branch.name']}"
             }
             if (!properties.containsKey('sonar.projectVersion')) {
@@ -53,7 +54,7 @@ class SonarQubeService {
 
     def generateCNESReport(String projectKey, String author, String sonarBranch, String sonarQubeEdition) {
         withSonarServerConfig { hostUrl, authToken ->
-            def branchParam = sonarQubeEdition != 'community' ? "-b $sonarBranch" : ''
+            def branchParam = sonarQubeEdition == 'community' ? '' : "-b $sonarBranch"
             script.sh(
                 label: 'Generate CNES Report',
                 script: """

--- a/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
@@ -76,7 +76,7 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
     then:
     printCallStack()
     1 * sonarQubeService.scan(
-      ['sonar.projectKey': 'foo-bar', 'sonar.projectName': 'foo-bar'],
+      ['sonar.projectKey': 'foo-bar', 'sonar.projectName': 'foo-bar', 'sonar.branch.name': 'feature/foo'],
       'cd3e9082d7466942e1de86902bb9e663751dae8e',
       [
         bitbucketUrl: 'https://bitbucket.example.com',

--- a/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
@@ -29,7 +29,8 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
       buildTime: '2020-03-23 12:27:08 +0100',
       odsSharedLibVersion: '2.x',
       branchToEnvironmentMapping: ['master': 'dev', 'release/': 'test'],
-      sonarQubeBranch: 'master'
+      sonarQubeBranch: 'master',
+      sonarQubeEdition: 'developer',
   ]
 
   def "run successfully"() {
@@ -87,6 +88,7 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
         branch: 'feature/foo',
         baseBranch: 'master'
       ],
+        "developer",
       false
     )
     assertJobStatusSuccess()


### PR DESCRIPTION
Fixes #491 

with this PR the following will happen:
- every git branch will have its own sonar branch when running through the pipeline (if sonarqube edition is higher than community and the respective env var is set)
- using `sonar.branch.name` in the sonar-projects.properties has no effect since it is automatically set in the pipeline to the git branch name (same behaviour as for `sonar.projectKey` and `sonar.projectName`)
- cnesreporter will use the `sonar.branch.name` value as input for its `-b` branch option (if sonarqube edition is higher than community and the respective env var is set) 

also see https://github.com/opendevstack/ods-core/pull/890 which goes along with this PR