### PR TITLE
by default analyzePullRequests should be false (#731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix referenced document versions after PR [#691] ([#709](https://github.com/opendevstack/ods-jenkins-shared-library/pull/709))
 - Fix missing grapes import in BitbucketService [#717] ([#717](https://github.com/opendevstack/ods-jenkins-shared-library/issues/717))
 - Documented the labeling functionality ([#715](https://github.com/opendevstack/ods-jenkins-shared-library/pull/715))
+- Fix by default sonarQu should analyzePullRequests:false ([#663](https://github.com/opendevstack/ods-jenkins-shared-library/issues/663))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -50,7 +50,7 @@ class ScanWithSonarStage extends Stage {
                 .toList()
         }
         if (!config.containsKey('analyzePullRequests')) {
-            config.analyzePullRequests = true
+            config.analyzePullRequests = false
         }
         if (!config.containsKey('requireQualityGatePass')) {
             config.requireQualityGatePass = false

--- a/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithSonarSpec.groovy
@@ -85,7 +85,7 @@ class OdsComponentStageScanWithSonarSpec extends PipelineSpockTestBase {
     helper.registerAllowedMethod('archiveArtifacts', [ Map ]) { Map args -> }
     helper.registerAllowedMethod('stash', [ Map ]) { Map args -> }
     helper.registerAllowedMethod('readFile', [ Map ]) { Map args -> ""}
-    script.call(context, ['branch': '*'])
+    script.call(context, ['branch': '*', 'analyzePullRequests': 'true'])
 
     then:
     printCallStack()


### PR DESCRIPTION
From this isssue #663
Instead of change all the 'quickstarters' is better to change the default behaviour.

Detailed explanation:

SonarQu can generate a scan for a branch or a scan for a PR.
We can only ask SonarQu a report of a branch. See Cannot generate report from Pull Request cnescatlab/sonar-cnes-report#159
As we are always asking for the report of the branch, not for a report of a PR. Then, by default, we should generate a report for the branch, not for the PR.