### PR TITLE
fix: reporting 3 bugs instead of 1 on deploy to Q in case there is 1 bug - master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## [4.0] - 2021-05-11
-- While deploying on Qa with 1 bug, 3 bugs are reported instead of 1 (https://github.com/opendevstack/ods-jenkins-shared-library/pull/757)
+- While deploying on Qa with 1 bug, 3 bugs are reported instead of 1 (https://github.com/opendevstack/ods-jenkins-shared-library/pull/777)
 ### Added
 - Fixed the Developer Preview fails because "Duplicated Tests"
 - Throw exception when two coded tests are linked to the same test issue (https://github.com/opendevstack/ods-jenkins-shared-library/pull/737)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## [4.0] - 2021-05-11
-
+- While deploying on Qa with 1 bug, 3 bugs are reported instead of 1 (https://github.com/opendevstack/ods-jenkins-shared-library/pull/757)
 ### Added
 - Fixed the Developer Preview fails because "Duplicated Tests"
 - Throw exception when two coded tests are linked to the same test issue (https://github.com/opendevstack/ods-jenkins-shared-library/pull/737)

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -300,17 +300,18 @@ class JiraUseCase {
     void reportTestResultsForComponent(String componentName, List<String> testTypes, Map testResults) {
         if (!this.jira) return
 
-        def testLevel = "${componentName ?: 'project'}"
+        def testComponent = "${componentName ?: 'project'}"
+        def testMessage = componentName ? " for component '${componentName}'" : ''
         if (logger.debugMode) {
-            logger.debug('Reporting unit test results to corresponding test cases in Jira for' +
-              " '${testLevel}' type: '${testTypes}'\rresults: ${testResults}")
+            logger.debug('Reporting unit test results to corresponding test cases in Jira' +
+                "${testMessage}. Test type: '${testTypes}'.\nTest results: ${testResults}")
         }
 
-        logger.startClocked("${testLevel}-jira-fetch-tests-${testTypes}")
+        logger.startClocked("${testComponent}-jira-fetch-tests-${testTypes}")
         def testIssues = this.project.getAutomatedTests(componentName, testTypes)
-        logger.debugClocked("${testLevel}-jira-fetch-tests-${testTypes}",
-            "Found automated tests for ${(componentName ?: 'project')} type: ${testTypes}: " +
-            "${testIssues?.size()}")
+        logger.debugClocked("${testComponent}-jira-fetch-tests-${testTypes}",
+            "Found automated tests$testMessage. Test type: ${testTypes}: " +
+                "${testIssues?.size()}")
 
         this.util.warnBuildIfTestResultsContainFailure(testResults)
         this.matchTestIssuesAgainstTestResults(testIssues, testResults, null) { unexecutedJiraTests ->
@@ -319,11 +320,11 @@ class JiraUseCase {
             }
         }
 
-        logger.startClocked("${testLevel}-jira-report-tests-${testTypes}")
+        logger.startClocked("${testComponent}-jira-report-tests-${testTypes}")
         this.support.applyXunitTestResults(testIssues, testResults)
-        logger.debugClocked("${testLevel}-jira-report-tests-${testTypes}")
+        logger.debugClocked("${testComponent}-jira-report-tests-${testTypes}")
         if (['Q', 'P'].contains(this.project.buildParams.targetEnvironmentToken)) {
-            logger.startClocked("${testLevel}-jira-report-bugs-${testTypes}")
+            logger.startClocked("${testComponent}-jira-report-bugs-${testTypes}")
             // Create bugs for erroneous test issues
             def errors = JUnitParser.Helper.getErrors(testResults)
             this.createBugsForFailedTestIssues(testIssues, errors, this.steps.env.RUN_DISPLAY_URL)
@@ -331,7 +332,7 @@ class JiraUseCase {
             // Create bugs for failed test issues
             def failures = JUnitParser.Helper.getFailures(testResults)
             this.createBugsForFailedTestIssues(testIssues, failures, this.steps.env.RUN_DISPLAY_URL)
-            logger.debugClocked("${testLevel}-jira-report-bugs-${testTypes}")
+            logger.debugClocked("${testComponent}-jira-report-bugs-${testTypes}")
         }
     }
 

--- a/src/org/ods/orchestration/util/DocumentHistory.groovy
+++ b/src/org/ods/orchestration/util/DocumentHistory.groovy
@@ -325,6 +325,7 @@ class DocumentHistory {
         this.allIssuesAreValid = true
 
         def versionMap = this.computeEntryData(jiraData, projectVersion, keysInDocument)
+        logger.debug("parseJiraDataToDocumentHistoryEntry: versionMap = ${versionMap.toString()}")
         return new DocumentHistoryEntry(versionMap, this.latestVersionId, projectVersion, previousProjectVersion, '')
     }
 

--- a/test/groovy/org/ods/orchestration/TestStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/TestStageSpec.groovy
@@ -77,7 +77,7 @@ class TestStageSpec extends SpecHelper {
         steps.env >> [WORKSPACE: "", BUILD_ID: 1]
         jenkins.unstashFilesIntoPath(_, _, "JUnit XML Report") >> true
         junit.loadTestReportsFromPath(_) >> []
-        junit.parseTestReportFiles(_) >> [:]
+        junit.parseTestReportFiles(_) >> [ testsuites: [] ]
 
         when:
         testStage.run()


### PR DESCRIPTION
fix problem with test reporting and added more logs in order to understand better the process

Fixing bug:
When executing step "deploying on QA"
And there is one bug in test project-
Then after execution in Jira exist three same bugs
and from those one one is linked with the test Jira ticket.
which was produced by keeping same data structure for every type of test

added also better logging
and reducing size of function because the same code is repeated for every type of test (Acceptance, Installation, Integration)