### PR TITLE
Deploy all Deployment(Config) resources of component together

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentPipeline.adoc
@@ -355,7 +355,6 @@ With this in place, you can adapt the rollout stage:
 odsComponentStageRolloutOpenShiftDeployment(
   context,
   [
-    resourceName: "${suffixedComponent}",
     tailorSelector: "app=${context.projectId}-${suffixedComponent}",
     tailorParams: ["COMPONENT_SUFFIX=${componentSuffix}"]
   ]

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -11,8 +11,8 @@ Available options:
 |===
 | Option | Description
 
-| resourceName
-| Name of `DeploymentConfig` to use (defaults to `context.componentId`).
+| selector
+| Selector scope used to determine which resources are part of a component (defaults to `app=<PROJECT>-<COMPONENT>`).
 
 | imageTag
 | Image tag on which to apply the `latest` tag (defaults to `context.shortGitCommit`).
@@ -30,7 +30,7 @@ Available options:
 | Credentials name of the secret key used by Tailor (defaults to `<PROJECT>-cd-tailor-private-key`). Only relevant if the directory referenced by `openshiftDir` exists.
 
 | tailorSelector
-| Selector scope used by Tailor (defaults to `app=<PROJECT>-<COMPONENT>`). Only relevant if the directory referenced by `openshiftDir` exists.
+| Selector scope used by Tailor (defaults to config option `selector`). Only relevant if the directory referenced by `openshiftDir` exists.
 
 | tailorVerify
 | Whether Tailor verifies the live configuration against the desired state after application (defaults to `false`). Only relevant if the directory referenced by `openshiftDir` exists.

--- a/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
@@ -125,9 +125,10 @@ class FinalizeOdsComponent {
         def allComponentDeployments = os.getResourcesForComponent(
             project.targetProject, OpenShiftService.DEPLOYMENTCONFIG_KIND, componentSelector
         )
+        def allComponentDeploymentNames = allComponentDeployments[OpenShiftService.DEPLOYMENTCONFIG_KIND]
         logger.debug(
             "ODS created deployments for ${repo.id}: " +
-            "${odsBuiltDeployments}, all deployments: ${allComponentDeployments}"
+            "${odsBuiltDeployments}, all deployments: ${allComponentDeploymentNames}"
         )
 
         odsBuiltDeployments.each { odsBuiltDeploymentName ->


### PR DESCRIPTION
* Avoids having to specify the `resourceName` config option to target
  multiple Deployment/DeploymentConfig resources
* Avoids having to specify the `deploymentKind` config option
* Important prerequisite for #496 as we only want to login to every
  cluster once, then deploy everything there in one go.
* This is also a better fit with Tailor/Helm, which update all
  resources with a certain label / which are part of a release, not
  individual resources.