### PR TITLE
Add ods-saas-service component

### DIFF
--- a/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
@@ -44,7 +44,7 @@ dependencies:
   - A
 ```
 
-The library supports the following repository types: `ods`, `ods-service`, and `ods-test`. Setting a repository type is required so the orchestrator can make correct assumptions based on the nature of the component at hand:
+The library supports the following repository types: `ods`, `ods-infra`, `ods-service`, `ods-ext-service`, and `ods-test`. Setting a repository type is required so the orchestrator can make correct assumptions based on the nature of the component at hand:
 
 ```
 id: PHOENIX
@@ -69,13 +69,21 @@ This type designates ODS components designed for _code development_. Such reposi
 
 If you use this type ODS expects to find JUnit XML test results. If you do not have any test results the pipeline will fail. If you are deploying something where JUnit XML test results are not available consider using <<Repository Type: ods-service>>.
 
+==== Repository Type: ods-infra
+
+This type designates ODS components designed for _consuming on-prem or cloud services_ of arbitrary type using infrastructure as code. Such components are based on quickstarters whose names start with `infra-`.
+
+==== Repository Type: ods-saas-service
+
+This type designates ODS components designed for _documenting vendor-provided SaaS services_.
+
 ==== Repository Type: ods-service
 
-This type designates ODS components designed for _running some service_. Examples include repositories based on the `airflow-cluster` quickstarter.
+This type designates ODS components designed for _running services_ of arbitrary type. Examples include repositories based on the `airflow-cluster` quickstarter.
 
 ==== Repository Type: ods-test
 
-This type designates ODS components designed for _running automated tests against a live application_. Such repositories are based on quickstarters whose names start with `e2e-`.
+This type designates ODS components designed for _running automated tests against a live application_. Such components are based on quickstarters whose names start with `e2e-`.
 
 === Automated Resolution of Repository Git URL
 

--- a/src/org/ods/orchestration/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/orchestration/scheduler/LeVADocumentScheduler.groovy
@@ -121,6 +121,8 @@ class LeVADocumentScheduler extends DocGenScheduler {
         (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_INFRA): [
             (LeVADocumentUseCase.DocumentType.TIR as String): null
         ],
+        (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE): [
+        ],
         (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SERVICE): [
             (LeVADocumentUseCase.DocumentType.TIR as String): null
         ],

--- a/src/org/ods/orchestration/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/orchestration/scheduler/LeVADocumentScheduler.groovy
@@ -121,8 +121,7 @@ class LeVADocumentScheduler extends DocGenScheduler {
         (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_INFRA): [
             (LeVADocumentUseCase.DocumentType.TIR as String): null
         ],
-        (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE): [
-        ],
+        (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE): [:],
         (MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SERVICE): [
             (LeVADocumentUseCase.DocumentType.TIR as String): null
         ],

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -947,7 +947,9 @@ class LeVADocumentUseCase extends DocGenUseCase {
             metadata: this.getDocumentMetadata(this.DOCUMENT_TYPE_NAMES[documentType]),
             data    : [
                 project_key : this.project.key,
-                repositories: this.project.repositories,
+                repositories: this.project.repositories.collect {
+                    it << [ doInstall: repo.type?.toLowerCase() == MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE.toLowerCase()]
+                },
                 sections    : sections,
                 documentHistory: docHistory?.getDocGenFormat() ?: [],
             ]

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -25,6 +25,7 @@ class MROPipelineUtil extends PipelineUtil {
 
         static final String REPO_TYPE_ODS_CODE = "ods"
         static final String REPO_TYPE_ODS_INFRA = "ods-infra"
+        static final String REPO_TYPE_ODS_SAAS_SERVICE = "ods-saas-service"
         static final String REPO_TYPE_ODS_SERVICE = "ods-service"
         static final String REPO_TYPE_ODS_TEST = "ods-test"
 
@@ -338,6 +339,12 @@ class MROPipelineUtil extends PipelineUtil {
                             executeODSComponent(repo, baseDir)
                         } else {
                             this.logger.debug("Repo '${repo.id}' is of type ODS Infrastructure as Code Component/Configuration Management. Nothing to do in phase '${name}' for target environment'${targetEnvToken}'.")
+                        }
+                    } else if (repo.type?.toLowerCase() == PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE) {
+                        if (this.project.isPromotionMode && name == PipelinePhases.DEPLOY) {
+                            executeODSComponent(repo, baseDir)
+                        } else {
+                            this.logger.debug("Repo '${repo.id}' is of type ODS SaaS Service Component. Nothing to do in phase '${name}' for target environment'${targetEnvToken}'.")
                         }
                     } else if (repo.type?.toLowerCase() == PipelineConfig.REPO_TYPE_ODS_SERVICE) {
                         if (this.project.isAssembleMode && name == PipelinePhases.BUILD) {


### PR DESCRIPTION
Add a new `ods-saas-service` component type to manage the automated documentation of external, vendor-provided services.