### PR TITLE
Feature/retrieve debug information

### DIFF
--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -8,6 +8,7 @@ import org.ods.orchestration.util.Project
 import org.ods.services.BitbucketService
 import org.ods.services.OpenShiftService
 import org.ods.services.GitService
+import org.ods.util.PipelineDebugInfo
 import org.ods.util.PipelineSteps
 import org.ods.util.IPipelineSteps
 import org.ods.util.Logger
@@ -93,6 +94,7 @@ class FinalizeStage extends Stage {
 
         // Dump a representation of the project
         logger.debug("---- ODS Project (${project.key}) data ----\r${project}\r -----")
+        new PipelineDebugInfo().save(project, steps, util)
 
         levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
 

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -94,7 +94,7 @@ class FinalizeStage extends Stage {
 
         // Dump a representation of the project
         logger.debug("---- ODS Project (${project.key}) data ----\r${project}\r -----")
-        new PipelineDebugInfo().save(project, steps, util)
+        new PipelineDebugInfo().save(project, steps)
 
         levaDocScheduler.run(phase, MROPipelineUtil.PipelinePhaseLifecycleStage.PRE_END)
 

--- a/src/org/ods/util/IPipelineSteps.groovy
+++ b/src/org/ods/util/IPipelineSteps.groovy
@@ -76,4 +76,5 @@ interface IPipelineSteps {
     def unwrap()
 
     def emailext(Map args)
+
 }

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -1,6 +1,7 @@
 package org.ods.util
 
 import com.cloudbees.groovy.cps.NonCPS
+import groovy.json.JsonOutput
 import hudson.EnvVars
 import org.ods.orchestration.util.Project
 
@@ -15,7 +16,8 @@ class PipelineDebugInfo {
         steps.archiveArtifacts(PROJECT_DEBUG_INFO_FILENAME)
 
         Map environmentDebugInfo = getStepsEnvDebugInfo(steps)
-        steps.writeFile(ENVIRONMENT_DEBUG_INFO_FILENAME, "${environmentDebugInfo}")
+        String environmentDebugInfoTxt = JsonOutput.toJson(environmentDebugInfo)
+        steps.writeFile(ENVIRONMENT_DEBUG_INFO_FILENAME, "${environmentDebugInfoTxt}")
         steps.archiveArtifacts(ENVIRONMENT_DEBUG_INFO_FILENAME)
     }
 

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -24,7 +24,7 @@ class PipelineDebugInfo {
         List keysList = environmentVariables.keySet().toList()
         for (int i=0; i<keysList.size(); i++) {
             String key = keysList.get(i) as String
-            String value = steps.env.get(key) as String
+            String value = environmentVariables.get(key) as String
             result.put(key, value)
         }
     }

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -1,20 +1,19 @@
 package org.ods.util
 
 import org.ods.orchestration.util.Project
-import org.ods.orchestration.util.MROPipelineUtil
 
 class PipelineDebugInfo {
 
     public final String PROJECT_DEBUG_INFO_FILENAME = "project_debug_info.yml"
     public final String ENVIRONMENT_DEBUG_INFO_FILENAME = "environment_debug_info.yml"
 
-    void save(Project project, PipelineSteps steps, MROPipelineUtil util) {
+    void save(Project project, PipelineSteps steps) {
 
-        writeFile(PROJECT_DEBUG_INFO_FILENAME, text: "${project}")
+        steps.writeFile(PROJECT_DEBUG_INFO_FILENAME, "${project}")
         steps.archiveArtifacts(PROJECT_DEBUG_INFO_FILENAME)
 
         Map environmentDebugInfo = getStepsEnvDebugInfo(steps)
-        writeFile(ENVIRONMENT_DEBUG_INFO_FILENAME, text: "${environmentDebugInfo}")
+        steps.writeFile(ENVIRONMENT_DEBUG_INFO_FILENAME, "${environmentDebugInfo}")
         steps.archiveArtifacts(ENVIRONMENT_DEBUG_INFO_FILENAME)
     }
 

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -1,5 +1,6 @@
 package org.ods.util
 
+import hudson.EnvVars
 import org.ods.orchestration.util.Project
 
 class PipelineDebugInfo {
@@ -19,7 +20,8 @@ class PipelineDebugInfo {
 
     private getStepsEnvDebugInfo(PipelineSteps steps) {
         Map result = [:]
-        List keysList = steps.env.keySet().toList()
+        EnvVars environmentVariables = steps.getEnv().getEnvironment()
+        List keysList = environmentVariables.keySet().toList()
         for (int i=0; i<keysList.size(); i++) {
             String key = keysList.get(i) as String
             String value = steps.env.get(key) as String

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -1,0 +1,30 @@
+package org.ods.util
+
+import org.ods.orchestration.util.Project
+import org.ods.orchestration.util.MROPipelineUtil
+
+class PipelineDebugInfo {
+
+    public final String PROJECT_DEBUG_INFO_FILENAME = "project_debug_info.yml"
+    public final String ENVIRONMENT_DEBUG_INFO_FILENAME = "environment_debug_info.yml"
+
+    void save(Project project, PipelineSteps steps, MROPipelineUtil util) {
+
+        writeFile(PROJECT_DEBUG_INFO_FILENAME, text: "${project}")
+        steps.archiveArtifacts(PROJECT_DEBUG_INFO_FILENAME)
+
+        Map environmentDebugInfo = getStepsEnvDebugInfo(steps)
+        writeFile(ENVIRONMENT_DEBUG_INFO_FILENAME, text: "${environmentDebugInfo}")
+        steps.archiveArtifacts(ENVIRONMENT_DEBUG_INFO_FILENAME)
+    }
+
+    private getStepsEnvDebugInfo(PipelineSteps steps) {
+        Map result = [:]
+        List keysList = steps.env.keySet().toList()
+        for (int i=0; i<keysList.size(); i++) {
+            String key = keysList.get(i) as String
+            String value = steps.env.get(key) as String
+            result.put(key, value)
+        }
+    }
+}

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -18,7 +18,7 @@ class PipelineDebugInfo {
         steps.archiveArtifacts(ENVIRONMENT_DEBUG_INFO_FILENAME)
     }
 
-    private getStepsEnvDebugInfo(PipelineSteps steps) {
+    private Map getStepsEnvDebugInfo(PipelineSteps steps) {
         Map result = [:]
         EnvVars environmentVariables = steps.getEnv().getEnvironment()
         List keysList = environmentVariables.keySet().toList()
@@ -27,5 +27,6 @@ class PipelineDebugInfo {
             String value = environmentVariables.get(key) as String
             result.put(key, value)
         }
+        return result
     }
 }

--- a/src/org/ods/util/PipelineDebugInfo.groovy
+++ b/src/org/ods/util/PipelineDebugInfo.groovy
@@ -1,5 +1,6 @@
 package org.ods.util
 
+import com.cloudbees.groovy.cps.NonCPS
 import hudson.EnvVars
 import org.ods.orchestration.util.Project
 
@@ -19,12 +20,19 @@ class PipelineDebugInfo {
     }
 
     private Map getStepsEnvDebugInfo(PipelineSteps steps) {
-        Map result = [:]
         EnvVars environmentVariables = steps.getEnv().getEnvironment()
-        List keysList = environmentVariables.keySet().toList()
-        for (int i=0; i<keysList.size(); i++) {
-            String key = keysList.get(i) as String
-            String value = environmentVariables.get(key) as String
+        Set<Map.Entry> entriesSet = environmentVariables.entrySet()
+        return getVarsMapFromEntriesSet(entriesSet)
+    }
+
+    @NonCPS
+    private Map getVarsMapFromEntriesSet(Set entriesSet) {
+        Map result = [:]
+        List entriesList = entriesSet.toList()
+        for (int i=0; i<entriesList.size(); i++) {
+            Map.Entry entry = entriesList.get(i)
+            String key = entry.getKey() as String
+            String value = entry.getValue() as String
             result.put(key, value)
         }
         return result


### PR DESCRIPTION
The code developed here generates and saves information that can be used by tests in a future stage of developments/refactors of docGen, so we could test that from the same data in a jenkins pipeline execution we obtain exactly the same pdfs.

It is rather interesting to include it in master before refactors like the ones proposed in:

https://github.com/opendevstack/ods-jenkins-shared-library/tree/feature/afterMoveLevaDoc

https://github.com/opendevstack/ods-document-generation-svc/tree/feature/moveLevaDoc

Thanks.