### PR TITLE
Add Helm Support to Release Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Remove orchestration pipeline restriction ([#867](https://github.com/opendevstack/ods-jenkins-shared-library/pull/867))
 - Prevent Jenkins nonCPS error after reporting bug  ([#776](https://github.com/opendevstack/ods-jenkins-shared-library/pull/776))
 - Fixed the Developer Preview fails because "Duplicated Tests"
 - Throw exception when two coded tests are linked to the same test issue (https://github.com/opendevstack/ods-jenkins-shared-library/pull/737)

--- a/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
@@ -73,6 +73,8 @@ If you use this type ODS expects to find JUnit XML test results. If you do not h
 
 This type designates ODS components designed for _consuming on-prem or cloud services_ of arbitrary type using infrastructure as code. Such components are based on quickstarters whose names start with `infra-`.
 
+The `ods-infra` type is suitable to deploy helm charts as well. If you have a directory `charts` in your component the orchestration pipeline will recognize it and make sure the resources in the helm chart are deployed.
+
 ==== Repository Type: ods-saas-service
 
 This type designates ODS components designed for _documenting vendor-provided SaaS services_.

--- a/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
+++ b/src/org/ods/component/RolloutOpenShiftDeploymentStage.groovy
@@ -124,10 +124,6 @@ class RolloutOpenShiftDeploymentStage extends Stage {
             retagImages(context.targetProject, getBuiltImages())
 
             if (steps.fileExists("${options.chartDir}/Chart.yaml")) {
-                if (context.triggeredByOrchestrationPipeline) {
-                    steps.error "Helm cannot be used in the orchestration pipeline yet."
-                    return
-                }
                 refreshResources = true
                 helmUpgrade(context.targetProject)
             } else if (steps.fileExists(options.openshiftDir)) {


### PR DESCRIPTION
This removes the restriction to deploy helm charts  via release manager

#537, #554

* fixes #866