### PR TITLE
backport: Improve error message when two coded tests are linked to the same test issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Improve error message when two coded tests are linked to the same test issue ([#826](https://github.com/opendevstack/ods-jenkins-shared-library/pull/826))
+- Improve error message when two coded tests are linked to the same test issue ([#835](https://github.com/opendevstack/ods-jenkins-shared-library/pull/835))
 - Fix RM: *found unexecuted Jira tests* error during promote2Production when functional test only runs on D and QA ([#832](https://github.com/opendevstack/ods-jenkins-shared-library/pull/832))
 
 ## [4.0] - 2021-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Improve error message when two coded tests are linked to the same test issue ([#826](https://github.com/opendevstack/ods-jenkins-shared-library/pull/826))
 - Fix RM: *found unexecuted Jira tests* error during promote2Production when functional test only runs on D and QA ([#832](https://github.com/opendevstack/ods-jenkins-shared-library/pull/832))
 
 ## [4.0] - 2021-05-11

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -258,7 +258,7 @@ class JiraUseCase {
     void matchTestIssuesAgainstTestResults(List testIssues, Map testResults,
                                            Closure matchedHandler, Closure unmatchedHandler = null,
                                            boolean checkDuplicateTestResults = true) {
-        def duplicateKeysErrorMessage = "Error: found duplicated Jira tests. Check tests with key: "
+        def duplicateKeysErrorMessage = "Error: the following test cases are implemented multiple times each: "
         def duplicatesKeys = []
 
         def result = [
@@ -293,7 +293,7 @@ class JiraUseCase {
         }
 
         if (checkDuplicateTestResults && duplicatesKeys) {
-            throw new IllegalStateException(duplicateKeysErrorMessage + duplicatesKeys);
+            throw new IllegalStateException("${duplicateKeysErrorMessage}${duplicatesKeys.join(', ')}.");
         }
     }
 

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -659,7 +659,7 @@ class JiraUseCaseSpec extends SpecHelper {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'Error: found duplicated Jira tests. Check tests with key: [JIRA-1, JIRA-2]'
+        e.message == 'Error: the following test cases are implemented multiple times each: JIRA-1, JIRA-2.'
     }
 
     def "match Jira test issues against test results having duplicate test results with flag check duplicate to false"() {


### PR DESCRIPTION
* Change error message for tests with more than one implementation

Co-authored-by: zxBCN Farre_Basurte,Juan_Antonio (IT EDS) EXTERNAL <juan_antonio.farre_basurte.ext@boehringer-ingelheim.com>

(cherry picked from commit a2c332367fb58de7777f9248d3325c72dbca8e5f)