### PR TITLE
Allow image references to *-cd project

### DIFF
--- a/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/FinalizeOdsComponent.groovy
@@ -147,13 +147,15 @@ class FinalizeOdsComponent {
         }
 
         def imagesFromOtherProjectsFail = []
+        // All images in *-cd are also present in *-dev, *-test, etc. so even
+        // if the underlying image points to *-cd, we can continue.
+        def excludedProjects = MROPipelineUtil.EXCLUDE_NAMESPACES_FROM_IMPORT + ["${project.key}-cd"]
         odsBuiltDeploymentInformation.each { String odsBuiltDeploymentName, Map odsBuiltDeployment ->
             odsBuiltDeployment.containers?.each { String containerName, String containerImage ->
                 def owningProject = os.imageInfoWithShaForImageStreamUrl(containerImage).repository
-                if (project.targetProject != owningProject
-                    && !MROPipelineUtil.EXCLUDE_NAMESPACES_FROM_IMPORT.contains(owningProject)) {
+                if (project.targetProject != owningProject && !excludedProjects.contains(owningProject)) {
                     def msg = "Deployment: ${odsBuiltDeploymentName} / " +
-                        "Container: ${containerName} / Owner: ${owningProject}"
+                        "Container: ${containerName} / Owner: ${owningProject}/ Excluded Projects: ${excludedProjects}"
                     logger.warn "! Image out of scope! ${msg}"
                     imagesFromOtherProjectsFail << msg
                 }

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -947,6 +947,11 @@ class OpenShiftService {
             pod.podStatus = podOCData.status?.phase ?: 'N/A'
             pod.podStartupTimeStamp = podOCData.status?.startTime ?: 'N/A'
             pod.containers = [:]
+            // We need to get the image SHA from the containerStatuses, and not
+            // from the pod spec because the pod spec image field is optional
+            // and may not contain an image SHA, but e.g. a tag, depending on
+            // the pod manager (e.g. ReplicationController, ReplicaSet). See
+            // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core.
             podOCData.spec?.containers?.each { container ->
                 podOCData.status?.containerStatuses?.each { containerStatus ->
                     if (containerStatus.name == container.name) {


### PR DESCRIPTION
Fixes #547. It's not the best fix, but a quick one. I might follow this up in the new year by updating how we check those SHAs are controlled by ODS.

As a side note, the pod spec cannot be used, see
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core.
The `image` field is optional, and is filled by the pod manager (e.g.
ReplicationController, ReplicaSet) and may not contain an image SHA.

Still trying to finish one RM test run successfully ... manually it works but the test is very flaky in my env :(