### PR TITLE
Fix property not found in JiraUseCase

### DIFF
--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -211,7 +211,7 @@ class JiraUseCase {
                 .collect{String l -> l.replace(LabelPrefix.DOCUMENT, '')}
             if (documentTypes.size() == 0) {
                 throw new IllegalArgumentException("Error: issue '${issue.key}' of type " +
-                    "'${JiraUseCase.IssueTypes.DOCUMENTATION_CHAPTER}' contains '${documentType.size()}' " +
+                    "'${JiraUseCase.IssueTypes.DOCUMENTATION_CHAPTER}' contains no " +
                     "document labels. There should be at least one label starting with '${LabelPrefix.DOCUMENT}'")
             }
 


### PR DESCRIPTION
When a documentation chapter does not have a label starting with "Doc:", an exception is thrown.
The message for this exception uses the number of labels found, but there's a typo and another exception is thrown.
But the first exception is thrown exactly when the number of labels is zero, so we have removed the invocation altogether.