### PR TITLE
Extend regex to match bitbucket merge commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Orchestation pipeline throws a non serializable exeption issue 645 ([#649](https://github.com/opendevstack/ods-jenkins-shared-library/pull/649))
 - Add labels to generated OpenShift resources ([#646](https://github.com/opendevstack/ods-jenkins-shared-library/pull/646))
 - Fixed bug that disallowed empty label values ([#655](https://github.com/opendevstack/ods-jenkins-shared-library/pull/655))
+- Added regexp compatibility with new Bitbucket merge commit messages ([#655](https://github.com/opendevstack/ods-jenkins-shared-library/pull/656))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -30,7 +30,7 @@ class GitService {
     @SuppressWarnings('LineLength')
     static String mergedBranch(String project, String repository, String commitMessage) {
         def uppercaseProject = project.toUpperCase()
-        def msgMatcher = commitMessage =~ /(?:Pull request #[0-9]+.*\R+Merge|Merge pull request #[0-9]+) in ODM\/odm-components from (\S*)|^Merge branch '(\S*)'/
+        def msgMatcher = commitMessage =~ /(?:Pull request #[0-9]+.*\R+Merge|Merge pull request #[0-9]+) in ${uppercaseProject}\/${repository} from (\S*)|^Merge branch '(\S*)'/
         if (msgMatcher) {
             return msgMatcher[0][1] ?: msgMatcher[0][2]
         }

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -30,7 +30,7 @@ class GitService {
     @SuppressWarnings('LineLength')
     static String mergedBranch(String project, String repository, String commitMessage) {
         def uppercaseProject = project.toUpperCase()
-        def msgMatcher = commitMessage =~ /Merge pull request #[0-9]* in ${uppercaseProject}\/${repository} from (\S*)|^Merge branch '(\S*)'/
+        def msgMatcher = commitMessage =~ /(?:Pull request #[0-9]+.*\R+Merge|Merge pull request #[0-9]+) in ODM\/odm-components from (\S*)|^Merge branch '(\S*)'/
         if (msgMatcher) {
             return msgMatcher[0][1] ?: msgMatcher[0][2]
         }

--- a/test/groovy/org/ods/services/GitServiceSpec.groovy
+++ b/test/groovy/org/ods/services/GitServiceSpec.groovy
@@ -51,9 +51,10 @@ class GitServiceSpec extends SpecHelper {
         result == mergedBranch
 
         where:
-        gitCommitMessage                                                                 || mergedBranch
-        'Merge pull request #62 in ODM/odm-components from bugfix/ODM-509-foo to master' || 'bugfix/ODM-509-foo'
-        "Merge branch 'bugfix/ODM-509-foo' to master"                                    || 'bugfix/ODM-509-foo'
+        gitCommitMessage                                                                            || mergedBranch
+        'Merge pull request #62 in ODM/odm-components from bugfix/ODM-509-foo to master'            || 'bugfix/ODM-509-foo'
+        'Pull request #62: test\n\nMerge in ODM/odm-components from bugfix/ODM-509-foo to master'   || 'bugfix/ODM-509-foo'
+        "Merge branch 'bugfix/ODM-509-foo' to master"                                               || 'bugfix/ODM-509-foo'
     }
 }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Merge commits produce messages which, by default, should match the regexp specified in `mergedBranch` (called by `org.ods.services.GitService.mergedIssueId`) which is used to automatically retrieve the issue Id from the message. However, the message Bitbucket produces by default does not match the expected format.

Example of a matching message in previously seen merge commits:
```
Merge pull request #123 in PROJECT/repo-name from feature/ISSUE-456 to master

* commit '...':
```
Example of a current non matching message created by Bitbucket in a merge commit:
```
Pull request #123: abcde

Merge in PROJECT/repo-name from feature/ISSUE-456 to master

* commit '...':
```
The matching group is the branch name `feature/ISSUE-456`.

This issue has been found when following the ["cleanup preview resources" part of the documentation](https://www.opendevstack.org/ods-documentation/opendevstack/3.x/jenkins-shared-library/component-pipeline.html), and uses the newer context property `gitCommitRawMessage` introduced after #587.

**Describe the solution you'd like**
The regexp has been extended to include the new format (preserving backwards compatibility).