### PR TITLE
Return blank with empty content in Document Chapter

### DIFF
--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -225,7 +225,7 @@ class JiraUseCase {
                     number: number,
                     heading: issue.fields.summary,
                     documents: documentTypes,
-                    content: content?.replaceAll("\u00a0", " ") ?: "",
+                    content: content?.replaceAll("\u00a0", " ") ?: " ",
                     status: issue.fields.status.name,
                     key: issue.key as String,
                     predecessors: predecessorLinks.isEmpty()? [] : predecessorLinks,

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -354,6 +354,110 @@ class JiraUseCaseSpec extends SpecHelper {
         result['JIRA-3'] == expected['JIRA-3']
     }
 
+    def "get document chapter data with version and content empty"() {
+        given:
+        // Test Parameters
+        def version = "myVersion"
+        def predecessorKey = "PRED-1"
+
+        def docChapterFields = [
+            (JiraUseCase.CustomIssueFields.HEADING_NUMBER): [id:"0"],
+            (JiraUseCase.CustomIssueFields.CONTENT): [id: "1"],
+        ]
+
+        // Argument Constraints
+        def jqlQuery = [
+            fields: ['key', 'status', 'summary', 'labels', 'issuelinks',
+                     docChapterFields[JiraUseCase.CustomIssueFields.CONTENT].id,
+                     docChapterFields[JiraUseCase.CustomIssueFields.HEADING_NUMBER].id],
+            jql: "project = ${project.jiraProjectKey} AND issuetype = '${JiraUseCase.IssueTypes.DOCUMENTATION_CHAPTER}'" +
+                " AND fixVersion = '${version}'",
+            expand: ['renderedFields'],
+        ]
+
+        // Stubbed Method Responses
+        def jiraIssue1 = createJiraIssue("1", null, null, null, "DONE")
+        jiraIssue1.fields["0"] = "1.0"
+        jiraIssue1.fields.labels = [JiraUseCase.LabelPrefix.DOCUMENT+ "CSD"]
+        jiraIssue1.renderedFields = [:]
+        jiraIssue1.renderedFields["1"] = "<html>myContent1</html>"
+        jiraIssue1.renderedFields.description = "<html>1-description</html>"
+
+        def jiraIssue2 = createJiraIssue("2", null, null, null, "DONE")
+        jiraIssue2.fields["0"] = "2.0"
+        jiraIssue2.fields.labels = [JiraUseCase.LabelPrefix.DOCUMENT+ "SSDS"]
+        jiraIssue2.fields.issuelinks = [
+            [type:[name: "Succeeds"], outwardIssue: [key: predecessorKey]],
+            [type:[name: "Succeeds"], inwardIssue: [key: "Should not appwar the successor"]],
+        ]
+        jiraIssue2.renderedFields = [:]
+        jiraIssue2.renderedFields["1"] = "<html>myContent2</html>"
+        jiraIssue2.renderedFields.description = "<html>2-description</html>"
+
+        def jiraIssue3 = createJiraIssue("3", null, null, null, "DONE")
+        jiraIssue3.fields["0"] = "3.0"
+        jiraIssue3.fields.labels = [JiraUseCase.LabelPrefix.DOCUMENT+ "DTP"]
+        jiraIssue3.fields.issuelinks = [
+            [type:[name: "AnotherLink"], outwardIssue: [key: "Should not appear other links outward"]],
+            [type:[name: "AnotherLink2"], inwardIssue: [key: "Should not appear other links inward"]],
+        ]
+        jiraIssue3.renderedFields = [:]
+        jiraIssue3.renderedFields["1"] = "" //Empty content
+        jiraIssue3.renderedFields.description = "<html>3-description</html>"
+
+        def jiraResult = [
+            issues: [jiraIssue1, jiraIssue2, jiraIssue3],
+        ]
+
+        when:
+        def result = usecase.getDocumentChapterData(project.jiraProjectKey, version)
+
+        then:
+        1 * project.getJiraFieldsForIssueType(JiraUseCase.IssueTypes.DOCUMENTATION_CHAPTER) >> docChapterFields
+        1 * jira.searchByJQLQuery(jqlQuery) >> jiraResult
+
+        then:
+        def expected = [
+            'JIRA-1': [
+                section: 'sec1s0',
+                number : '1.0',
+                heading: '1-summary',
+                documents: ['CSD'],
+                content: '<html>myContent1</html>',
+                status: 'DONE',
+                key: 'JIRA-1',
+                predecessors: [],
+                versions: [version],
+            ],
+            'JIRA-2': [
+                section: 'sec2s0',
+                number : '2.0',
+                heading: '2-summary',
+                documents: ['SSDS'],
+                content: '<html>myContent2</html>',
+                status: 'DONE',
+                key: 'JIRA-2',
+                predecessors: [predecessorKey],
+                versions: [version],
+            ],
+            'JIRA-3': [
+                section: 'sec3s0',
+                number : '3.0',
+                heading: '3-summary',
+                documents: ['DTP'],
+                content: ' ', // With empty content a blank must be returned to avoid problems with preceding
+                status: 'DONE',
+                key: 'JIRA-3',
+                predecessors: [],
+                versions: [version],
+            ]
+        ]
+
+        result['JIRA-1'] == expected['JIRA-1']
+        result['JIRA-2'] == expected['JIRA-2']
+        result['JIRA-3'] == expected['JIRA-3']
+    }
+
     def "get document chapter data with multiple doclabels"() {
         given:
         // Test Parameters


### PR DESCRIPTION
When a Document Chapter has a predecessor and the new Document Chapter is empty the precesor was shown (and this is an error).