### PR TITLE
Fix image not shown in document chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - verbosity of standard shared libary stages ([#196](https://github.com/opendevstack/ods-jenkins-shared-library/issues/196))
 - Allow easy configuration of compute resources ([#173](https://github.com/opendevstack/ods-jenkins-shared-library/issues/173))
 - Fix rollout race condition and display events in Jenkins log ([#385](https://github.com/opendevstack/ods-jenkins-shared-library/pull/385))
+- Fix image not shown in documents like TIR and DTR from Document Chapters ([#789](https://github.com/opendevstack/ods-jenkins-shared-library/pull/789))
 
 ### Changed
 - Lazily set OpenShift app domain ([#396](https://github.com/opendevstack/ods-jenkins-shared-library/pull/396))

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1667,6 +1667,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
     protected Map getDocumentSections(String documentType) {
         def sections = this.project.getDocumentChaptersForDocument(documentType)
+
         if (!sections) {
             throw new RuntimeException("Error: unable to create ${documentType}. " +
                 'Could not obtain document chapter data from Jira.')
@@ -1680,7 +1681,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
     protected Map getDocumentSectionsFileOptional(String documentType) {
         def sections = this.project.getDocumentChaptersForDocument(documentType)
         sections = sections?.collectEntries { sec ->
-            [(sec.section): sec]
+            [(sec.section): sec + [content: this.convertImages(sec.content)]]
         }
         if (!sections || sections.isEmpty() ) {
             sections = this.levaFiles.getDocumentChapterData(documentType)
@@ -1688,7 +1689,11 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 this.project.data.jira.undoneDocChapters = [:]
             }
             this.project.data.jira.undoneDocChapters[documentType] = this.computeSectionsNotDone(sections)
+            sections = sections?.collectEntries { key, sec ->
+                [(key): sec + [content: this.convertImages(sec.content)]]
+            }
         }
+
         if (!sections) {
             throw new RuntimeException("Error: unable to create ${documentType}. " +
                 'Could not obtain document chapter data from Jira nor files.')


### PR DESCRIPTION
We introduce the jira image conversion from for some specific case where the image document chapters were retrieved in a different way or from the .yaml that exists in the folder docs of the Release Manager