### PR TITLE
Fixes to retrieve the proper information for history in CSD and avoid…

### DIFF
--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -160,7 +160,10 @@ class LeVADocumentUseCase extends DocGenUseCase {
             ]
         }
 
-        def keysInDoc = requirementsForDocument.values().collect { it.key }.flatten()
+        def keysInDoc = requirementsForDocument.values().collect{it.noepics*.key + it.epics*.key}.flatten()
+        if(project.data?.jira?.discontinuationsPerType) {
+            keysInDoc += project.data.jira.discontinuationsPerType.requirements*.key
+        }
         def docHistory = this.getAndStoreDocumentHistory(documentType, keysInDoc)
         def data_ = [
             metadata: this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType]),

--- a/src/org/ods/orchestration/util/DocumentHistory.groovy
+++ b/src/org/ods/orchestration/util/DocumentHistory.groovy
@@ -43,7 +43,13 @@ class DocumentHistory {
     DocumentHistory load(Map jiraData, Long savedVersionId = null, List<String> filterKeys) {
         this.latestVersionId = (savedVersionId ?: 0L) + 1L
         if (savedVersionId && savedVersionId != 0L) {
-            this.data = sortDocHistoriesReversed(this.loadSavedDocHistoryData(savedVersionId))
+            def docHistories = sortDocHistoriesReversed(this.loadSavedDocHistoryData(savedVersionId))
+            def projectVersion = jiraData.version
+            if (projectVersion == docHistories.get(0).projectVersion) {
+                latestVersionId = docHistories.get(0).entryId
+                docHistories.remove(0)
+            }
+            this.data = docHistories
         }
         def newDocDocumentHistoryEntry = parseJiraDataToDocumentHistoryEntry(jiraData, filterKeys)
         if (this.allIssuesAreValid) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -1431,7 +1431,7 @@ class Project {
             newData
         } else {
             oldData[JiraDataItem.TYPE_COMPONENTS] = this.mergeComponentsLinks(oldData, newData)
-            def discontinuations = newData.getOrDefault('discontinuations',[]) +
+            def discontinuations = newData.getOrDefault('discontinuedKeys',[]) +
                 this.getComponentDiscontinuations(oldData, newData)
             newData.discontinuations = discontinuations
             // Expand some information from old saved data

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -385,7 +385,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         jiraDataItem3.get("funcSpec").put("name", "fs3")
 
         def requirements = [jiraDataItem1, jiraDataItem2, jiraDataItem3]
-
+        project.data.jira.discontinuationsPerType = [requirements:[]]
         when:
         usecase.createCSD()
 
@@ -1474,6 +1474,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
                 techSpecs     : [techSpecs[0]]
             ]
         ]
+        project.data.jira.discontinuationsPerType = [requirements:[]]
+
         when:
         def result = usecase.convertImages(contentWithImage)
 

--- a/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
@@ -2002,7 +2002,7 @@ class ProjectSpec extends SpecHelper {
             tests       : [:],
             techSpecs   : [:],
             docs        : [:],
-            discontinuations: [tst2.key]
+            discontinuedKeys: [tst2.key]
         ]
 
         def mergedData = [


### PR DESCRIPTION
With this fix we solve problem to:
a) retrieve all the needed information to discontinue a issue
b) avoid problems with duplicated entries in the History of the documents