### PR TITLE
Fix RM: *found unexecuted Jira tests* error during promote2Production when functional test only runs on D and QA (#832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix RM: *found unexecuted Jira tests* error during promote2Production when functional test only runs on D and QA ([#832](https://github.com/opendevstack/ods-jenkins-shared-library/pull/832))
 
 ## [4.0] - 2021-05-11
 

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -279,7 +279,7 @@ class JiraUseCase {
         }
 
         testIssues.each { testIssue ->
-            if (!result.matched.keySet().contains(testIssue)) {
+            if (!result.matched.keySet().contains(testIssue) && mustRun(testIssue)) {
                 result.unmatched << testIssue
             }
         }
@@ -295,6 +295,11 @@ class JiraUseCase {
         if (checkDuplicateTestResults && duplicatesKeys) {
             throw new IllegalStateException(duplicateKeysErrorMessage + duplicatesKeys);
         }
+    }
+
+    private boolean mustRun(testIssue) {
+        return !project.promotingToProd() ||
+            testIssue.testType?.equalsIgnoreCase(Project.TestType.INSTALLATION)
     }
 
     void reportTestResultsForComponent(String componentName, List<String> testTypes, Map testResults) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -555,6 +555,10 @@ class Project {
         ['Q', 'P'].contains(targetEnvironmentToken)
     }
 
+    boolean promotingToProd() {
+        buildParams.targetEnvironmentToken == 'P'
+    }
+
     boolean getIsWorkInProgress() {
         isWorkInProgress(buildParams.version)
     }

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -552,6 +552,91 @@ class JiraUseCaseSpec extends SpecHelper {
         mismatched == expectedMismatched
     }
 
+    def "match Jira test issues against test results when deploying into P"() {
+        given:
+        def testIssues = createJiraTestIssues()
+        def testResults = createTestResults()
+
+        def matched = [:]
+        def matchedHandler = { result ->
+            matched = result.collectEntries { jiraTestIssue, testcase ->
+                [(jiraTestIssue.key.toString()), testcase.name]
+            }
+        }
+
+        def mismatched = [:]
+        def mismatchedHandler = { result ->
+            mismatched = result.collect { it.key }
+        }
+        project.data.buildParams.targetEnvironmentToken = 'P'
+
+        when:
+        testIssues[4].testType = Project.TestType.INSTALLATION
+        usecase.matchTestIssuesAgainstTestResults(testIssues, testResults, matchedHandler, mismatchedHandler)
+        def expectedMatched = [
+            "JIRA-1": "JIRA1_my-testcase-1",
+            "JIRA-2": "JIRA2_my-testcase-2",
+            "JIRA-3": "JIRA3_my-testcase-3",
+            "JIRA-4": "JIRA4_my-testcase-4"
+        ]
+
+        def expectedMismatched = [
+            "JIRA-5"
+        ]
+
+        then:
+        matched == expectedMatched
+        mismatched == expectedMismatched
+
+        when:
+        testIssues[4].testType = Project.TestType.INTEGRATION
+        usecase.matchTestIssuesAgainstTestResults(testIssues, testResults, matchedHandler, mismatchedHandler)
+        expectedMatched = [
+            "JIRA-1": "JIRA1_my-testcase-1",
+            "JIRA-2": "JIRA2_my-testcase-2",
+            "JIRA-3": "JIRA3_my-testcase-3",
+            "JIRA-4": "JIRA4_my-testcase-4"
+        ]
+
+        expectedMismatched = []
+
+        then:
+        matched == expectedMatched
+        mismatched == expectedMismatched
+
+        when:
+        testIssues[4].testType = Project.TestType.ACCEPTANCE
+        usecase.matchTestIssuesAgainstTestResults(testIssues, testResults, matchedHandler, mismatchedHandler)
+        expectedMatched = [
+            "JIRA-1": "JIRA1_my-testcase-1",
+            "JIRA-2": "JIRA2_my-testcase-2",
+            "JIRA-3": "JIRA3_my-testcase-3",
+            "JIRA-4": "JIRA4_my-testcase-4"
+        ]
+
+        expectedMismatched = []
+
+        then:
+        matched == expectedMatched
+        mismatched == expectedMismatched
+
+        when:
+        testIssues[4].testType = Project.TestType.UNIT
+        usecase.matchTestIssuesAgainstTestResults(testIssues, testResults, matchedHandler, mismatchedHandler)
+        expectedMatched = [
+            "JIRA-1": "JIRA1_my-testcase-1",
+            "JIRA-2": "JIRA2_my-testcase-2",
+            "JIRA-3": "JIRA3_my-testcase-3",
+            "JIRA-4": "JIRA4_my-testcase-4"
+        ]
+
+        expectedMismatched = []
+
+        then:
+        matched == expectedMatched
+        mismatched == expectedMismatched
+    }
+
     def "match Jira test issues against test results having duplicate test results"() {
         given:
         def testIssues = createJiraTestIssues()


### PR DESCRIPTION
* Ignore unexecuted acceptance and integration tests when deploying into prod

Co-authored-by: zxBCN Farre_Basurte,Juan_Antonio (IT EDS) EXTERNAL <juan_antonio.farre_basurte.ext@boehringer-ingelheim.com>

(cherry picked from commit 3e807504360723bed7291d5b174b2cc8dbb292a8)