### PR TITLE
Fix The Document History on the TIR is not showing the Document Chapters

### DIFF
--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1538,7 +1538,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             def environment = this.computeSavedDocumentEnvironment(documentType)
             def latestValidVersionId = this.getLatestDocVersionId(documentType, [environment])
             def docHistory = new DocumentHistory(this.steps, new Logger(this.steps, false), environment, documentName)
-            def docChapters = this.project.getDocumentChaptersForDocument(documentName)
+            def docChapters = this.project.getDocumentChaptersForDocument(documentType)
             def docChapterKeys = docChapters.collect { chapter ->
                 chapter.key
             }

--- a/src/org/ods/orchestration/util/DocumentHistory.groovy
+++ b/src/org/ods/orchestration/util/DocumentHistory.groovy
@@ -367,7 +367,7 @@ class DocumentHistory {
     private List<Map> getIssueChangesForVersion(String version, String issueType, Map issues) {
         // Filter chapter issues for this document only
         if (issueType == JiraDataItem.TYPE_DOCS) {
-            issues = issues.findAll { it.value.documents.contains(this.documentType) }
+            issues = issues.findAll { it.value.documents.contains(this.documentType.split('-').first()) }
         }
 
         issues.findAll { it.value.versions?.contains(version) }


### PR DESCRIPTION
* Retrieve documentation chapters for document type, not for concrete
document name.

Co-authored-by: zxBCN Farre_Basurte,Juan_Antonio (IT EDS) EXTERNAL <juan_antonio.farre_basurte.ext@boehringer-ingelheim.com>