### PR TITLE
Increase Socket Timeout on Pipeline Orchestrator  3x

### DIFF
--- a/vars/odsOrchestrationPipeline.groovy
+++ b/vars/odsOrchestrationPipeline.groovy
@@ -22,8 +22,8 @@ import org.ods.util.PipelineSteps
 @SuppressWarnings('AbcMetric')
 def call(Map config) {
     Unirest.config()
-        .socketTimeout(1200000)
-        .connectTimeout(120000)
+        .socketTimeout(6000000)
+        .connectTimeout(600000)
 
     def steps = new PipelineSteps(this)
 


### PR DESCRIPTION
When we are generating very big Reports With Docgen sometimes we get socket timeout