### PR TITLE
Fix updating of link destinations to superseded issues

### DIFF
--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -1488,6 +1488,34 @@ class Project {
             return left
         }
 
+        def updateIssueLinks = { issue, index ->
+            issue.collectEntries { String type, value ->
+                if(JiraDataItem.TYPES.contains(type)) {
+                    def newLinks = value.collect { link ->
+                        def newLink = index[link]
+                        newLink?:link
+                    }.unique()
+                    [(type): newLinks]
+                } else {
+                    [(type): value]
+                }
+            }
+        }
+
+        def updateLinks = { data, index ->
+            data.collectEntries { issueType, content ->
+                if(JiraDataItem.TYPES.contains(issueType)) {
+                    def updatedIssues = content.collectEntries { String issueKey, Map issue ->
+                        def updatedIssue = updateIssueLinks(issue, index)
+                        [(issueKey): updatedIssue]
+                    }
+                    [(issueType): updatedIssues]
+                } else {
+                    [(issueType): content]
+                }
+            }
+        }
+
         if (!oldData || oldData.isEmpty()) {
             newData
         } else {
@@ -1501,15 +1529,17 @@ class Project {
 
             // Update data from previous version
             def oldDataWithUpdatedLinks = updateIssues(oldData, newDataExpanded)
-            def obsoleteKeys = discontinuations + getPreceededKeys(newDataExpanded)
+            def successorIndex = getSuccessorIndex(newDataExpanded)
+            def newDataExpandedWithUpdatedLinks = updateLinks(newDataExpanded, successorIndex)
+            def obsoleteKeys = discontinuations + successorIndex.keySet()
             def oldDataWithoutObsoletes = removeObsoleteIssues(oldDataWithUpdatedLinks, obsoleteKeys)
 
             // merge old component data to new for the existing components
-            newDataExpanded[JiraDataItem.TYPE_COMPONENTS] = newDataExpanded[JiraDataItem.TYPE_COMPONENTS]
+            newDataExpandedWithUpdatedLinks[JiraDataItem.TYPE_COMPONENTS] = newDataExpandedWithUpdatedLinks[JiraDataItem.TYPE_COMPONENTS]
                 .collectEntries { compN, v ->
                     [ (compN): (oldDataWithoutObsoletes[JiraDataItem.TYPE_COMPONENTS][compN] ?: v)]
                 }
-            mergeMaps(oldDataWithoutObsoletes, newDataExpanded)
+            mergeMaps(oldDataWithoutObsoletes, newDataExpandedWithUpdatedLinks)
         }
     }
 
@@ -1623,15 +1653,19 @@ class Project {
     /**
      * Expected format is:
      *   issueType.issue."expandedPredecessors" -> [key:"", version:""]
+     *   Note that an issue can only have a single successor in a single given version.
+     *   An issue can only have multiple successors if they belong to different succeeding versions.
      * @param jiraData map of jira data
-     * @return keys of preceeded issues
+     * @return a Map with the issue keys as values and their respective predecessor keys as keys
      */
-    private static List getPreceededKeys(Map jiraData) {
-        jiraData.findAll { JiraDataItem.TYPES.contains(it.key) }.values().collect { issueGroup ->
-            issueGroup.values().collect { issue ->
-                [(issue.expandedPredecessors ?: []).collect { it.key }]
+    private static Map getSuccessorIndex(Map jiraData) {
+        def index = [:]
+        jiraData.findAll { JiraDataItem.TYPES.contains(it.key) }.values().each { issueGroup ->
+            issueGroup.values().each { issue ->
+                (issue.expandedPredecessors ?: []).each { index[it.key] = issue.key }
             }
-        }.flatten().unique()
+        }
+        return index
     }
 
     /**


### PR DESCRIPTION
When creating documents, data from one version and its preceding versions is merged.
Links between issues existing in older versions are inherited in newer versions.
Until now, if a link destination had been succeeded, the inherited link was not updated accordingly and kept pointing to the superseded issue. Therefore, after removing superseded issues from the model, this kind of link was broken and caused NullPointerException's.
This fix updates link destinations so that they point to successor issues.