### PR TITLE
fix nexus pypi upload for master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Increase default timeout for rollout  ([#903](https://github.com/opendevstack/ods-jenkins-shared-library/issues/903))
 - Add retry for Openshift image build status ([#901](https://github.com/opendevstack/ods-jenkins-shared-library/issues/901))
 - fix Aqua integration fails for future versions ([#875](https://github.com/opendevstack/ods-jenkins-shared-library/issues/875))
+- fix nexus pypi upload ([#812](https://github.com/opendevstack/ods-jenkins-shared-library/issues/812))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/component/UploadToNexusStage.groovy
+++ b/src/org/ods/component/UploadToNexusStage.groovy
@@ -53,6 +53,8 @@ class UploadToNexusStage extends Stage {
         } else if (options.repositoryType == 'raw') {
             nexusParams << ['raw.asset1.filename': options.distributionFile]
             nexusParams << ['raw.directory': (options.targetDirectory ?: context.projectId)]
+        } else if (options.repositoryType == 'pypi') {
+            nexusParams << ['pypi.asset': options.distributionFile]
         }
 
         def data = steps.readFile(file: options.distributionFile, encoding: 'Base64').toString().getBytes()


### PR DESCRIPTION
fix for Nexus upload stage
related to #812 

Right now we are getting this error when trying to upload a pypi package in this [line](https://github.com/opendevstack/ods-jenkins-shared-library/blob/master/src/org/ods/services/NexusService.groovy#L105) as _pypi.asset_ is null
````
WARN: Error: java.lang.NullPointerException: Cannot invoke method lastIndexOf() on null object
````