### PR TITLE
Always build image in orchestration pipeline

### DIFF
--- a/src/org/ods/component/BuildOpenShiftImageStage.groovy
+++ b/src/org/ods/component/BuildOpenShiftImageStage.groovy
@@ -22,8 +22,13 @@ class BuildOpenShiftImageStage extends Stage {
         super(script, context, config, logger)
         // If user did not explicitly define which branches to build images for,
         // build images for all branches which are mapped (deployed) to an environment.
+        // In orchestration pipelines, always build the image.
         if (!config.containsKey('branches') && !config.containsKey('branch')) {
-            config.branches = context.branchToEnvironmentMapping.keySet().toList()
+            if (context.triggeredByOrchestrationPipeline) {
+                config.branch = context.gitBranch
+            } else {
+                config.branches = context.branchToEnvironmentMapping.keySet().toList()
+            }
         }
         if (!config.resourceName) {
             config.resourceName = context.componentId


### PR DESCRIPTION
Before https://github.com/opendevstack/ods-jenkins-shared-library/pull/517, an image was built if an environment was determined. In an orchestration context, an environment is always given, which means an image would have been built always. #517 accidentally changed that behaviour - an image would not have been built when no environment was selected via the branchToEnvironmentMapping.

The problem only affects `master` under certain configuration combinations (e.g. when `release/` branches are not configured, and a commit is made to a release branch but not to master first). That is why the quickstarter tests pass prior to this fix.