### PR TITLE
Use Go template instead of jsonpath

### DIFF
--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -431,7 +431,7 @@ class OpenShiftService {
         def items = steps.sh(
             script: """oc -n ${project} get ${kinds.join(',')} \
                 -l ${selector} \
-                -o jsonpath='{range .items[*]}{@.kind}:{@.metadata.name} {end}'""",
+                -o template='{{range .items}}{{.kind}}:{{.metadata.name}} {{end}}'""",
             returnStdout: true,
             label: "Getting all ${kinds.join(',')} names for selector '${selector}'"
         ).toString().trim().tokenize(' ')


### PR DESCRIPTION
I've seen errors with this in OpenShift 4. I'm not entirely sure why and
when this happens, as most times it works. But for cases where it fails,
it fails consistently.

The error shown is:
```
  error: error executing jsonpath "{range .items[*]}{@.kind}:{@.metadata.name} {end}": Error executing template: not in range, nothing to end. Printing more information for debugging the template:
	template was:
		{range .items[*]}{@.kind}:{@.metadata.name} {end}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
```

Googling revealed https://github.com/kubernetes/kubectl/issues/913,
which sounds similar.

The Go template version succeeds in the cases where the
jsonpath version fails.

The bug affects `master` only.