### PR TITLE
Fix backwards compatibility error when tests do not have components

### DIFF
--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -392,7 +392,14 @@ class Project {
                 if (this.isVersioningEnabled) {
                     throw new IllegalArgumentException("Error: unit tests must have exactly 1 component assigned. Following unit tests have an invalid number of components: ${faultyTestIssues}")
                 }
-                logger.warn("Warning: unit tests should have exactly 1 component assigned. Following unit tests have an abnormal number of components: ${faultyTestIssues}")
+                def filteredFaultMap = faultMap.findAll { key, size -> size > 1 }
+                if (!filteredFaultMap.isEmpty()) {
+                    faultyTestIssues = filteredFaultMap
+                        .collect { key, value -> key + ": " + value + "; " }
+                        .inject("") { temp, val -> temp + val }
+                    throw new IllegalArgumentException("Error: unit tests must have at most 1 component assigned. Following unit tests have an invalid number of components: ${faultyTestIssues}")
+                }
+                logger.warn("Warning: unit tests should have exactly 1 component assigned. Following unit tests do not have components: ${faultyTestIssues}")
             }
         }
 

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -389,7 +389,10 @@ class Project {
                 def faultyTestIssues = faultMap.keySet()
                     .collect{key -> key + ": " + faultMap.get(key) + "; "}
                     .inject(""){temp, val -> temp + val}
-                throw new IllegalArgumentException("Error: unit tests must have exactly 1 component assigned. Following unit tests have an invalid number of components: ${faultyTestIssues}")
+                if (this.isVersioningEnabled) {
+                    throw new IllegalArgumentException("Error: unit tests must have exactly 1 component assigned. Following unit tests have an invalid number of components: ${faultyTestIssues}")
+                }
+                logger.warn("Warning: unit tests should have exactly 1 component assigned. Following unit tests have an abnormal number of components: ${faultyTestIssues}")
             }
         }
 


### PR DESCRIPTION
For backwards compability, when versioning is disabled, allow tests without one component. Turned the error into a warning when the number of components is not exactly 1.