### PR TITLE
[orchestration] Move repo execution from util to each stage 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ codenarc {
     configFile = file('codenarc.groovy')
     maxPriority1Violations = 0
     maxPriority2Violations = 0
-    maxPriority3Violations = 321
+    maxPriority3Violations = 255
     reportFormat = 'html'
 }
 

--- a/codenarc.groovy
+++ b/codenarc.groovy
@@ -382,7 +382,7 @@ ruleset {
     UnnecessaryCallToSubstring
     UnnecessaryCast
     UnnecessaryCatchBlock
-    UnnecessaryCollectCall
+    UnnecessaryCollectCall(enabled: false)
     UnnecessaryCollectionCall
     UnnecessaryConstructor
     UnnecessaryDefInFieldDeclaration(enabled: false)

--- a/codenarc.groovy
+++ b/codenarc.groovy
@@ -275,7 +275,7 @@ ruleset {
     UseCollectNested
 
     // rulesets/imports.xml
-    DuplicateImport
+    DuplicateImport(priority: 1)
     ImportFromSamePackage
     ImportFromSunPackages
     MisorderedStaticImports

--- a/src/org/ods/orchestration/BuildStage.groovy
+++ b/src/org/ods/orchestration/BuildStage.groovy
@@ -1,14 +1,15 @@
 package org.ods.orchestration
 
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+
 import org.ods.orchestration.scheduler.LeVADocumentScheduler
 import org.ods.orchestration.usecase.JiraUseCase
 import org.ods.orchestration.util.MROPipelineUtil
 import org.ods.orchestration.util.Project
 import org.ods.services.ServiceRegistry
-import org.ods.util.PipelineSteps
-import org.ods.util.Logger
-import org.ods.util.ILogger
 
+@TypeChecked
 class BuildStage extends Stage {
 
     public final String STAGE_NAME = 'Build'
@@ -17,65 +18,83 @@ class BuildStage extends Stage {
         super(script, project, repos, startMROStageName)
     }
 
-    @SuppressWarnings('ParameterName')
     def run() {
-        def steps = ServiceRegistry.instance.get(PipelineSteps)
-        def jira = ServiceRegistry.instance.get(JiraUseCase)
         def util = ServiceRegistry.instance.get(MROPipelineUtil)
         def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
-        ILogger logger = ServiceRegistry.instance.get(Logger)
 
         def phase = MROPipelineUtil.PipelinePhases.BUILD
 
-        def preExecuteRepo = { steps_, repo ->
+        def preExecuteRepo = { Map repo ->
             levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO, repo)
         }
 
-        def postExecuteRepo = { steps_, repo ->
-            // FIXME: we are mixing a generic scheduler capability with a data
-            // dependency and an explicit repository constraint.
-            // We should turn the last argument 'data' of the scheduler into a
-            // closure that return data.
-            if (project.isAssembleMode
-                && repo.type?.toLowerCase() == MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_CODE) {
-                def data = [ : ]
-                def resultsResurrected = !!repo.data.openshift.resurrectedBuild
-                if (!resultsResurrected) {
-                    data << [tests: [unit: getTestResults(steps, repo) ]]
-                    jira.reportTestResultsForComponent(
-                        "Technology-${repo.id}",
-                        [Project.TestType.UNIT],
-                        data.tests.unit.testResults
-                    )
-                } else {
-                    logger.info("[${repo.id}] Resurrected tests from run " +
-                        "${repo.data.openshift.resurrectedBuild} " +
-                        "- no unit tests results will be reported")
-                }
-
-                levaDocScheduler.run(
-                    phase,
-                    MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO,
-                    repo,
-                    data
-                )
+        Closure executeRepo = { Map repo ->
+            switch (util.repoType(repo)) {
+                case MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_CODE:
+                case MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SERVICE:
+                    if (this.project.isAssembleMode) {
+                        util.executeODSComponent(repo)
+                    } else {
+                        util.logRepoSkip(phase, repo)
+                    }
+                    break
+                case MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST:
+                    util.logRepoSkip(phase, repo)
+                    break
+                default:
+                    util.runCustomInstructionsForPhaseOrSkip(phase, repo)
+                    break
             }
+        }
+
+        def postExecuteRepo = { Map repo ->
+            runPostExecuteRepo(util, levaDocScheduler, repo)
         }
 
         Closure generateDocuments = {
             levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
         }
 
-        // Execute phase for each repository
-        Closure executeRepos = {
-            util.prepareExecutePhaseForReposNamedJob(phase, repos, preExecuteRepo, postExecuteRepo)
-                .each { group ->
-                    group.failFast = true
-                    script.parallel(group)
-                }
+        Closure executeRepoGroups = {
+            util.executeRepoGroups(repos, executeRepo, preExecuteRepo, postExecuteRepo)
         }
-        executeInParallel(executeRepos, generateDocuments)
+
+        executeInParallel(executeRepoGroups, generateDocuments)
+
         levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private runPostExecuteRepo(MROPipelineUtil util, LeVADocumentScheduler levaDocScheduler, Map repo) {
+        def jira = ServiceRegistry.instance.get(JiraUseCase)
+        // FIXME: we are mixing a generic scheduler capability with a data
+        // dependency and an explicit repository constraint.
+        // We should turn the last argument 'data' of the scheduler into a
+        // closure that return data.
+        if (this.project.isAssembleMode
+            && util.repoType(repo) == MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_CODE) {
+            def data = [ : ]
+            def resultsResurrected = !!repo.data.openshift.resurrectedBuild
+            if (resultsResurrected) {
+                this.logger.info("[${repo.id}] Resurrected tests from run " +
+                    "${repo.data.openshift.resurrectedBuild} " +
+                    "- no unit tests results will be reported")
+            } else {
+                data << [tests: [unit: getTestResults(this.steps, repo) ]]
+                jira.reportTestResultsForComponent(
+                    "Technology-${repo.id}".toString(),
+                    [Project.TestType.UNIT],
+                    data.tests.unit.testResults as Map
+                )
+            }
+
+            levaDocScheduler.run(
+                MROPipelineUtil.PipelinePhases.BUILD,
+                MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO,
+                repo,
+                data
+            )
+        }
     }
 
 }

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -16,8 +16,6 @@ import org.ods.orchestration.util.MROPipelineUtil
 
 import org.ods.util.GitCredentialStore
 import org.ods.util.PipelineSteps
-import org.ods.util.Logger
-import org.ods.util.ILogger
 
 @SuppressWarnings('AbcMetric')
 class InitStage extends Stage {
@@ -30,8 +28,6 @@ class InitStage extends Stage {
 
     @SuppressWarnings(['CyclomaticComplexity', 'NestedBlockDepth', 'GStringAsMapKey', 'LineLength'])
     def run() {
-        ILogger logger = ServiceRegistry.instance.get(Logger)
-        def steps = new PipelineSteps(script)
         def git = new GitService(steps, logger)
 
         // load build params
@@ -41,7 +37,7 @@ class InitStage extends Stage {
         // Read the environment state on main branch. We do not want to read
         // the state file on a release branch, as that might be stale (e.g. due
         // to concurrent releases).
-        def envState = loadEnvState(logger, buildParams.targetEnvironment)
+        def envState = loadEnvState(buildParams.targetEnvironment)
 
         logger.startClocked("git-releasemanager-${STAGE_NAME}")
         // git checkout
@@ -90,7 +86,6 @@ class InitStage extends Stage {
         def registry = ServiceRegistry.instance
         registry.add(GitService, git)
         registry.add(PDFUtil, new PDFUtil())
-        registry.add(PipelineSteps, steps)
         def util = new MROPipelineUtil(project, steps, git, logger)
         registry.add(MROPipelineUtil, util)
         registry.add(Project, project)
@@ -407,15 +402,15 @@ class InitStage extends Stage {
         ])
     }
 
-    private Map loadEnvState(ILogger logger, String targetEnvironment) {
+    private Map loadEnvState(String targetEnvironment) {
         def envStateFile = "${Project.envStateFileName(targetEnvironment)}"
-        logger.info "Load env state from ${envStateFile}"
+        this.logger.info "Load env state from ${envStateFile}"
         script.sh("mkdir -p ${MROPipelineUtil.ODS_STATE_DIR}")
         if (!script.fileExists(envStateFile)) {
-            logger.debug "No env state ${envStateFile} found, initializing ..."
+            this.logger.debug "No env state ${envStateFile} found, initializing ..."
             return [:]
         }
-        logger.debug "Env state ${envStateFile} found"
+        this.logger.debug "Env state ${envStateFile} found"
         script.readJSON(file: envStateFile)
     }
 

--- a/src/org/ods/orchestration/TestStage.groovy
+++ b/src/org/ods/orchestration/TestStage.groovy
@@ -1,13 +1,16 @@
 package org.ods.orchestration
 
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+
 import org.ods.services.ServiceRegistry
 import org.ods.orchestration.scheduler.LeVADocumentScheduler
 import org.ods.orchestration.usecase.JiraUseCase
 import org.ods.orchestration.usecase.JUnitTestReportsUseCase
 import org.ods.orchestration.util.Project
 import org.ods.orchestration.util.MROPipelineUtil
-import org.ods.util.PipelineSteps
 
+@TypeChecked
 class TestStage extends Stage {
 
     public final String STAGE_NAME = 'Test'
@@ -16,11 +19,7 @@ class TestStage extends Stage {
         super(script, project, repos, startMROStageName)
     }
 
-    @SuppressWarnings(['AbcMetric', 'ParameterName'])
     def run() {
-        def steps = ServiceRegistry.instance.get(PipelineSteps)
-        def jira = ServiceRegistry.instance.get(JiraUseCase)
-        def junit = ServiceRegistry.instance.get(JUnitTestReportsUseCase)
         def levaDocScheduler = ServiceRegistry.instance.get(LeVADocumentScheduler)
         def util = ServiceRegistry.instance.get(MROPipelineUtil)
 
@@ -43,58 +42,48 @@ class TestStage extends Stage {
             ]
         ]
 
-        def preExecuteRepo = { steps_, repo ->
+        Closure preExecuteRepo = { Map repo ->
             levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_EXECUTE_REPO, repo)
         }
 
-        def postExecuteRepo = { steps_, repo ->
-            if (repo.type?.toLowerCase() == MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST) {
-                def data = [
-                    tests: [
-                        acceptance: getTestResults(steps, repo, Project.TestType.ACCEPTANCE),
-                        installation: getTestResults(steps, repo, Project.TestType.INSTALLATION),
-                        integration: getTestResults(steps, repo, Project.TestType.INTEGRATION),
-                    ]
-                ]
-
-                jira.reportTestResultsForProject(
-                    [Project.TestType.INSTALLATION],
-                    data.tests.installation.testResults
-                )
-
-                jira.reportTestResultsForProject(
-                    [Project.TestType.INTEGRATION],
-                    data.tests.integration.testResults
-                )
-
-                jira.reportTestResultsForProject(
-                    [Project.TestType.ACCEPTANCE],
-                    data.tests.acceptance.testResults
-                )
-
-                levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO, repo)
-
-                globalData.tests.acceptance.testReportFiles.addAll(data.tests.acceptance.testReportFiles)
-                globalData.tests.installation.testReportFiles.addAll(data.tests.installation.testReportFiles)
-                globalData.tests.integration.testReportFiles.addAll(data.tests.integration.testReportFiles)
+        Closure executeRepo = { Map repo ->
+            switch (util.repoType(repo)) {
+                case MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST:
+                    util.executeODSComponent(repo)
+                    break
+                case MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_CODE:
+                case MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SERVICE:
+                    util.logRepoSkip(phase, repo)
+                    break
+                default:
+                    util.runCustomInstructionsForPhaseOrSkip(phase, repo)
+                    break
             }
+        }
+
+        Closure postExecuteRepo = { Map repo ->
+            runPostExecuteRepo(levaDocScheduler, repo, globalData)
         }
 
         Closure generateDocuments = {
             levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
         }
 
-        // Execute phase for each repository
-        Closure executeRepos = {
-            util.prepareExecutePhaseForReposNamedJob(phase, repos, preExecuteRepo, postExecuteRepo)
-                .each { group ->
-                    group.failFast = true
-                    script.parallel(group)
-                }
+        Closure executeRepoGroups = {
+            util.executeRepoGroups(repos, executeRepo, preExecuteRepo, postExecuteRepo)
         }
-        executeInParallel(executeRepos, generateDocuments)
 
-        // Parse all test report files into a single data structure
+        executeInParallel(executeRepoGroups, generateDocuments)
+
+        parseTestReportFiles(globalData)
+
+        levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END, [:], globalData)
+    }
+
+    // Parse all test report files into a single data structure
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private parseTestReportFiles(Map globalData) {
+        def junit = ServiceRegistry.instance.get(JUnitTestReportsUseCase)
         globalData.tests.acceptance.testResults = junit.parseTestReportFiles(
             globalData.tests.acceptance.testReportFiles
         )
@@ -104,8 +93,46 @@ class TestStage extends Stage {
         globalData.tests.integration.testResults = junit.parseTestReportFiles(
             globalData.tests.integration.testReportFiles
         )
+    }
 
-        levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END, [:], globalData)
+    @SuppressWarnings('AbcMetric')
+    @TypeChecked(TypeCheckingMode.SKIP)
+    private runPostExecuteRepo(LeVADocumentScheduler levaDocScheduler, Map repo, Map globalData) {
+        def jira = ServiceRegistry.instance.get(JiraUseCase)
+        if (repo.type?.toLowerCase() == MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST) {
+            def data = [
+                tests: [
+                    acceptance: getTestResults(this.steps, repo, Project.TestType.ACCEPTANCE),
+                    installation: getTestResults(this.steps, repo, Project.TestType.INSTALLATION),
+                    integration: getTestResults(this.steps, repo, Project.TestType.INTEGRATION),
+                ]
+            ]
+
+            jira.reportTestResultsForProject(
+                [Project.TestType.INSTALLATION],
+                data.tests.installation.testResults
+            )
+
+            jira.reportTestResultsForProject(
+                [Project.TestType.INTEGRATION],
+                data.tests.integration.testResults
+            )
+
+            jira.reportTestResultsForProject(
+                [Project.TestType.ACCEPTANCE],
+                data.tests.acceptance.testResults
+            )
+
+            levaDocScheduler.run(
+                MROPipelineUtil.PipelinePhases.TEST,
+                MROPipelineUtil.PipelinePhaseLifecycleStage.POST_EXECUTE_REPO,
+                repo,
+            )
+
+            globalData.tests.acceptance.testReportFiles.addAll(data.tests.acceptance.testReportFiles)
+            globalData.tests.installation.testReportFiles.addAll(data.tests.installation.testReportFiles)
+            globalData.tests.integration.testReportFiles.addAll(data.tests.integration.testReportFiles)
+        }
     }
 
 }

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -10,7 +10,6 @@ import org.ods.orchestration.dependency.DependencyGraph
 import org.ods.orchestration.dependency.Node
 import org.ods.services.OpenShiftService
 import org.ods.services.ServiceRegistry
-import org.ods.orchestration.util.DeploymentDescriptor
 import org.ods.orchestration.phases.DeployOdsComponent
 import org.ods.orchestration.phases.FinalizeOdsComponent
 import org.yaml.snakeyaml.Yaml
@@ -20,6 +19,7 @@ import org.yaml.snakeyaml.Yaml
 class MROPipelineUtil extends PipelineUtil {
 
     class PipelineConfig {
+
         // TODO: deprecate .pipeline-config.yml in favor of release-manager.yml
         static final List FILE_NAMES = ["release-manager.yml", ".pipeline-config.yml"]
 
@@ -32,17 +32,21 @@ class MROPipelineUtil extends PipelineUtil {
 
         static final List PHASE_EXECUTOR_TYPES = [
             PHASE_EXECUTOR_TYPE_MAKEFILE,
-            PHASE_EXECUTOR_TYPE_SHELLSCRIPT
+            PHASE_EXECUTOR_TYPE_SHELLSCRIPT,
         ]
+
     }
 
     class PipelineEnvs {
+
         static final String DEV = "dev"
         static final String QA = "qa"
         static final String PROD = "prod"
+
     }
 
     class PipelinePhases {
+
         static final String BUILD = "Build"
         static final String DEPLOY = "Deploy"
         static final String FINALIZE = "Finalize"
@@ -51,13 +55,16 @@ class MROPipelineUtil extends PipelineUtil {
         static final String TEST = "Test"
 
         static final List ALWAYS_PARALLEL = []
+
     }
 
     enum PipelinePhaseLifecycleStage {
+
         POST_START,
         PRE_EXECUTE_REPO,
         POST_EXECUTE_REPO,
         PRE_END
+
     }
 
     static final String COMPONENT_METADATA_FILE_NAME = 'metadata.yml'
@@ -275,7 +282,7 @@ class MROPipelineUtil extends PipelineUtil {
                         }
                     }
                 }
-            }
+            },
         ]
     }
 
@@ -296,7 +303,7 @@ class MROPipelineUtil extends PipelineUtil {
             "*/${branch}",
             [
                 [ $class: 'RelativeTargetDirectory', relativeTargetDir: "${REPOS_BASE_DIR}/${repo.id}" ],
-                [ $class: 'LocalBranch', localBranch: "**" ]
+                [ $class: 'LocalBranch', localBranch: "**" ],
             ],
             [[ credentialsId: credentialsId, url: repo.url ]]
         )
@@ -365,7 +372,7 @@ class MROPipelineUtil extends PipelineUtil {
                         postExecute(this.steps, repo)
                     }
                 }
-            }
+            },
         ]
     }
 
@@ -488,7 +495,7 @@ class MROPipelineUtil extends PipelineUtil {
                 OpenShiftService.DEPLOYMENTCONFIG_KIND,
                 deploymentDescriptor.deploymentNames
             )
-        } catch(ex) {
+        } catch (ex) {
             logger.info(
                 "Resurrection of previous build for '${repo.id}' not possible as " +
                 "not all deployments could be retrieved: ${ex.message}"
@@ -518,4 +525,5 @@ class MROPipelineUtil extends PipelineUtil {
         repo.data.openshift.deployments = deployments
         logger.debug("Data from previous Jenkins build:\r${repo.data.openshift}")
     }
+
 }

--- a/src/org/ods/util/IPipelineSteps.groovy
+++ b/src/org/ods/util/IPipelineSteps.groovy
@@ -27,6 +27,8 @@ interface IPipelineSteps {
 
     def node(String name, Closure block)
 
+    def node(Closure block)
+
     def sh(def args)
 
     void stage(String name, Closure block)
@@ -66,6 +68,8 @@ interface IPipelineSteps {
     def sshUserPrivateKey(Map credentialsData)
 
     def withCredentials(List credentialsList, Closure block)
+
+    def parallel(Map<String, Closure> tasks)
 
     def unwrap()
 

--- a/src/org/ods/util/PipelineSteps.groovy
+++ b/src/org/ods/util/PipelineSteps.groovy
@@ -61,7 +61,11 @@ class PipelineSteps implements IPipelineSteps, Serializable {
     }
 
     def node(String name, Closure block) {
-        this.context.node (name, block)
+        this.context.node(name, block)
+    }
+
+    def node(Closure block) {
+        this.context.node(block)
     }
 
     def sh(def args) {
@@ -142,6 +146,10 @@ class PipelineSteps implements IPipelineSteps, Serializable {
 
     def withCredentials(List credentialsList, Closure block) {
         this.context.withCredentials(credentialsList, block)
+    }
+
+    def parallel(Map<String, Closure> tasks) {
+        this.context.parallel(tasks)
     }
 
     def unwrap() {

--- a/test/groovy/org/ods/orchestration/BuildStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/BuildStageSpec.groovy
@@ -1,0 +1,67 @@
+package org.ods.orchestration
+
+import org.ods.PipelineScript
+import org.ods.orchestration.scheduler.LeVADocumentScheduler
+import org.ods.services.ServiceRegistry
+import org.ods.services.GitService
+import org.ods.services.OpenShiftService
+import org.ods.orchestration.usecase.JUnitTestReportsUseCase
+import org.ods.orchestration.usecase.JiraUseCase
+import org.ods.util.IPipelineSteps
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.Project
+import util.SpecHelper
+import util.PipelineSteps
+import org.ods.util.Logger
+import org.ods.util.ILogger
+
+import static util.FixtureHelper.createProject
+
+class BuildStageSpec extends SpecHelper {
+
+    Project project
+    BuildStage buildStage
+    IPipelineSteps steps
+    PipelineScript script
+    MROPipelineUtil util
+    GitService git
+    OpenShiftService openShift
+    LeVADocumentScheduler levaDocScheduler
+    ILogger logger
+
+    def phase = MROPipelineUtil.PipelinePhases.BUILD
+
+    def setup() {
+        this.script = new PipelineScript()
+        this.steps = new PipelineSteps()
+        this.levaDocScheduler = Mock(LeVADocumentScheduler)
+        this.project = Spy(createProject())
+        this.util = Mock(MROPipelineUtil)
+        this.git = Mock(GitService)
+        this.openShift = Mock(OpenShiftService)
+        this.logger = new Logger(script, !!script.env.DEBUG)
+
+        ServiceRegistry.instance.add(org.ods.util.PipelineSteps, this.steps)
+        ServiceRegistry.instance.add(LeVADocumentScheduler, this.levaDocScheduler)
+        ServiceRegistry.instance.add(MROPipelineUtil, this.util)
+        ServiceRegistry.instance.add(GitService, this.git)
+        ServiceRegistry.instance.add(OpenShiftService, this.openShift)
+        ServiceRegistry.instance.add(Logger, this.logger)
+
+        this.buildStage = Spy(new BuildStage(this.script, this.project, this.project.repositories, null))
+    }
+
+    def "succesful execution"() {
+        given:
+        this.steps.env >> [WORKSPACE: "", BUILD_ID: 1]
+
+        when:
+        buildStage.execute()
+
+        then:
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
+        1 * util.executeRepoGroups(*_)
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
+    }
+
+}

--- a/test/groovy/org/ods/orchestration/DeployStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/DeployStageSpec.groovy
@@ -1,0 +1,67 @@
+package org.ods.orchestration
+
+import org.ods.PipelineScript
+import org.ods.orchestration.scheduler.LeVADocumentScheduler
+import org.ods.services.ServiceRegistry
+import org.ods.services.GitService
+import org.ods.services.OpenShiftService
+import org.ods.orchestration.usecase.JUnitTestReportsUseCase
+import org.ods.orchestration.usecase.JiraUseCase
+import org.ods.util.IPipelineSteps
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.Project
+import util.SpecHelper
+import util.PipelineSteps
+import org.ods.util.Logger
+import org.ods.util.ILogger
+
+import static util.FixtureHelper.createProject
+
+class DeployStageSpec extends SpecHelper {
+
+    Project project
+    DeployStage deployStage
+    IPipelineSteps steps
+    PipelineScript script
+    MROPipelineUtil util
+    GitService git
+    OpenShiftService openShift
+    LeVADocumentScheduler levaDocScheduler
+    ILogger logger
+
+    def phase = MROPipelineUtil.PipelinePhases.DEPLOY
+
+    def setup() {
+        this.script = new PipelineScript()
+        this.steps = new PipelineSteps()
+        this.levaDocScheduler = Mock(LeVADocumentScheduler)
+        this.project = Spy(createProject())
+        this.util = Mock(MROPipelineUtil)
+        this.git = Mock(GitService)
+        this.openShift = Mock(OpenShiftService)
+        this.logger = new Logger(script, !!script.env.DEBUG)
+
+        ServiceRegistry.instance.add(org.ods.util.PipelineSteps, this.steps)
+        ServiceRegistry.instance.add(LeVADocumentScheduler, this.levaDocScheduler)
+        ServiceRegistry.instance.add(MROPipelineUtil, this.util)
+        ServiceRegistry.instance.add(GitService, this.git)
+        ServiceRegistry.instance.add(OpenShiftService, this.openShift)
+        ServiceRegistry.instance.add(Logger, this.logger)
+
+        this.deployStage = Spy(new DeployStage(this.script, this.project, this.project.repositories, null))
+    }
+
+    def "succesful execution"() {
+        given:
+        this.steps.env >> [WORKSPACE: "", BUILD_ID: 1]
+
+        when:
+        deployStage.execute()
+
+        then:
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
+        1 * util.executeRepoGroups(*_)
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
+    }
+
+}

--- a/test/groovy/org/ods/orchestration/FinalizeStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/FinalizeStageSpec.groovy
@@ -1,0 +1,77 @@
+package org.ods.orchestration
+
+import org.ods.PipelineScript
+import org.ods.orchestration.scheduler.LeVADocumentScheduler
+import org.ods.services.ServiceRegistry
+import org.ods.services.GitService
+import org.ods.services.OpenShiftService
+import org.ods.services.BitbucketService
+import org.ods.orchestration.usecase.JUnitTestReportsUseCase
+import org.ods.orchestration.usecase.JiraUseCase
+import org.ods.util.IPipelineSteps
+import org.ods.util.PipelineSteps
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.Project
+import util.SpecHelper
+import util.PipelineSteps
+import org.ods.util.Logger
+import org.ods.util.ILogger
+
+import static util.FixtureHelper.createProject
+
+class FinalizeStageSpec extends SpecHelper {
+
+    Project project
+    FinalizeStage finalizeStage
+    IPipelineSteps steps
+    PipelineScript script
+    MROPipelineUtil util
+    GitService git
+    OpenShiftService openShift
+    BitbucketService bitbucket
+    LeVADocumentScheduler levaDocScheduler
+    ILogger logger
+
+    def phase = MROPipelineUtil.PipelinePhases.FINALIZE
+
+    def setup() {
+        this.script = new PipelineScript()
+        this.steps = new PipelineSteps()
+        this.levaDocScheduler = Mock(LeVADocumentScheduler)
+        this.project = Spy(createProject())
+        this.util = Mock(MROPipelineUtil)
+        this.git = Mock(GitService)
+        this.openShift = Mock(OpenShiftService)
+        this.bitbucket = Mock(BitbucketService)
+        this.logger = new Logger(script, !!script.env.DEBUG)
+
+        ServiceRegistry.instance.add(org.ods.util.PipelineSteps, this.steps)
+        ServiceRegistry.instance.add(LeVADocumentScheduler, this.levaDocScheduler)
+        ServiceRegistry.instance.add(MROPipelineUtil, this.util)
+        ServiceRegistry.instance.add(GitService, this.git)
+        ServiceRegistry.instance.add(OpenShiftService, this.openShift)
+        ServiceRegistry.instance.add(BitbucketService, this.bitbucket)
+        ServiceRegistry.instance.add(Logger, this.logger)
+
+        this.finalizeStage = Spy(new FinalizeStage(this.script, this.project, this.project.repositories))
+    }
+
+    def "succesful execution"() {
+        given:
+        this.steps.env >> [WORKSPACE: "", BUILD_ID: 1]
+        this.openShift.envExists(_) >> true
+        finalizeStage.runOnAgentPod(_, _) >> { condition, block -> block() }
+
+        when:
+        finalizeStage.execute()
+
+        then:
+        // TODO: Should this be called? All other stages call this ...
+        //       This test was written after the stage was already widely in used
+        //       so it looks like it's not needed, but I'm not sure if it's correct.
+        // 1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
+        1 * util.executeRepoGroups(*_)
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
+    }
+
+}

--- a/test/groovy/org/ods/orchestration/ReleaseStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/ReleaseStageSpec.groovy
@@ -1,0 +1,56 @@
+package org.ods.orchestration
+
+import org.ods.PipelineScript
+import org.ods.orchestration.scheduler.LeVADocumentScheduler
+import org.ods.services.ServiceRegistry
+import org.ods.orchestration.usecase.JUnitTestReportsUseCase
+import org.ods.orchestration.usecase.JiraUseCase
+import org.ods.util.IPipelineSteps
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.Project
+import util.SpecHelper
+import util.PipelineSteps
+import org.ods.util.Logger
+import org.ods.util.ILogger
+
+import static util.FixtureHelper.createProject
+
+class ReleaseStageSpec extends SpecHelper {
+
+    Project project
+    ReleaseStage releaseStage
+    IPipelineSteps steps
+    PipelineScript script
+    MROPipelineUtil util
+    LeVADocumentScheduler levaDocScheduler
+    ILogger logger
+
+    def phase = MROPipelineUtil.PipelinePhases.RELEASE
+
+    def setup() {
+        this.script = new PipelineScript()
+        this.steps = new PipelineSteps()
+        this.levaDocScheduler = Mock(LeVADocumentScheduler)
+        this.project = Spy(createProject())
+        this.util = Mock(MROPipelineUtil)
+        this.logger = new Logger(script, !!script.env.DEBUG)
+
+        ServiceRegistry.instance.add(org.ods.util.PipelineSteps, this.steps)
+        ServiceRegistry.instance.add(LeVADocumentScheduler, this.levaDocScheduler)
+        ServiceRegistry.instance.add(MROPipelineUtil, this.util)
+        ServiceRegistry.instance.add(Logger, this.logger)
+
+        this.releaseStage = Spy(new ReleaseStage(this.script, this.project, this.project.repositories))
+    }
+
+    def "succesful execution"() {
+        when:
+        releaseStage.execute()
+
+        then:
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.POST_START)
+        1 * util.executeRepoGroups(*_)
+        1 * levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
+    }
+
+}

--- a/test/groovy/org/ods/orchestration/util/MROPipelineUtilSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/MROPipelineUtilSpec.groovy
@@ -579,4 +579,34 @@ class MROPipelineUtilSpec extends SpecHelper {
         then:
         noExceptionThrown() // pipeline does not stop here
     }
+
+    def "execute repos in groups"() {
+        given:
+        Set<Map> repoGroupA = [ [id: 'x', type: 'ods'], [id: 'y', type: 'ods'] ]
+        Set<Map> repoGroupB = [ [id: 'z', type: 'ods'] ]
+        List<Set<Map>> repoGroups = [ repoGroupA, repoGroupB ]
+        Closure preRepoExecute = { Map repo -> logger.info("preRepoExecute: ${repo.id}") }
+        Closure repoExecute = { Map repo -> logger.info("repoExecute: ${repo.id}") }
+        Closure postRepoExecute = { Map repo -> logger.info("postRepoExecute: ${repo.id}") }
+        def repoBaseDir = "${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}"
+
+        when:
+        util.executeRepoGroups(repoGroups, repoExecute, preRepoExecute, postRepoExecute)
+
+        then:
+        1 * logger.debug("Executing repo group consisting of: [x, y]")
+        1 * logger.debug("Executing repo group consisting of: [z]")
+        1 * logger.info("preRepoExecute: x")
+        1 * steps.dir("${repoBaseDir}/x", _)
+        1 * logger.info("repoExecute: x")
+        1 * logger.info("postRepoExecute: x")
+        1 * logger.info("preRepoExecute: y")
+        1 * steps.dir("${repoBaseDir}/y", _)
+        1 * logger.info("repoExecute: y")
+        1 * logger.info("postRepoExecute: y")
+        1 * logger.info("preRepoExecute: z")
+        1 * steps.dir("${repoBaseDir}/z", _)
+        1 * logger.info("repoExecute: z")
+        1 * logger.info("postRepoExecute: z")
+    }
 }

--- a/test/groovy/util/PipelineSteps.groovy
+++ b/test/groovy/util/PipelineSteps.groovy
@@ -148,7 +148,15 @@ class PipelineSteps implements IPipelineSteps {
       return [:]
     }
 
-    def node (String name, Closure block) {
-      block ()
+    def node(Closure block) {
+      block()
+    }
+
+    def node(String name, Closure block) {
+      block()
+    }
+
+    def parallel(Map<String, Closure> tasks) {
+        tasks.findAll { name, _ -> name != "failFast" }.each { name, block -> block() }
     }
 }


### PR DESCRIPTION
tl;dr

Currently what's happening in each stage (build, deploy, test, release, finalize) for each repo is defined in one huge method in `MROPipelineUtil`. This method is complicated to read, error prone and untested. Further it's "far away" from the stage, and the way it's called from each stage is quite complicated to trace IMO. The PR moves the code of what is happening for each repo into each stage class, making it much easier to follow what's going on.

Long version: 

This should make it much easier to follow what's going on. The previous
version was so difficult to understand that each time I looked at it, I
had to trace the flow again. This was even more complicated by the fact
that the previous version used incorrect method types (which Jenkins
ignores), and no tests were written for those methods, either.

The new version should be simpler to understand, and has tests. Further, all
stages are now type checked, and there is at least one test run to
verify the bare minimum.

Note that this PR led me to discover issue https://github.com/opendevstack/ods-jenkins-shared-library/issues/555. In this PR, the behaviour was kept as-is so far though ... 

The quickstarter test for the `release-manager` quickstarter passes. 