### PR TITLE
Fail early when resourceName is given

### DIFF
--- a/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
@@ -192,6 +192,20 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     assertJobStatusFailure()
   }
 
+  def "fail when resourceName is given"() {
+    given:
+    IContext context = new Context(null, [:], logger)
+
+    when:
+    def script = loadScript('vars/odsComponentStageRolloutOpenShiftDeployment.groovy')
+    script.call(context, [resourceName: 'foo'])
+
+    then:
+    printCallStack()
+    assertCallStackContains("The config option 'resourceName' has been removed from odsComponentStageRolloutOpenShiftDeployment")
+    assertJobStatusFailure()
+  }
+
   def "skip when no environment given"() {
     given:
     def config = [environment: null, gitCommit: 'cd3e9082d7466942e1de86902bb9e663751dae8e', openshiftRolloutTimeoutRetries: 5]

--- a/vars/odsComponentStageRolloutOpenShiftDeployment.groovy
+++ b/vars/odsComponentStageRolloutOpenShiftDeployment.groovy
@@ -13,6 +13,17 @@ def call(IContext context, Map config = [:]) {
     if (!logger) {
         logger = new Logger (this, !!env.DEBUG)
     }
+    // ODS 3.x allowed to specify resourceName, which is no longer possible.
+    // Fail if the option is still given to inform about this breaking change.
+    if (config.resourceName) {
+        error(
+            "The config option 'resourceName' has been removed from odsComponentStageRolloutOpenShiftDeployment. " +
+            "Instead, all resources with a common label are rollout out together. " +
+            "If you need separate rollouts, consider specifying additional labels " +
+            "and target those via the 'selector' config option."
+        )
+        return
+    }
     return new RolloutOpenShiftDeploymentStage(
         this,
         context,


### PR DESCRIPTION
This should help uncover cases like #526 in real projects a little bit easier.