### PR TITLE
Exchange thumbnail for the right image in document chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added regexp compatibility with new Bitbucket merge commit messages ([#655](https://github.com/opendevstack/ods-jenkins-shared-library/pull/656))
 - Set jenkins job to unstable in case of open issues ([#664](https://github.com/opendevstack/ods-jenkins-shared-library/pull/664))
 - Fixed regression on project dump in release manager ([#666](https://github.com/opendevstack/ods-jenkins-shared-library/issues/666))
+- Fixed use of full image in the creation of the documents ([682](https://github.com/opendevstack/ods-jenkins-shared-library/pull/682))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -206,6 +206,12 @@ class JiraUseCase {
             }
             content = content ? content.getValue() : ""
 
+            def matcher = content =~ /<a.*id="(.*)_thumb".*href="(.*?)"/
+            matcher.each {
+                def imageMatcher = content =~ /<a.*id="${it[1]}_thumb".*src="(.*?)"/
+                content = content.replace(imageMatcher[0][1], it[2])
+            }
+
             def documentTypes = (issue.fields.labels ?: [])
                 .findAll { String l -> l.startsWith(LabelPrefix.DOCUMENT) }
                 .collect { String l -> l.replace(LabelPrefix.DOCUMENT, '') }

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -577,7 +577,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             return [
                 key: r.key,
                 name: r.name,
-                description: r.description,
+                description: convertImages(r.description),
                 proposedMeasures: "Mitigations: ${mitigationsText}<br/>Tests: ${testsText}",
                 requirements: requirements.collect { it.name }.join("<br/>"),
                 requirementsKey: requirements.collect { it.key }.join("<br/>"),

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -146,7 +146,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                     epic            : epic?.key,
                     epicName        : epic?.epicName,
                     epicTitle       : epic?.title,
-                    epicDescription : epic?.description,
+                    epicDescription : this.convertImages(epic?.description),
                 ]
             }
 
@@ -277,7 +277,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
             [
                 key               : testIssue.key,
-                description       : description ?: "N/A",
+                description       : this.convertImages(description ?: 'N/A'),
                 systemRequirement : testIssue.requirements.join(", "),
                 success           : testIssue.isSuccess ? "Y" : "N",
                 remarks           : testIssue.isUnexecuted ? "Not executed" : "N/A",
@@ -446,7 +446,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 acceptanceTests : acceptanceTestIssues.collect { testIssue ->
                     [
                         key        : testIssue.key,
-                        description: testIssue.description ?: '',
+                        description: this.convertImages(testIssue.description ?: ''),
                         ur_key     : testIssue.requirements ? testIssue.requirements.join(', ') : 'N/A',
                         risk_key   : testIssue.risks ? testIssue.risks.join(', ') : 'N/A'
                     ]
@@ -454,7 +454,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 integrationTests: integrationTestIssues.collect { testIssue ->
                     [
                         key        : testIssue.key,
-                        description: testIssue.description ?: '',
+                        description: this.convertImages(testIssue.description ?: ''),
                         ur_key     : testIssue.requirements ? testIssue.requirements.join(', ') : 'N/A',
                         risk_key   : testIssue.risks ? testIssue.risks.join(', ') : 'N/A'
                     ]
@@ -729,7 +729,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 tests             : SortUtil.sortIssuesByKey(installationTestIssues.collect { testIssue ->
                     [
                         key        : testIssue.key,
-                        description: testIssue.description ?: "",
+                        description: this.convertImages(testIssue.description ?: ''),
                         remarks    : testIssue.isUnexecuted ? "Not executed" : "",
                         success    : testIssue.isSuccess ? "Y" : "N",
                         summary    : testIssue.name,
@@ -813,7 +813,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 integrationTests    : SortUtil.sortIssuesByKey(integrationTestIssues.collect { testIssue ->
                     [
                         key         : testIssue.key,
-                        description : testIssue.description,
+                        description : this.convertImages(testIssue.description ?: ''),
                         requirements: testIssue.requirements ? testIssue.requirements.join(", ") : "N/A",
                         isSuccess   : testIssue.isSuccess,
                         bugs        : testIssue.bugs ? testIssue.bugs.join(", ") : (testIssue.comment ? "": "N/A"),
@@ -826,7 +826,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 acceptanceTests     : SortUtil.sortIssuesByKey(acceptanceTestIssues.collect { testIssue ->
                     [
                         key         : testIssue.key,
-                        description : testIssue.description,
+                        description : this.convertImages(testIssue.description ?: ''),
                         requirements: testIssue.requirements ? testIssue.requirements.join(", ") : "N/A",
                         isSuccess   : testIssue.isSuccess,
                         bugs        : testIssue.bugs ? testIssue.bugs.join(", ") : (testIssue.comment ? "": "N/A"),
@@ -870,7 +870,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 integrationTests: SortUtil.sortIssuesByKey(integrationTestIssues.collect { testIssue ->
                     [
                         key         : testIssue.key,
-                        description : testIssue.description,
+                        description : this.convertImages(testIssue.description ?: ''),
                         requirements: testIssue.requirements ? testIssue.requirements.join(", ") : "N/A",
                         bugs        : testIssue.bugs ? testIssue.bugs.join(", ") : "N/A",
                         steps       : sortTestSteps(testIssue.steps)
@@ -879,7 +879,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 acceptanceTests : SortUtil.sortIssuesByKey(acceptanceTestIssues.collect { testIssue ->
                     [
                         key         : testIssue.key,
-                        description : testIssue.description,
+                        description : this.convertImages(testIssue.description ?: ''),
                         requirements: testIssue.requirements ? testIssue.requirements.join(", ") : "N/A",
                         bugs        : testIssue.bugs ? testIssue.bugs.join(", ") : "N/A",
                         steps       : sortTestSteps(testIssue.steps)
@@ -934,7 +934,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 nameOfSoftware: c.nameOfSoftware,
                 componentType : c.componentType,
                 componentId   : c.componentId,
-                description   : c.description,
+                description   : this.convertImages(c.description ?: ''),
                 supplier      : c.supplier,
                 version       : c.version,
                 references    : c.references
@@ -1136,7 +1136,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             [
                 key         : r.key,
                 name        : r.name,
-                description : r.description,
+                description : this.convertImages(r.description ?: ''),
                 risks       : r.risks.join(", "),
                 tests       : r.tests.join(", "),
                 predecessors: predecessors,
@@ -1333,7 +1333,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             [
                 moduleName: testIssue.components.join(", "),
                 testKey: testIssue.key,
-                description: description ?: "N/A",
+                description: this.convertImages(description ?: 'N/A'),
                 systemRequirement: testIssue.requirements ? testIssue.requirements.join(", ") : "N/A",
                 softwareDesignSpec: (softwareDesignSpecs.join(", ")) ?: "N/A",
                 riskLevel: riskLevels ? riskLevels.join(", ") : "N/A"

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1595,7 +1595,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         then:
         1 * usecase.getDocumentSections(_) >> docChapters2
         1 * project.getSystemRequirements() >> requirements
-        4 * usecase.convertImages(_)
+        5 * usecase.convertImages(_)
         3 * jiraUseCase.convertHTMLImageSrcIntoBase64Data(contentWithImage) >> imageb64
         1 * usecase.createDocument(*_) >> ''
         1 * usecase.updateJiraDocumentationTrackingIssue(*_)
@@ -1608,7 +1608,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         1 * usecase.computeComponentMetadata(_) >> compMetadata
 
         then:
-        1 * usecase.convertImages(_)
+        2 * usecase.convertImages(_)
         1 * jiraUseCase.convertHTMLImageSrcIntoBase64Data(contentWithImage) >> imageb64
         1 * usecase.createDocument(*_) >> ''
         usecase.obtainCodeReviewReport(*_) >> []


### PR DESCRIPTION
In order to display full image in the documents generated, we need to change the url on the documentation chapters to retrieve the link to the full image instead of the link to the thumbnails