### PR TITLE
do not re-integrate state into parent branch for ods-saas components in finalize - master

### DIFF
--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -171,7 +171,8 @@ class FinalizeStage extends Stage {
         def flattenedRepos = repos.flatten()
         def repoIntegrateTasks = flattenedRepos
             .findAll { it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST &&
-               it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_INFRA }
+               it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_INFRA &&
+               it.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE }
             .collectEntries { repo ->
                 [
                     (repo.id): {


### PR DESCRIPTION
on finalize we attempt to export the state from OCP for various component types - and this fix prevents this for ods-saas components 