### PR TITLE
Fix error trying to get "ProductRelease Version" field for projects without versioning

### DIFF
--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -242,6 +242,9 @@ class JiraUseCase {
         def releaseStatusIssueFields = this.project.getJiraFieldsForIssueType(JiraUseCase.IssueTypes.RELEASE_STATUS)
 
         def productReleaseVersionField = releaseStatusIssueFields[CustomIssueFields.RELEASE_VERSION]
+        if(!productReleaseVersionField) {
+            throw new IllegalStateException("Release status issue with key ${releaseStatusIssueKey} does not have a product release vesion field.")
+        }
         def versionField = this.jira.getTextFieldsOfIssue(releaseStatusIssueKey, [productReleaseVersionField.id])
         if (!versionField || !versionField[productReleaseVersionField.id]?.name) {
             throw new IllegalArgumentException('Unable to obtain version name from release status issue' +

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -2,11 +2,11 @@ package org.ods.orchestration.usecase
 
 import org.ods.orchestration.parser.JUnitParser
 import org.ods.orchestration.service.JiraService
-import org.ods.util.IPipelineSteps
-import org.ods.util.ILogger
 import org.ods.orchestration.util.MROPipelineUtil
 import org.ods.orchestration.util.Project
 import org.ods.orchestration.util.Project.JiraDataItem
+import org.ods.util.ILogger
+import org.ods.util.IPipelineSteps
 
 @SuppressWarnings(['IfStatementBraces', 'LineLength'])
 class JiraUseCase {
@@ -242,8 +242,10 @@ class JiraUseCase {
         def releaseStatusIssueFields = this.project.getJiraFieldsForIssueType(JiraUseCase.IssueTypes.RELEASE_STATUS)
 
         def productReleaseVersionField = releaseStatusIssueFields[CustomIssueFields.RELEASE_VERSION]
-        if(!productReleaseVersionField) {
-            throw new IllegalStateException("Release status issue with key ${releaseStatusIssueKey} does not have a product release vesion field.")
+        if (!productReleaseVersionField) {
+            // The project does not use versioning or is malformed.
+            // The decision on whether to throw an exception is left for the caller.
+            return null
         }
         def versionField = this.jira.getTextFieldsOfIssue(releaseStatusIssueKey, [productReleaseVersionField.id])
         if (!versionField || !versionField[productReleaseVersionField.id]?.name) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -992,6 +992,7 @@ class Project {
      * @ true if versioning is enabled
      */
     boolean checkIfVersioningIsEnabled(String projectKey, String versionName) {
+        if (!versionName) return false
         if (!this.jiraUseCase) return false
         if (!this.jiraUseCase.jira) return false
         def levaDocsCapability = this.getCapability('LeVADocs')


### PR DESCRIPTION
Projects with the versioning capability disabled don't have a ProductRelease Version defined, and trying to get it results in an exception.
For backwards compability, it has been fixed by considering the absence of this field as an indication that vesioning is not enabled.