### PR TITLE
Include a better filter for the technical specifications

### DIFF
--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -834,7 +834,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         def componentsMetadata = SortUtil.sortIssuesByKey(this.computeComponentMetadata(documentType).values())
         def systemDesignSpecifications = this.project.getTechnicalSpecifications()
-            .findAll { it.systemDesignSpec }
+            .findAll { it.systemDesignSpec || !it.softwareDesignSpec }
             .collect { techSpec ->
                 [
                     key        : techSpec.key,
@@ -888,7 +888,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             return this.pdf.merge(documents)
         }
 
-        def keysInDoc = (this.project.getTechnicalSpecifications().findAll { it.systemDesignSpec }
+        def keysInDoc = (this.project.getTechnicalSpecifications()
             .collect { it.subMap(['key', 'requirements']).values() }.flatten()
         + componentsMetadata.collect { it.key }
         + modules.collect { it.subMap(['requirementKeys', 'softwareDesignSpecKeys']).values() }.flatten())
@@ -1209,7 +1209,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         tests.collect { testIssue ->
             def softwareDesignSpecs = testIssue.getResolvedTechnicalSpecifications()
-                .findAll { it.softwareDesignSpec }.collect { it.key }
+                .findAll { it.softwareDesignSpec }
+                .collect { it.key }
             def riskLevels = testIssue.getResolvedRisks(). collect {
                 def value = obtainEnum("SeverityOfImpact", it.severityOfImpact)
                 return value ? value.text : "None"
@@ -1298,7 +1299,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             def metadata = repo_.metadata
 
             def sowftwareDesignSpecs = component.getResolvedTechnicalSpecifications()
-                .findAll { it.softwareDesignSpec }
+                .findAll { it.softwareDesignSpec || !it.systemDesignSpec }
                 .collect { [key: it.key, softwareDesignSpec: this.convertImages(it.softwareDesignSpec)] }
 
             return [

--- a/test/groovy/util/FixtureHelper.groovy
+++ b/test/groovy/util/FixtureHelper.groovy
@@ -63,6 +63,7 @@ class FakeProject extends Project {
 
         this.data.jira.undone = this.computeWipJiraIssues(this.data.jira)
         this.data.jira.undone.docChapters = [:]
+        this.data.jira[Project.JiraDataItem.TYPE_DOCS] = this.loadDocs()
 
         this.data.documents = [:]
         this.data.openshift = [:]
@@ -123,6 +124,19 @@ class FakeProject extends Project {
     void setRepositories(List repos) {
         this.data.metadata.repositories = repos
     }
+
+    Map loadDocs(){
+        return ["doc1": [
+                    "key": "DOC-1",
+                    "version": "1.0",
+                    "name": "name",
+                    "number": "1",
+                    "documents":["SSDS"],
+                    "section": "sec1",
+                    "content": "myContent"
+                ]]
+    }
+
 }
 
 class FixtureHelper {

--- a/test/resources/project-jira-data.json
+++ b/test/resources/project-jira-data.json
@@ -289,17 +289,6 @@
             ]
         }
     },
-    "docs": {
-        "doc1": {
-            "key": "DOC-1",
-            "version": "1.0",
-            "name": "name",
-            "number": "1",
-            "documents":["SSDS"],
-            "section": "sec1",
-            "content": "myContent"
-        }
-    },
     "tests": {
         "NET-127": {
             "key": "NET-127",

--- a/test/resources/project-jira-data.json
+++ b/test/resources/project-jira-data.json
@@ -289,6 +289,17 @@
             ]
         }
     },
+    "docs": {
+        "doc1": {
+            "key": "DOC-1",
+            "version": "1.0",
+            "name": "name",
+            "number": "1",
+            "documents":["SSDS"],
+            "section": "sec1",
+            "content": "myContent"
+        }
+    },
     "tests": {
         "NET-127": {
             "key": "NET-127",


### PR DESCRIPTION
When a tech spec does not have software of design specification it is render on the pdf, and if it has any of them, it is displayed on the proper section of the SSDS document