### PR TITLE
WIP:  inf-terraform-aws - preserve errored.tfstate file in case of write failure in make deploy

### DIFF
--- a/src/org/ods/component/InfrastructureStage.groovy
+++ b/src/org/ods/component/InfrastructureStage.groovy
@@ -56,6 +56,10 @@ class InfrastructureStage extends Stage {
             }
             if (runMakeStage("deploy", this.options.cloudProvider,
                               environmentVars, tfBackendS3Key, tfVars['meta_environment'] as String) != 0) {
+                if (script.fileExists('errored.tfstate')) {
+                    logger.warn ("WARN: Terraform could not write statefile. errored.tfstate will be saved as artifact.")
+                    steps.archiveArtifacts(artifacts: 'errored.tfstate')
+                }
                 script.error("IaC - Deploy stage failed!")
             }
             if (runMakeStage("deployment-test", this.options.cloudProvider,


### PR DESCRIPTION
First draft on [#665](https://github.com/opendevstack/ods-quickstarters/issues/665). Need to clarify the process though.
![image](https://user-images.githubusercontent.com/3447712/163407213-3b89dbaf-32ed-46e6-9631-75a26e196ef7.png)
