### PR TITLE
Fix the Document History of the IVP & IVR is not being generated (3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fixed the Document History of the IVP & IVR is not being generated ([#627](https://github.com/opendevstack/ods-jenkins-shared-library/pull/627))
+
 ## [3.0] - 2020-08-11
 
 ### Added

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1,19 +1,19 @@
 package org.ods.orchestration.usecase
 
 import com.cloudbees.groovy.cps.NonCPS
-
-import java.time.LocalDateTime
+import groovy.xml.XmlUtil
+import org.ods.orchestration.scheduler.LeVADocumentScheduler
+import org.ods.orchestration.service.DocGenService
+import org.ods.orchestration.service.LeVADocumentChaptersFileService
+import org.ods.orchestration.util.*
 import org.ods.services.GitService
 import org.ods.services.JenkinsService
 import org.ods.services.NexusService
 import org.ods.services.OpenShiftService
-import org.ods.orchestration.scheduler.LeVADocumentScheduler
-import org.ods.orchestration.service.*
-import org.ods.orchestration.util.*
 import org.ods.util.IPipelineSteps
 import org.ods.util.Logger
 
-import groovy.xml.XmlUtil
+import java.time.LocalDateTime
 
 @SuppressWarnings(['IfStatementBraces',
     'LineLength',
@@ -644,9 +644,9 @@ class LeVADocumentUseCase extends DocGenUseCase {
                     ]
                 }),
                 testsOdsService: testsOfRepoTypeOdsService,
-                testsOdsCode   : testsOfRepoTypeOdsCode
-            ],
-            documentHistory: docHistory?.getDocGenFormat() ?: [],
+                testsOdsCode   : testsOfRepoTypeOdsCode,
+                documentHistory: docHistory?.getDocGenFormat() ?: []
+            ]
         ]
 
         def uri = this.createDocument(documentType, null, data_, [:], null, getDocumentTemplateName(documentType), watermarkText)
@@ -708,9 +708,9 @@ class LeVADocumentUseCase extends DocGenUseCase {
                     statement: discrepancies.conclusion.statement
                 ],
                 testsOdsService   : testsOfRepoTypeOdsService,
-                testsOdsCode      : testsOfRepoTypeOdsCode
-            ],
-            documentHistory: docHistory?.getDocGenFormat() ?: [],
+                testsOdsCode      : testsOfRepoTypeOdsCode,
+                documentHistory   : docHistory?.getDocGenFormat() ?: []
+            ]
         ]
 
         def files = data.tests.installation.testReportFiles.collectEntries { file ->


### PR DESCRIPTION
Move the documentation history data to its correct place in the data structure.