### PR TITLE
Introduce PodData structure

### DIFF
--- a/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
@@ -70,7 +70,7 @@ class DeployOdsComponent {
                 )
                 // TODO: Once the orchestration pipeline can deal with multiple replicas,
                 // update this to deal with multiple pods.
-                def pod = podData[0]
+                def pod = podData[0].toMap()
 
                 verifyImageShas(deployment, pod.containers)
 

--- a/src/org/ods/util/PodData.groovy
+++ b/src/org/ods/util/PodData.groovy
@@ -1,0 +1,67 @@
+package org.ods.util
+
+import groovy.transform.TypeChecked
+import com.cloudbees.groovy.cps.NonCPS
+
+// PodData describes a Kubernetes pod.
+@TypeChecked
+class PodData {
+
+    // podName is the name of the pod.
+    // Example: foo-3-vfhxb
+    String podName
+
+    // podNamespace is the namespace in which the pod is running.
+    // Example: foo
+    String podNamespace
+
+    // podMetaDataCreationTimestamp equals .metadata.creationTimestamp.
+    // Example: 2020-11-02T10:57:35Z
+    String podMetaDataCreationTimestamp
+
+    // deploymentId is the name of the pod manager, such as the ReplicaSet or
+    // ReplicationController . It is read from .metadata.generateName.
+    // Example: foo-3
+    String deploymentId
+
+    // podNode is the node name on which of the pod, equal to .spec.nodeName.
+    // Example: ip-172-32-53-123.eu-west-1.compute.internal
+    String podNode
+
+    // podIp is the IP of the pod, equal to .status.podIP.
+    // Example: 10.132.16.73
+    String podIp
+
+    // podStatus is the status phase of the pod, equal to .status.phase
+    // Example: Running
+    String podStatus
+
+    // podStartupTimeStamp is the start time of the pod, equal to .status.startTime.
+    // Example: 2020-11-02T10:57:35Z
+    String podStartupTimeStamp
+
+    // containers is a map of container names to their image.
+    // Example: [bar: '172.30.21.193:5000/foo/bar@sha256:a828...4389']
+    Map<String, String> containers
+
+    @NonCPS
+    Map<String, Object> toMap() {
+        [
+            podName: podName,
+            podNamespace: podNamespace,
+            podMetaDataCreationTimestamp: podMetaDataCreationTimestamp,
+            deploymentId: deploymentId,
+            podNode: podNode,
+            podIp: podIp,
+            podStatus: podStatus,
+            podStartupTimeStamp: podStartupTimeStamp,
+            containers: containers,
+        ]
+    }
+
+    @NonCPS
+    String toString() {
+        toMap().toMapString()
+    }
+
+}

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -66,19 +66,18 @@ class OpenShiftServiceSpec extends SpecHelper {
         def result = service.extractPodData(new JsonSlurperClassic().parseText(file.text))
 
         then:
-        result == [
-            [
-                podName: 'bar-164-6xxbw',
-                podNamespace: 'foo-dev',
-                podMetaDataCreationTimestamp: '2020-05-18T10:43:56Z',
-                deploymentId: 'bar-164',
-                podNode: 'ip-172-31-61-82.eu-central-1.compute.internal',
-                podIp: '10.128.17.92',
-                podStatus: 'Running',
-                podStartupTimeStamp: '2020-05-18T10:43:56Z',
-                containers: [
-                    bar: '172.30.21.196:5000/foo-dev/bar@sha256:07ba1778e7003335e6f6e0f809ce7025e5a8914dc5767f2faedd495918bee58a'
-                ]
+        result.size() == 1
+        result[0].toMap() == [
+            podName: 'bar-164-6xxbw',
+            podNamespace: 'foo-dev',
+            podMetaDataCreationTimestamp: '2020-05-18T10:43:56Z',
+            deploymentId: 'bar-164',
+            podNode: 'ip-172-31-61-82.eu-central-1.compute.internal',
+            podIp: '10.128.17.92',
+            podStatus: 'Running',
+            podStartupTimeStamp: '2020-05-18T10:43:56Z',
+            containers: [
+                bar: '172.30.21.196:5000/foo-dev/bar@sha256:07ba1778e7003335e6f6e0f809ce7025e5a8914dc5767f2faedd495918bee58a'
             ]
         ]
     }

--- a/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageRolloutOpenShiftDeploymentSpec.groovy
@@ -6,6 +6,7 @@ import org.ods.services.OpenShiftService
 import org.ods.services.JenkinsService
 import org.ods.services.ServiceRegistry
 import org.ods.util.Logger
+import org.ods.util.PodData
 import vars.test_helper.PipelineSpockTestBase
 import spock.lang.*
 
@@ -37,7 +38,7 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     openShiftService.getRevision('foo-dev', 'DeploymentConfig', 'bar') >> 123
     openShiftService.rollout('foo-dev', 'DeploymentConfig', 'bar', 123, 5) >> "bar-124"
     // test the handover of the poddata retries
-    openShiftService.getPodDataForDeployment('foo-dev', 'DeploymentConfig', 'bar-124', 6) >> [[ deploymentId: "bar-124" ]]
+    openShiftService.getPodDataForDeployment('foo-dev', 'DeploymentConfig', 'bar-124', 6) >> [new PodData([ deploymentId: "bar-124" ])]
     openShiftService.getImagesOfDeployment('foo-dev', 'DeploymentConfig', 'bar') >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
@@ -51,13 +52,13 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     then:
     printCallStack()
     assertJobStatusSuccess()
-    deploymentInfo['DeploymentConfig']['bar'][0].deploymentId == "bar-124"
+    deploymentInfo['DeploymentConfig/bar'][0].deploymentId == "bar-124"
 
     // test artifact URIS
     def buildArtifacts = context.getBuildArtifactURIs()
     buildArtifacts.size() > 0
     buildArtifacts.deployments.containsKey (config.componentId)
-    buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo['DeploymentConfig']['bar'][0].deploymentId
+    buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo['DeploymentConfig/bar'][0].deploymentId
   }
 
   def "run successfully without Tailor [Deployment]"() {
@@ -69,7 +70,7 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     openShiftService.getRevision('foo-dev', 'Deployment', 'bar') >> 123
     openShiftService.rollout('foo-dev', 'Deployment', 'bar', 123, 5) >> "bar-6f8db5fb69"
     // test the handover of the poddata retries
-    openShiftService.getPodDataForDeployment('foo-dev', 'Deployment', 'bar-6f8db5fb69', 6) >> [[ deploymentId: "bar-6f8db5fb69" ]]
+    openShiftService.getPodDataForDeployment('foo-dev', 'Deployment', 'bar-6f8db5fb69', 6) >> [new PodData([ deploymentId: "bar-6f8db5fb69" ])]
     openShiftService.getImagesOfDeployment('foo-dev', 'Deployment', 'bar') >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
 
@@ -83,13 +84,13 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     then:
     printCallStack()
     assertJobStatusSuccess()
-    deploymentInfo['Deployment']['bar'][0].deploymentId == "bar-6f8db5fb69"
+    deploymentInfo['Deployment/bar'][0].deploymentId == "bar-6f8db5fb69"
 
     // test artifact URIS
     def buildArtifacts = context.getBuildArtifactURIs()
     buildArtifacts.size() > 0
     buildArtifacts.deployments.containsKey (config.componentId)
-    buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo['Deployment']['bar'][0].deploymentId
+    buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo['Deployment/bar'][0].deploymentId
   }
 
   def "run successfully with Tailor"() {
@@ -100,7 +101,7 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     openShiftService.getResourcesForComponent('foo-dev', ['Deployment', 'DeploymentConfig'], 'app=foo-bar') >> [DeploymentConfig: ['bar']]
     openShiftService.getRevision(*_) >> 123
     openShiftService.rollout(*_) >> "${config.componentId}-124"
-    openShiftService.getPodDataForDeployment(*_) >> [[ deploymentId: "${config.componentId}-124" ]]
+    openShiftService.getPodDataForDeployment(*_) >> [new PodData([ deploymentId: "${config.componentId}-124" ])]
     openShiftService.getImagesOfDeployment(*_) >> [[ repository: 'foo', name: 'bar' ]]
     ServiceRegistry.instance.add(OpenShiftService, openShiftService)
     JenkinsService jenkinsService = Stub(JenkinsService.class)
@@ -117,13 +118,13 @@ class OdsComponentStageRolloutOpenShiftDeploymentSpec extends PipelineSpockTestB
     then:
     printCallStack()
     assertJobStatusSuccess()
-    deploymentInfo['DeploymentConfig']['bar'][0].deploymentId == "bar-124"
+    deploymentInfo['DeploymentConfig/bar'][0].deploymentId == "bar-124"
 
     // test artifact URIS
     def buildArtifacts = context.getBuildArtifactURIs()
     buildArtifacts.size() > 0
     buildArtifacts.deployments.containsKey(config.componentId)
-    buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo['DeploymentConfig']['bar'][0].deploymentId
+    buildArtifacts.deployments[config.componentId].deploymentId == deploymentInfo['DeploymentConfig/bar'][0].deploymentId
 
     1 * openShiftService.tailorApply(
       'foo-dev',


### PR DESCRIPTION
Replaces the brittle map. I'm converting back to a `Map` when we handover to the orchestration pipeline to avoid any changes there. Eventually the orchestration pipeline should work with the `PodData` type.

Closes #529.

Note that we need to merge https://github.com/opendevstack/ods-quickstarters/pull/523 at the same time to avoid CI failures.