### PR TITLE
Print eligible branches if stage is skipped

### DIFF
--- a/src/org/ods/component/Stage.groovy
+++ b/src/org/ods/component/Stage.groovy
@@ -19,7 +19,10 @@ abstract class Stage {
     def execute() {
         setConfiguredBranches()
         if (!isEligibleBranch(config.branches, context.gitBranch)) {
-            logger.info "Skipping stage '${stageLabel()}' for branch '${context.gitBranch}'"
+            logger.info(
+                "Skipping stage '${stageLabel()}' for branch '${context.gitBranch}' " +
+                "as it is not covered by: ${config.branches.collect { "'${it}'" } join(', ')}."
+            )
             return
         }
         script.withStage(stageLabel(), context, logger) {


### PR DESCRIPTION
Small improvment for the functionality implemented in #515.
This should make it easier to figure out why some stage is skipped.