### PR TITLE
Increase Socket Timeout on Pipeline Orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Increase Socket Timeout on Pipeline Orchestrator (https://github.com/opendevstack/ods-jenkins-shared-library/pull/781) 
 
 ## [4.0] - 2021-05-11
 

--- a/vars/odsOrchestrationPipeline.groovy
+++ b/vars/odsOrchestrationPipeline.groovy
@@ -25,8 +25,8 @@ import org.ods.util.PipelineSteps
 @SuppressWarnings('AbcMetric')
 def call(Map config) {
     Unirest.config()
-        .socketTimeout(1200000)
-        .connectTimeout(120000)
+        .socketTimeout(6000000)
+        .connectTimeout(600000)
 
     def steps = new PipelineSteps(this)
 


### PR DESCRIPTION
When we are generating very big Reports With Docgen sometimes we get socket timeout