### PR TITLE
Remove auto-cloning feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ codenarc {
     configFile = file('codenarc.groovy')
     maxPriority1Violations = 0
     maxPriority2Violations = 0
-    maxPriority3Violations = 332
+    maxPriority3Violations = 329
     reportFormat = 'html'
 }
 

--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -58,9 +58,6 @@ Available options are:
 | branchToEnvironmentMapping
 | Define which branches are deployed to which environments, see <<_git_workflow_branch_to_environment_mapping,Git Workflow / Branch to Environment Mapping>>
 
-| autoCloneEnvironmentsFromSourceMapping
-| Define which environments are cloned from which source environments.
-
 | projectId
 | Project ID, e.g. `foo`.
 
@@ -134,9 +131,6 @@ The `context` object contains the following properties:
 
 | sonarQubeEdition
 | Edition of SonarQube in use, determined by `SONARQUBE_EDITION` (defaults to `community`).
-
-| cloneSourceEnv
-| The environment which was chosen as the clone source.
 
 | environment
 | The environment which was chosen as the deployment target, e.g. `dev`.
@@ -422,62 +416,3 @@ def sayHello(def context) {
 === Skipping pipeline runs
 
 If the message of the built commit contains `[ci skip]`, the pipeline is skipped. The Jenkins build status will be set to `NOT_BUILT`, the Bitbucket build status to `SUCCESSFUL` (as there is no "skipped" state). The pipeline will start to execute initially, but abort before launching any agent nodes or starting any of the stages defined in the `Jenkinsfile`.
-
-=== Automatically cloning environments on the fly
-
-Caution! Cloning environments on-the-fly is an advanced feature and should only be used if you understand OpenShift well, as there are many moving parts and things can go wrong in multiple places.
-
-Example:
-
-----
-autoCloneEnvironmentsFromSourceMapping: [
-  "hotfix": "prod",
-  "review": "dev"
-]
-----
-
-Instead of deploying multiple branches to the same environment, individual environments can be created on-the-fly. For example, the mapping `"*": "review"` deploys all branches to the `review` environment. To have one environment per branch / ticket ID, you can add the `review` environment to `autoCloneEnvironmentsFromSourceMapping`, e.g. like this: `"review": "dev"`. This will create individual environments (named e.g. `review-123` or `review-foobar`), each cloned from the `dev` environment.
-
-==== Examples
-
-If you use git-flow, the following config fits well:
-
-----
-branchToEnvironmentMapping: [
-  'master': 'prod',
-  'develop': 'dev',
-  'release/': 'rel',
-  'hotfix/': 'hotfix',
-  '*': 'preview'
-]
-autoCloneEnvironmentsFromSourceMapping: [
-  'rel': 'dev',
-  'hotfix': 'prod',
-  'preview': 'dev'
-]
-----
-
-If you use GitHub Flow, the following config fits well:
-
-----
-branchToEnvironmentMapping: [
-  'master': 'prod',
-  '*': 'preview'
-]
-autoCloneEnvironmentsFromSourceMapping: [
-  'preview': 'prod'
-]
-----
-
-If you use a custom workflow, the config could look like this:
-
-----
-branchToEnvironmentMapping: [
-  'production': 'prod',
-  'master': 'dev',
-  'staging': 'uat'
-]
-autoCloneEnvironmentsFromSourceMapping: [
-  'uat': 'prod'
-]
-----

--- a/src/org/ods/component/IContext.groovy
+++ b/src/org/ods/component/IContext.groovy
@@ -61,21 +61,7 @@ interface IContext {
     // Define which branches are deployed to which environments.
     Map<String, String> getBranchToEnvironmentMapping()
 
-    // Define which environments are cloned from which source environments.
-    String getAutoCloneEnvironmentsFromSourceMapping()
-
     List<String> getImagePromotionSequences()
-
-    // The environment which was chosen as the clone source.
-    String getCloneSourceEnv()
-
-    // Set the environment to clone
-    void setCloneSourceEnv( String cloneSourceEnv)
-
-    // The branch in which the clone-project.sh script is used
-    String getCloneProjectScriptBranch()
-
-    Map<String, String> getCloneProjectScriptUrls()
 
     // The environment which was chosen as the deployment target, e.g. "dev".
     String getEnvironment()

--- a/test/groovy/org/ods/component/ContextSpec.groovy
+++ b/test/groovy/org/ods/component/ContextSpec.groovy
@@ -53,8 +53,7 @@ class ContextSpec extends Specification {
                 'release/': 'rel',
                 'hotfix/' : 'hotfix',
                 '*'       : 'preview'
-            ],
-            autoCloneEnvironmentsFromSourceMapping: [:]
+            ]
         ]
 
         when:
@@ -62,7 +61,6 @@ class ContextSpec extends Specification {
 
         then:
         config.environment == expectedEnv
-        config.cloneSourceEnv == null
 
         where:
         branch                | existingEnv         | expectedEnv
@@ -76,7 +74,7 @@ class ContextSpec extends Specification {
     }
 
     @Unroll
-    def "Githubflow: when branch = #branch and existingEnv = #existingEnv expectedEnv should be #expectedEnv and cloneSourceEnv = #cloneSourceEnv"(branch, existingEnv, expectedEnv, cloneSourceEnv) {
+    def "Githubflow: when branch = #branch and existingEnv = #existingEnv expectedEnv should be #expectedEnv"(branch, existingEnv, expectedEnv) {
 
         given:
         def config = [
@@ -84,9 +82,6 @@ class ContextSpec extends Specification {
             branchToEnvironmentMapping            : [
                 'master': 'prod',
                 '*'     : 'preview'
-            ],
-            autoCloneEnvironmentsFromSourceMapping: [
-                'preview': 'prod'
             ]
         ]
 
@@ -95,130 +90,23 @@ class ContextSpec extends Specification {
 
         then:
         config.environment == expectedEnv
-        config.cloneSourceEnv == cloneSourceEnv
 
         where:
-        branch                | existingEnv | expectedEnv   | cloneSourceEnv
-        'master'              | noEnv       | 'prod'        | null
-        'feature/foo-123-bar' | noEnv       | 'preview-123' | 'prod'
+        branch                | existingEnv | expectedEnv
+        'master'              | noEnv       | 'prod'
+        'feature/foo-123-bar' | noEnv       | 'preview'
     }
 
-    @Unroll
-    def testDetermineEnvironmentAutocloneWithoutBranchprefix(branch, existingEnv, expectedEnv, cloneSourceEnv) {
-
-        given:
-        def config = [
-            projectId                             : 'foo',
-            branchToEnvironmentMapping            : [
-                'master'     : 'prod',
-                'develop'    : 'dev',
-                'integration': 'int'
-            ],
-            autoCloneEnvironmentsFromSourceMapping: [
-                'int': 'dev'
-            ]
-        ]
-
-        when:
-        determineEnvironment(config, existingEnv, branch)
-
-        then:
-        config.environment == expectedEnv
-        config.cloneSourceEnv == cloneSourceEnv
-
-        where:
-        branch        | existingEnv     | expectedEnv | cloneSourceEnv
-        'integration' | ['dev', 'prod'] | 'int'       | 'dev'
-        'integration' | ['int']         | 'int'       | false
-    }
-
-    @Unroll
-    def testDetermineEnvironment_autoclone(branch, existingEnv, expectedEnv, cloneSourceEnv) {
-
-        given:
-        def config = [
-            projectId                             : 'foo',
-            branchToEnvironmentMapping            : [
-                'master'  : 'prod',
-                'develop' : 'dev',
-                'release/': 'rel',
-                'hotfix/' : 'hotfix',
-                '*'       : 'preview'
-            ],
-            autoCloneEnvironmentsFromSourceMapping: [
-                'rel'    : 'dev',
-                'hotfix' : 'prod',
-                'preview': 'dev'
-            ]
-        ]
-
-        when:
-        determineEnvironment(config, existingEnv, branch)
-
-        then:
-        config.environment == expectedEnv
-        config.cloneSourceEnv == cloneSourceEnv
-
-        where:
-        branch                | existingEnv | expectedEnv       | cloneSourceEnv
-        'release/1.0.0'       | []          | 'rel-1.0.0'       | 'dev'
-        'hotfix/foo-123-bar'  | []          | 'hotfix-123'      | 'prod'
-        'hotfix/foo'          | []          | 'hotfix-foo'      | 'prod'
-        'feature/foo-123-bar' | []          | 'preview-123'     | 'dev'
-        'foo-bar'             | []          | 'preview-foo-bar' | 'dev'
-    }
-
-    //resets config.environment and call determineEnvironment on newly created Context object
+    // resets config.environment and call determineEnvironment on newly created Context object
     void determineEnvironment(config, existingEnvironments, String branch) {
         config.environment = null
         config.gitBranch = branch
-        config.cloneSourceEnv = null
         def uut = new Context(script, config, logger) {
             boolean environmentExists(String name) {
                 existingEnvironments.contains(name)
             }
         }
         uut.determineEnvironment()
-
     }
 
-    def bbBaseUrl = 'https://bitbucket.example.com/projects/opendevstack/repos/ods-core/raw/ocp-scripts'
-
-    def testCloneProjectScriptUrlsDefault() {
-        when:
-        def m = getCloneProjectScriptUrls([
-            podContainers: [],
-            branchToEnvironmentMapping: [:],
-            environment: 'foo-dev',
-        ])
-
-        then:
-        m.keySet() == ['clone-project.sh', 'import-project.sh', 'export-project.sh'] as Set
-        m['clone-project.sh'] == "${bbBaseUrl}/clone-project.sh?at=refs%2Fheads%2Fmaster"
-        m['export-project.sh'] == "${bbBaseUrl}/export-project.sh?at=refs%2Fheads%2Fmaster"
-        m['import-project.sh'] == "${bbBaseUrl}/import-project.sh?at=refs%2Fheads%2Fmaster"
-    }
-
-    void testCloneProjectScriptUrlsAtBranch() {
-
-        when:
-        def m = getCloneProjectScriptUrls([
-            podContainers: [],
-            branchToEnvironmentMapping: [:],
-            environment: 'foo-dev',
-            cloneProjectScriptBranch: 'fix/gh318-test',
-        ])
-
-        then:
-        m.keySet() == ['clone-project.sh', 'import-project.sh', 'export-project.sh'] as Set
-        m['clone-project.sh'] == "${bbBaseUrl}/clone-project.sh?at=refs%2Fheads%2Ffix%2Fgh318-test"
-        m['export-project.sh'] == "${bbBaseUrl}/export-project.sh?at=refs%2Fheads%2Ffix%2Fgh318-test"
-        m['import-project.sh'] == "${bbBaseUrl}/import-project.sh?at=refs%2Fheads%2Ffix%2Fgh318-test"
-    }
-
-    Map<String, String> getCloneProjectScriptUrls(config) {
-        def uut = new Context(script, config, logger)
-        uut.assemble()
-        return uut.getCloneProjectScriptUrls()
-    }
 }


### PR DESCRIPTION
Closes #374, which also explains the reasons why.

While it can be tough to say good-bye to a feature, I'm quite excited
about this change. It simplifies things quite a bit, it removes some
piece of code that proved to be brittle, and it allows to implement
other things like #497 much more easily.

Once merged I will follow up with a PR to remove the scripts from `ods-core`.