### PR TITLE
Feature/early stop on open issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 - Fixed environment value of SonarQube edition ([#618](https://github.com/opendevstack/ods-jenkins-shared-library/issues/618))
-
+- Early stop on opened Jira issues before deploy to dev environment ([#626](https://github.com/opendevstack/ods-jenkins-shared-library/pull/626))
 ## [3.0] - 2020-08-11
 
 ### Added

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -115,12 +115,6 @@ class FinalizeStage extends Stage {
 
             util.failBuild(message)
             throw new IllegalStateException(message)
-        } else if (!project.isWorkInProgress && !project.isProjectReadyToFreeze(project.data.jira)) {
-            project.reportPipelineStatus('Build fail as it has open issues.', true)
-            if (!project.isWorkInProgress) {
-                bitbucket.setBuildStatus (steps.env.BUILD_URL, project.gitData.commit,
-                    "SUCCESSFUL", "Release Manager for commit: ${project.gitData.commit}")
-            }
         } else {
             project.reportPipelineStatus()
             if (!project.isWorkInProgress) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -362,9 +362,10 @@ class Project {
         this.data.jira.undoneDocChapters = this.computeWipDocChapterPerDocument(this.data.jira)
 
         if (this.hasWipJiraIssues()) {
-            def message = 'Pipeline-generated documents are watermarked ' +
-                    "'${LeVADocumentUseCase.WORK_IN_PROGRESS_WATERMARK}' " +
-                    'since the following issues are work in progress: '
+            def message = this.isWorkInProgress ?'Pipeline-generated documents are watermarked ' +
+                "'${LeVADocumentUseCase.WORK_IN_PROGRESS_WATERMARK}' " +
+                'since the following issues are work in progress: ':
+                "The pipeline failed since the following issues are work in progress (no documents were generated): "
 
             this.getWipJiraIssues().each { type, keys ->
                 def values = keys instanceof Map ? keys.values().flatten() : keys
@@ -373,6 +374,9 @@ class Project {
                 }
             }
 
+            if(!this.isWorkInProgress){
+                throw new IllegalArgumentException(message)
+            }
             this.addCommentInReleaseStatus(message)
         }
 

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -398,10 +398,6 @@ class Project {
             }
         }
 
-        if(!this.isWorkInProgress && this.hasWipJiraIssues()){
-            throw new Exception("Error: Build fail as it has open issues, please check previous comment.")
-        }
-
         this.data.documents = [:]
         this.data.openshift = [:]
 

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -394,6 +394,10 @@ class Project {
             }
         }
 
+        if(!this.isWorkInProgress && this.hasWipJiraIssues()){
+            throw new Exception("Error: Build fail as it has open issues, please check previous comment.")
+        }
+
         this.data.documents = [:]
         this.data.openshift = [:]
 


### PR DESCRIPTION
Add the code needed to fail the pipeline when issues are open and we beyond the developer preview.
It will create the comment in Jira issue with all the issues that are opened so the user can close them properly.

The code is being removed from the FinalStage that was checking that there are no opened issues, to clean up that class