### PR TITLE
(orchestration) fail build after ALL unit tests have been executed - master

### DIFF
--- a/src/org/ods/orchestration/BuildStage.groovy
+++ b/src/org/ods/orchestration/BuildStage.groovy
@@ -17,7 +17,7 @@ class BuildStage extends Stage {
         super(script, project, repos, startMROStageName)
     }
 
-    @SuppressWarnings('ParameterName')
+    @SuppressWarnings(['ParameterName', 'AbcMetric'])
     def run() {
         def steps = ServiceRegistry.instance.get(PipelineSteps)
         def jira = ServiceRegistry.instance.get(JiraUseCase)

--- a/src/org/ods/orchestration/BuildStage.groovy
+++ b/src/org/ods/orchestration/BuildStage.groovy
@@ -88,7 +88,7 @@ class BuildStage extends Stage {
         def failedRepos = repos.flatten().findAll { it.data?.failedStage }
         if (project.isAssembleMode && project.isWorkInProgress &&
             (project.hasFailingTests || failedRepos.size > 0)) {
-            util.failBuild ("Failing build as repositoies contain errors!\nFailed: ${failedRepos}")
+            util.failBuild("Failing build as repositories contain errors!\nFailed: ${failedRepos}")
         }
     }
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -111,6 +111,7 @@ class MROPipelineUtil extends PipelineUtil {
             this.logger.debug("Collected ODS build artifacts for repo '${repo.id}': ${repo.data.openshift}")
 
             if (buildArtifacts.failedStage) {
+                repo.data << ['failedStage', buildArtifacts.failedStage]
                 if (failfast) {
                     throw new RuntimeException("Error: aborting due to previous errors in repo '${repo.id}'.")
                 } else {

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -111,7 +111,7 @@ class MROPipelineUtil extends PipelineUtil {
             this.logger.debug("Collected ODS build artifacts for repo '${repo.id}': ${repo.data.openshift}")
 
             if (buildArtifacts.failedStage) {
-                repo.data << ['failedStage', buildArtifacts.failedStage]
+                repo.data << ['failedStage': buildArtifacts.failedStage]
                 if (failfast) {
                     throw new RuntimeException("Error: aborting due to previous errors in repo '${repo.id}'.")
                 } else {

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -85,7 +85,7 @@ class MROPipelineUtil extends PipelineUtil {
         }
     }
 
-    private void executeODSComponent(Map repo, String baseDir) {
+    private void executeODSComponent(Map repo, String baseDir, boolean failfast = true) {
         this.steps.dir(baseDir) {
             if (repo.data.openshift.resurrectedBuild) {
                 logger.info("Repository '${repo.id}' is in sync with OpenShift, no need to rebuild")
@@ -111,7 +111,11 @@ class MROPipelineUtil extends PipelineUtil {
             this.logger.debug("Collected ODS build artifacts for repo '${repo.id}': ${repo.data.openshift}")
 
             if (buildArtifacts.failedStage) {
-                throw new RuntimeException("Error: aborting due to previous errors in repo '${repo.id}'.")
+                if (failfast) {
+                    throw new RuntimeException("Error: aborting due to previous errors in repo '${repo.id}'.")
+                } else {
+                    this.logger.warn("Got errors in repo '${repo.id}', will fail delayed.")
+                }
             }
         }
     }
@@ -316,7 +320,7 @@ class MROPipelineUtil extends PipelineUtil {
 
                     if (repo.type?.toLowerCase() == PipelineConfig.REPO_TYPE_ODS_CODE) {
                         if (this.project.isAssembleMode && name == PipelinePhases.BUILD) {
-                            executeODSComponent(repo, baseDir)
+                            executeODSComponent(repo, baseDir, false)
                         } else if (this.project.isPromotionMode && name == PipelinePhases.DEPLOY) {
                             new DeployOdsComponent(project, steps, git, logger).run(repo, baseDir)
                         } else if (this.project.isAssembleMode && name == PipelinePhases.FINALIZE) {
@@ -326,7 +330,7 @@ class MROPipelineUtil extends PipelineUtil {
                         }
                     } else if (repo.type?.toLowerCase() == PipelineConfig.REPO_TYPE_ODS_SERVICE) {
                         if (this.project.isAssembleMode && name == PipelinePhases.BUILD) {
-                            executeODSComponent(repo, baseDir)
+                            executeODSComponent(repo, baseDir, false)
                         } else if (this.project.isPromotionMode && name == PipelinePhases.DEPLOY) {
                             new DeployOdsComponent(project, steps, git, logger).run(repo, baseDir)
                         } else if (this.project.isAssembleMode && PipelinePhases.FINALIZE) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -765,7 +765,7 @@ class Project {
         return this.capabilities.collect(collector).contains(name.toLowerCase())
     }
 
-    boolean hasFailingTests() {
+    boolean getHasFailingTests() {
         return this.data.build.hasFailingTests
     }
 

--- a/test/groovy/org/ods/orchestration/util/MROPipelineUtilSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/MROPipelineUtilSpec.groovy
@@ -550,7 +550,7 @@ class MROPipelineUtilSpec extends SpecHelper {
         util.warnBuildIfTestResultsContainFailure(testResults)
 
         then:
-        project.hasFailingTests() == true
+        project.getHasFailingTests() == true
 
         then:
         steps.currentBuild.result == "UNSTABLE"


### PR DESCRIPTION
ok - the idea is pretty simple .. fail delayed if in `WIP` and only during `assemble` after all unit tests executed /in all repos - rather than fail fast (immediately)

@metmajer - please verify