### PR TITLE
Add sonar.branch.name only in absence of PR

### DIFF
--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -24,9 +24,6 @@ class SonarQubeService {
                 "-Dsonar.projectKey=${properties['sonar.projectKey']}",
                 "-Dsonar.projectName=${properties['sonar.projectName']}",
             ]
-            if (sonarQubeEdition != 'community') {
-                scannerParams << "-Dsonar.branch.name=${properties['sonar.branch.name']}"
-            }
             if (!properties.containsKey('sonar.projectVersion')) {
                 scannerParams << "-Dsonar.projectVersion=${gitCommit.take(8)}"
             }
@@ -44,6 +41,8 @@ class SonarQubeService {
                     "-Dsonar.pullrequest.branch=${pullRequestInfo.branch}",
                     "-Dsonar.pullrequest.base=${pullRequestInfo.baseBranch}",
                 ].each { scannerParams << it }
+            } else if (sonarQubeEdition != 'community') {
+                scannerParams << "-Dsonar.branch.name=${properties['sonar.branch.name']}"
             }
             script.sh(
                 label: 'Run SonarQube scan',


### PR DESCRIPTION
Fixes #601.

SQ 8.0 and above show this error message otherwise:
```
ERROR: Error during SonarQube Scanner execution
ERROR: A pull request analysis cannot have the branch analysis parameter 'sonar.branch.name'
```