### PR TITLE
Accept empty response in overall docs

### DIFF
--- a/src/org/ods/orchestration/service/DocGenService.groovy
+++ b/src/org/ods/orchestration/service/DocGenService.groovy
@@ -32,13 +32,14 @@ class DocGenService {
     List<DocumentHistoryEntry> createDocument(String projectId, String buildNumber, String levaDocType, Map data) {
         String url = "${this.baseURL}/levaDoc/{projectId}/{build}/{levaDocType}"
         Object response = doRequest(url, projectId, buildNumber, levaDocType, data)
-        return LEVADocResponseMapper.parse(response)
+        String parsedBody = new JsonSlurperClassic().parseText(response.getBody() as String)
+        return LEVADocResponseMapper.parse(parsedBody)
     }
 
     @NonCPS
-    List<DocumentHistoryEntry> createDocumentOverall(String projectId, String buildNumber, String levaDocType, Map data) {
+    void createDocumentOverall(String projectId, String buildNumber, String levaDocType, Map data) {
         String url = "${this.baseURL}/levaDoc/{projectId}/{build}/overall/{levaDocType}"
-        return doRequest(url, projectId, buildNumber, levaDocType, data)
+        doRequest(url, projectId, buildNumber, levaDocType, data)
     }
 
     @NonCPS
@@ -54,7 +55,7 @@ class DocGenService {
         response.ifFailure {
             checkError(levaDocType, response)
         }
-        return new JsonSlurperClassic().parseText(response.getBody())
+        return response
     }
 
     @NonCPS

--- a/src/org/ods/orchestration/service/DocGenService.groovy
+++ b/src/org/ods/orchestration/service/DocGenService.groovy
@@ -32,7 +32,7 @@ class DocGenService {
     List<DocumentHistoryEntry> createDocument(String projectId, String buildNumber, String levaDocType, Map data) {
         String url = "${this.baseURL}/levaDoc/{projectId}/{build}/{levaDocType}"
         Object response = doRequest(url, projectId, buildNumber, levaDocType, data)
-        String parsedBody = new JsonSlurperClassic().parseText(response.getBody() as String)
+        Object parsedBody = new JsonSlurperClassic().parseText(response.getBody() as String)
         return LEVADocResponseMapper.parse(parsedBody)
     }
 

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -116,7 +116,7 @@ class LeVADocumentUseCase {
     }
 
     void createTCR(Map repo = null, Map data = null) {
-        createDocWithTestDataParams(DocumentType.TCR)
+        createDocWithTestDataParams(DocumentType.TCR, data)
     }
 
     void createDTR(Map repo, Map data) {
@@ -150,21 +150,25 @@ class LeVADocumentUseCase {
     }
 
     private void createDocWithDefaultParams(DocumentType documentType) {
+        logger.info("create document ${documentType} start ")
         createDoc(documentType, leVADocumentParamsMapper.build())
+        logger.info("create document ${documentType} end")
     }
 
     private void createDocWithTestDataParams(DocumentType documentType, Map testData) {
         logger.info("create document ${documentType} start, data:${prettyPrint(toJson(testData))}")
         createDoc(documentType, leVADocumentParamsMapper.build(testData))
+        logger.info("create document ${documentType} end")
     }
 
     private void createDocWithComponentDataParams(DocumentType documentType, Map repo, Map testData) {
         logger.info("repo:${prettyPrint(toJson(repo))}), data:${prettyPrint(toJson(testData))}")
         createDoc(documentType, leVADocumentParamsMapper.build([tests: testData, repo: repo]))
+        logger.info("create document ${documentType} end")
     }
 
+    @NonCPS
     private void createDoc(DocumentType documentType, Map params) {
-        logger.info("create document ${documentType} start")
         if (documentType.name().startsWith(OVERALL)){
             docGen.createDocumentOverall(
                 project.getJiraProjectKey(),
@@ -181,7 +185,7 @@ class LeVADocumentUseCase {
                 this.project.setHistoryForDocument(docHistoryList, documentType.name())
             }
         }
-        logger.info("create document ${documentType} end")
+
     }
 
     private String uploadJenkinsJobLog(String projectKey, String buildNumber, InputStream jenkinsJobLog) {


### PR DESCRIPTION
- accepts an empty response when requesting docgen to create an overall doc.
- json parsed text must be Object, not String.