### PR TITLE
Fix A "null" string is added in the Section 3.1 of the CFTR when the Description of the Zephyr Unit Test doesn't has a Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Early stop on opened Jira issues before deploy to dev environment ([#626](https://github.com/opendevstack/ods-jenkins-shared-library/pull/626))
 - Fixed the Document History of the IVP & IVR is not being generated ([#627](https://github.com/opendevstack/ods-jenkins-shared-library/pull/627))
 - Fixed Test name/summary in DTP/DTR documents ([#625](https://github.com/opendevstack/ods-jenkins-shared-library/pull/625)).
+- Fix A "null" string is added in the Section 3.1 of the CFTR when the Description of the Zephyr Unit Test doesn't has a Description ([#634](https://github.com/opendevstack/ods-jenkins-shared-library/pull/634))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -478,10 +478,12 @@ class LeVADocumentUseCase extends DocGenUseCase {
         if (!acceptanceTestIssues.isEmpty()) {
             data_.data.acceptanceTests = acceptanceTestIssues.collect { testIssue ->
                 def description = testIssue.name ?: ""
-                if (description && testIssue.description) {
-                    description += ": "
+                if (testIssue.description) {
+                    if (description) {
+                        description += ": "
+                    }
+                    description += testIssue.description
                 }
-                description += testIssue.description
 
                 [
                     key        : testIssue.key,
@@ -498,10 +500,12 @@ class LeVADocumentUseCase extends DocGenUseCase {
         if (!integrationTestIssues.isEmpty()) {
             data_.data.integrationTests = integrationTestIssues.collect { testIssue ->
                 def description = testIssue.name ?: ""
-                if (description && testIssue.description) {
-                    description += ": "
+                if (testIssue.description) {
+                    if (description) {
+                        description += ": "
+                    }
+                    description += testIssue.description
                 }
-                description += testIssue.description
 
                 [
                     key        : testIssue.key,

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -477,18 +477,10 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!acceptanceTestIssues.isEmpty()) {
             data_.data.acceptanceTests = acceptanceTestIssues.collect { testIssue ->
-                def description = testIssue.name ?: ""
-                if (testIssue.description) {
-                    if (description) {
-                        description += ": "
-                    }
-                    description += testIssue.description
-                }
-
                 [
                     key        : testIssue.key,
                     datetime   : testIssue.timestamp ? testIssue.timestamp.replaceAll("T", "</br>") : "N/A",
-                    description: description ?: "N/A",
+                    description: getTestDescription(testIssue),
                     remarks    : testIssue.isUnexecuted ? "Not executed" : "",
                     risk_key   : testIssue.risks ? testIssue.risks.join(", ") : "N/A",
                     success    : testIssue.isSuccess ? "Y" : "N",
@@ -499,18 +491,10 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!integrationTestIssues.isEmpty()) {
             data_.data.integrationTests = integrationTestIssues.collect { testIssue ->
-                def description = testIssue.name ?: ""
-                if (testIssue.description) {
-                    if (description) {
-                        description += ": "
-                    }
-                    description += testIssue.description
-                }
-
                 [
                     key        : testIssue.key,
                     datetime   : testIssue.timestamp ? testIssue.timestamp.replaceAll("T", "</br>") : "N/A",
-                    description: description ?: "N/A",
+                    description: getTestDescription(testIssue),
                     remarks    : testIssue.isUnexecuted ? "Not executed" : "",
                     risk_key   : testIssue.risks ? testIssue.risks.join(", ") : "N/A",
                     success    : testIssue.isSuccess ? "Y" : "N",
@@ -526,6 +510,11 @@ class LeVADocumentUseCase extends DocGenUseCase {
         def uri = this.createDocument(documentType, null, data_, files, null, getDocumentTemplateName(documentType), watermarkText)
         this.updateJiraDocumentationTrackingIssue(documentType, uri, docHistory?.getVersion() as String)
         return uri
+    }
+
+    //TODO Use this method to generate the test description everywhere
+    def getTestDescription(testIssue) {
+        return testIssue.description ?: testIssue.name ?: 'N/A'
     }
 
     String createRA(Map repo = null, Map data = null) {


### PR DESCRIPTION
Use the description. If not present, then use the name.