### PR TITLE
Implement Helm deploy

### DIFF
--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -23,6 +23,21 @@ Available options:
 | deployTimeoutRetries
 | Adjust retries to wait for the pod during a rollout (defaults to 5). 
 
+| chartDir
+| Directory of Helm chart (defaults to `chart`).
+
+| helmReleaseName
+| Name of the Helm release (defaults to `context.componentId`). Change this value if you want to install separate instances of the Helm chart in the same namespace. In that case, make sure to use `{{ .Release.Name }}` in resource names to avoid conflicts.
+
+| helmValues
+| Map of key/value pairs to pass as values (by default, the key `imageTag` is set to the config option `imageTag`).
+
+| helmValuesFiles
+| List of paths to values files (empty by default).
+
+| helmAdditionalFlags
+| List of additional flags to be passed verbatim to the `helm` binary (empty by default).
+
 | openshiftDir
 | Directory with OpenShift templates (defaults to `openshift`).
 

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -27,28 +27,31 @@ Available options:
 | Directory of Helm chart (defaults to `chart`).
 
 | helmReleaseName
-| Name of the Helm release (defaults to `context.componentId`). Change this value if you want to install separate instances of the Helm chart in the same namespace. In that case, make sure to use `{{ .Release.Name }}` in resource names to avoid conflicts.
+| Name of the Helm release (defaults to `context.componentId`). Change this value if you want to install separate instances of the Helm chart in the same namespace. In that case, make sure to use `{{ .Release.Name }}` in resource names to avoid conflicts.  Only relevant if the directory referenced by `chartDir` exists.
 
 | helmValues
-| Map of key/value pairs to pass as values (by default, the key `imageTag` is set to the config option `imageTag`).
+| Map of key/value pairs to pass as values (by default, the key `imageTag` is set to the config option `imageTag`). Only relevant if the directory referenced by `chartDir` exists.
 
 | helmValuesFiles
-| List of paths to values files (empty by default).
+| List of paths to values files (empty by default). Only relevant if the directory referenced by `chartDir` exists.
 
 | helmDefaultFlags
-| List of default flags to be passed verbatim to to `helm upgrade` (defaults to `['--install', '--atomic']`). Typically these should not be modified - if you want to pass more flags, use `helmAdditionalFlags` instead.
+| List of default flags to be passed verbatim to to `helm upgrade` (defaults to `['--install', '--atomic']`). Typically these should not be modified - if you want to pass more flags, use `helmAdditionalFlags` instead. Only relevant if the directory referenced by `chartDir` exists.
 
 | helmAdditionalFlags
-| List of additional flags to be passed verbatim to to `helm upgrade` (empty by default).
+| List of additional flags to be passed verbatim to to `helm upgrade` (empty by default). Only relevant if the directory referenced by `chartDir` exists.
 
 | helmDiff
-| Whether to show diff explaining changes to the release before running `helm upgrade` (`true` by default).
+| Whether to show diff explaining changes to the release before running `helm upgrade` (`true` by default). Only relevant if the directory referenced by `chartDir` exists.
+
+| helmPrivateKeyCredentialsId
+| Credentials name of the private key used by helm-secrets (defaults to `<PROJECT>-cd-helm-private-key`). The fingerprint must match the one specified in `.sops.yaml`. Only relevant if the directory referenced by `chartDir` exists.
 
 | openshiftDir
 | Directory with OpenShift templates (defaults to `openshift`).
 
 | tailorPrivateKeyCredentialsId
-| Credentials name of the secret key used by Tailor (defaults to `<PROJECT>-cd-tailor-private-key`). Only relevant if the directory referenced by `openshiftDir` exists.
+| Credentials name of the private key used by Tailor (defaults to `<PROJECT>-cd-tailor-private-key`). Only relevant if the directory referenced by `openshiftDir` exists.
 
 | tailorSelector
 | Selector scope used by Tailor (defaults to config option `selector`). Only relevant if the directory referenced by `openshiftDir` exists.

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -35,6 +35,9 @@ Available options:
 | helmValuesFiles
 | List of paths to values files (empty by default).
 
+| helmDefaultFlags
+| List of default flags to be passed verbatim to the `helm` binary (defaults to `['--install', '--atomic']`). Typically these should not be modified - if you want to pass more flags, use `helmAdditionalFlags` instead.
+
 | helmAdditionalFlags
 | List of additional flags to be passed verbatim to the `helm` binary (empty by default).
 

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageRolloutOpenShiftDeployment.adoc
@@ -36,10 +36,13 @@ Available options:
 | List of paths to values files (empty by default).
 
 | helmDefaultFlags
-| List of default flags to be passed verbatim to the `helm` binary (defaults to `['--install', '--atomic']`). Typically these should not be modified - if you want to pass more flags, use `helmAdditionalFlags` instead.
+| List of default flags to be passed verbatim to to `helm upgrade` (defaults to `['--install', '--atomic']`). Typically these should not be modified - if you want to pass more flags, use `helmAdditionalFlags` instead.
 
 | helmAdditionalFlags
-| List of additional flags to be passed verbatim to the `helm` binary (empty by default).
+| List of additional flags to be passed verbatim to to `helm upgrade` (empty by default).
+
+| helmDiff
+| Whether to show diff explaining changes to the release before running `helm upgrade` (`true` by default).
 
 | openshiftDir
 | Directory with OpenShift templates (defaults to `openshift`).

--- a/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
+++ b/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
@@ -52,6 +52,9 @@ class RolloutOpenShiftDeploymentStage extends Stage {
         if (!config.containsKey('helmAdditionalFlags')) {
             config.helmAdditionalFlags = []
         }
+        if (!config.containsKey('helmDiff')) {
+            config.helmDiff = true
+        }
         // Tailor options
         if (!config.openshiftDir) {
             config.openshiftDir = 'openshift'
@@ -151,7 +154,8 @@ class RolloutOpenShiftDeploymentStage extends Stage {
                 config.helmValuesFiles,
                 config.helmValues,
                 config.helmDefaultFlags,
-                config.helmAdditionalFlags
+                config.helmAdditionalFlags,
+                config.helmDiff
             )
         }
     }

--- a/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
+++ b/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
@@ -12,6 +12,7 @@ class RolloutOpenShiftDeploymentStage extends Stage {
     private final OpenShiftService openShift
     private final JenkinsService jenkins
 
+    @SuppressWarnings('CyclomaticComplexity')
     RolloutOpenShiftDeploymentStage(
         def script,
         IContext context,
@@ -44,6 +45,9 @@ class RolloutOpenShiftDeploymentStage extends Stage {
         }
         if (!config.containsKey('helmValuesFiles')) {
             config.helmValuesFiles = []
+        }
+        if (!config.containsKey('helmDefaultFlags')) {
+            config.helmDefaultFlags = ['--install', '--atomic']
         }
         if (!config.containsKey('helmAdditionalFlags')) {
             config.helmAdditionalFlags = []
@@ -146,6 +150,7 @@ class RolloutOpenShiftDeploymentStage extends Stage {
                 config.helmReleaseName,
                 config.helmValuesFiles,
                 config.helmValues,
+                config.helmDefaultFlags,
                 config.helmAdditionalFlags
             )
         }

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -153,12 +153,12 @@ class OpenShiftService {
             def diffFlags = upgradeFlags.findAll { it != '--atomic' }
             diffFlags << '--no-color'
             steps.sh(
-                script: "helm -n ${project} diff upgrade ${diffFlags.join(' ')} ${release} ./",
+                script: "helm -n ${project} secrets diff upgrade ${diffFlags.join(' ')} ${release} ./",
                 label: "Show diff explaining what helm upgrade would change for release ${release} in ${project}"
             )
         }
         steps.sh(
-            script: "helm -n ${project} upgrade ${upgradeFlags.join(' ')} ${release} ./",
+            script: "helm -n ${project} secrets upgrade ${upgradeFlags.join(' ')} ${release} ./",
             label: "Upgrade Helm release ${release} in ${project}"
         )
     }

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -133,6 +133,28 @@ class OpenShiftService {
         getApiUrl(steps)
     }
 
+    // helmUpgrade installs given "release" into "project" from the chart
+    // located in the working directory.
+    void helmUpgrade(
+        String project,
+        String release,
+        List<String> valuesFiles,
+        Map<String, String> values,
+        List<String> additionalFlags) {
+        def valuesFilesFlags = valuesFiles.collect { f -> "-f ${f}" }
+        def setFlags = values.collect { k, v -> "--set ${k}=${v}" }
+        steps.sh(
+            script: """helm \
+                -n ${project} \
+                upgrade --install --wait \
+                ${valuesFilesFlags.join(' ')} \
+                ${setFlags.join(' ')} \
+                ${additionalFlags.join(' ')} \
+                ${release} ./""",
+            label: "Upgrade Helm release ${release} in ${project}"
+        )
+    }
+
     @SuppressWarnings(['LineLength', 'ParameterCount'])
     void tailorApply(String project, Map<String, String> target, String paramFile, List<String> params, List<String> preserve, String tailorPrivateKeyFile, boolean verify) {
         def verifyFlag = verify ? '--verify' : ''

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -135,22 +135,18 @@ class OpenShiftService {
 
     // helmUpgrade installs given "release" into "project" from the chart
     // located in the working directory.
+    @SuppressWarnings(['ParameterCount', 'LineLength'])
     void helmUpgrade(
         String project,
         String release,
         List<String> valuesFiles,
         Map<String, String> values,
+        List<String> defaultFlags,
         List<String> additionalFlags) {
         def valuesFilesFlags = valuesFiles.collect { f -> "-f ${f}" }
         def setFlags = values.collect { k, v -> "--set ${k}=${v}" }
         steps.sh(
-            script: """helm \
-                -n ${project} \
-                upgrade --install --wait \
-                ${valuesFilesFlags.join(' ')} \
-                ${setFlags.join(' ')} \
-                ${additionalFlags.join(' ')} \
-                ${release} ./""",
+            script: "helm -n ${project} upgrade ${defaultFlags.join(' ')} ${valuesFilesFlags.join(' ')} ${setFlags.join(' ')} ${additionalFlags.join(' ')} ${release} ./",
             label: "Upgrade Helm release ${release} in ${project}"
         )
     }

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -94,12 +94,17 @@ class OpenShiftServiceSpec extends SpecHelper {
             ['values.yml', 'values-dev.yml'],
             [imageTag: '6f8db5fb'],
             ['--install', '--atomic'],
-            ['--force']
+            ['--force'],
+            true
         )
 
         then:
         1 * steps.sh(
-            script: 'helm -n foo upgrade --install --atomic -f values.yml -f values-dev.yml --set imageTag=6f8db5fb --force bar ./',
+            script: 'helm -n foo diff upgrade --install --force -f values.yml -f values-dev.yml --set imageTag=6f8db5fb --no-color bar ./',
+            label: 'Show diff explaining what helm upgrade would change for release bar in foo'
+        )
+        1 * steps.sh(
+            script: 'helm -n foo upgrade --install --atomic --force -f values.yml -f values-dev.yml --set imageTag=6f8db5fb bar ./',
             label: 'Upgrade Helm release bar in foo'
         )
     }

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -82,6 +82,28 @@ class OpenShiftServiceSpec extends SpecHelper {
         ]
     }
 
+    def "helm upgrade"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def service = new OpenShiftService(steps, new Logger(steps, false))
+
+        when:
+        service.helmUpgrade(
+            'foo',
+            'bar',
+            ['values.yml', 'values-dev.yml'],
+            [imageTag: '6f8db5fb'],
+            ['--install', '--atomic'],
+            ['--force']
+        )
+
+        then:
+        1 * steps.sh(
+            script: 'helm -n foo upgrade --install --atomic -f values.yml -f values-dev.yml --set imageTag=6f8db5fb --force bar ./',
+            label: 'Upgrade Helm release bar in foo'
+        )
+    }
+
     // test implementation to prove as much as possible without actually
     // running against a real cluster.
     def "rollout: just watch if triggered already"() {

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -100,11 +100,11 @@ class OpenShiftServiceSpec extends SpecHelper {
 
         then:
         1 * steps.sh(
-            script: 'helm -n foo diff upgrade --install --force -f values.yml -f values-dev.yml --set imageTag=6f8db5fb --no-color bar ./',
+            script: 'helm -n foo secrets diff upgrade --install --force -f values.yml -f values-dev.yml --set imageTag=6f8db5fb --no-color bar ./',
             label: 'Show diff explaining what helm upgrade would change for release bar in foo'
         )
         1 * steps.sh(
-            script: 'helm -n foo upgrade --install --atomic --force -f values.yml -f values-dev.yml --set imageTag=6f8db5fb bar ./',
+            script: 'helm -n foo secrets upgrade --install --atomic --force -f values.yml -f values-dev.yml --set imageTag=6f8db5fb bar ./',
             label: 'Upgrade Helm release bar in foo'
         )
     }

--- a/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
@@ -148,6 +148,9 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     openShiftService.getPodDataForDeployment(*_) >> [new PodData([ deploymentId: "${config.componentId}-124" ])]
     openShiftService.getImagesOfDeployment(*_) >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
+    JenkinsService jenkinsService = Stub(JenkinsService.class)
+    jenkinsService.maybeWithPrivateKeyCredentials(*_) >> { args -> args[1]('/tmp/file') }
+    ServiceRegistry.instance.add(JenkinsService, jenkinsService)
 
     when:
     def script = loadScript('vars/odsComponentStageRolloutOpenShiftDeployment.groovy')


### PR DESCRIPTION
Allows to use a chart in the repository to deploy via Helm (closes #495). I have implemented only very few options for now. I think we could start with this in `master` and review if we need more/different options once we have first users. The PR is a draft for now until we have gathered some feedback on the general direction, then I'll finish up the implementation/tests.

A comment towards general strategy: my view is that we should support Helm as an alternative to Tailor for the time being. Tailor is better suited for OpenShift 3.11, but for OpenShift 4, I would like us to transition to Helm. If you want to know more what this means and which implications this has, I'm starting to collect thoughts on this at https://github.com/opendevstack/tailor/wiki/Migrating-from-Tailor-to-Helm.

Would love to get your thoughts on the integration / strategy / implementation ... all comments welcome :)

FYI @segfault16 @serverhorror would especially appreciate your feedback as users of Helm if this would fit your use case