### PR TITLE
Set test summary for empty description in TCR (#837) Cherry-pick to 3.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix Traceability matrix NULL ([#817](https://github.com/opendevstack/ods-jenkins-shared-library/pull/817)
 - rerunning of master pipeline after dev release via release-manager ([#793](https://github.com/opendevstack/ods-jenkins-shared-library/pull/793))
 - Fix RM: *found unexecuted Jira tests* error during promote2Production when functional test only runs on D and QA ([#832](https://github.com/opendevstack/ods-jenkins-shared-library/pull/832))
+- Set test summary for empty description in TCR ([#837](https://github.com/opendevstack/ods-jenkins-shared-library/pull/837))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -829,7 +829,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 integrationTests    : SortUtil.sortIssuesByKey(integrationTestIssues.collect { testIssue ->
                     [
                         key         : testIssue.key,
-                        description : testIssue.description,
+                        description : getTestDescription(testIssue),
                         requirements: testIssue.requirements ? testIssue.requirements.join(", ") : "N/A",
                         isSuccess   : testIssue.isSuccess,
                         bugs        : testIssue.bugs ? testIssue.bugs.join(", ") : (testIssue.comment ? "": "N/A"),

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1772,4 +1772,22 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         'ab-c-d'  | 'ab&#x2011;c&#x2011;d'
     }
 
+    def "getTestDescription"(testIssue, expected) {
+        given:
+        LeVADocumentUseCase leVADocumentUseCase = new LeVADocumentUseCase(null, null, null,
+            null, null, null, null, null, null, null, null, null, null, null)
+
+        when:
+        def result = leVADocumentUseCase.getTestDescription(testIssue)
+
+        then:
+        result == expected
+
+        where:
+        testIssue                                      |       expected
+        [name: '',description: '']                     |       'N/A'
+        [name: 'NAME',description: '']                 |       'NAME'
+        [name: '',description: 'DESCRIPTION']          |       'DESCRIPTION'
+        [name: 'NAME',description: 'DESCRIPTION']      |       'DESCRIPTION'
+    }
 }

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1775,7 +1775,8 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
     def "getTestDescription"(testIssue, expected) {
         given:
         LeVADocumentUseCase leVADocumentUseCase = new LeVADocumentUseCase(null, null, null,
-            null, null, null, null, null, null, null, null, null, null, null)
+            null, null, null, null, null, null, null,
+            null, null)
 
         when:
         def result = leVADocumentUseCase.getTestDescription(testIssue)


### PR DESCRIPTION
* Set test summary for empty description in TCR and added getTestDescription test
# Conflicts:
#	src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy