### PR TITLE
Feature/flexible r2p jira workflow (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Added default timeout to Aqua stage ([#899](https://github.com/opendevstack/ods-jenkins-shared-library/issues/899))
 - Add retry for Openshift image build status ([#901](https://github.com/opendevstack/ods-jenkins-shared-library/issues/901))
 - Increase default timeout for rollout ([#903](https://github.com/opendevstack/ods-jenkins-shared-library/issues/903))
+- Removes DIL from the set of docs generated for enviroment P ([914](https://github.com/opendevstack/ods-jenkins-shared-library/pull/914))
+- Developer preview uses the release branch if exists, the branch in Release Manager s metadata.yml cfg if not ([#920](https://github.com/opendevstack/ods-jenkins-shared-library/pull/920/))
+- Allow to redeploy to D, Q and P, by setting repromote to true by default and creating tags only if they do not exist ([#926](https://github.com/opendevstack/ods-jenkins-shared-library/pull/926))
 
 ## [4.0] - 2021-05-11
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     if (no_nexus) {
         println("using repositories 'jcenter' and 'mavenCentral'")
         mavenLocal()
-        jcenter()
+        // deprecated: jcenter()
         mavenCentral()
         maven {
             url "https://repo1.maven.org/maven2/"
@@ -47,7 +47,7 @@ repositories {
                 url repoUrl
             }
         }
-        nexusMaven("${nexus_url}/repository/jcenter/")
+        // deprecated: nexusMaven("${nexus_url}/repository/jcenter/")
         nexusMaven("${nexus_url}/repository/maven-public/")
         nexusMaven("${nexus_url}/repository/atlassian_public/")
         nexusMaven("${nexus_url}/repository/jenkins-ci-releases/")
@@ -83,7 +83,7 @@ dependencies {
     testImplementation ("com.athaydes:spock-reports:1.6.0") { transitive = false }
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.0'
     testImplementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
-    testImplementation "com.lesfurets:jenkins-pipeline-unit:1.9"
+    testImplementation group: 'com.lesfurets', name: 'jenkins-pipeline-unit', version: '1.9' // "com.lesfurets:jenkins-pipeline-unit:1.9"
     testImplementation "net.bytebuddy:byte-buddy:1.10.8"
     testImplementation "org.objenesis:objenesis:3.1"
     testImplementation "cglib:cglib-nodep:3.3.0"                      // for mocking classes

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -73,10 +73,8 @@ class FinalizeStage extends Stage {
             logger.debug("Gathering commits")
             gatherCreatedExecutionCommits(steps, git)
 
-            if (!project.buildParams.rePromote) {
-                pushRepos(steps, git)
-                recordAndPushEnvStateForReleaseManager(steps, logger, git)
-            }
+            pushRepos(steps, git)
+            recordAndPushEnvStateForReleaseManager(steps, logger, git)
 
             // add the tag commit that was created for traceability ..
             logger.debug "Current release manager commit: ${project.gitData.commit}"
@@ -97,6 +95,9 @@ class FinalizeStage extends Stage {
         logger.debug("---- ODS Project (${project.key}) data ----\r${project}\r -----")
 
         levaDocScheduler.run(phase, PipelinePhaseLifecycleStage.PRE_END)
+
+        logger.debug("Project has failing tests? ${project.hasFailingTests()}")
+        logger.debug("Project has unexecuted jira tests? ${project.hasUnexecutedJiraTests()}")
 
         // Fail the build in case of failing tests.
         if (project.hasFailingTests() || project.hasUnexecutedJiraTests()) {
@@ -124,6 +125,7 @@ class FinalizeStage extends Stage {
             util.failBuild(message)
             throw new IllegalStateException(message)
         } else {
+            logger.debug("Reporting pipeline status to Jira...")
             project.reportPipelineStatus()
             if (!project.isWorkInProgress) {
                 bitbucket.setBuildStatus (steps.env.BUILD_URL, project.gitData.commit,
@@ -141,12 +143,17 @@ class FinalizeStage extends Stage {
             repoPushTasks << [ (repo.id): {
                 steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
                     if (project.isWorkInProgress) {
-                        git.pushRef(repo.branch)
+                        String branchName = repo.data.git.branch ?: repo.branch
+                        git.pushRef(branchName)
                     } else if (project.isAssembleMode) {
-                        git.createTag(project.targetTag)
+                        if (!git.remoteTagExists(project.targetTag)) {
+                            git.createTag(project.targetTag)
+                        }
                         git.pushBranchWithTags(project.gitReleaseBranch)
                     } else {
-                        git.createTag(project.targetTag)
+                        if (!git.remoteTagExists(project.targetTag)) {
+                            git.createTag(project.targetTag)
+                        }
                         git.pushRef(project.targetTag)
                     }
                 }
@@ -255,8 +262,11 @@ class FinalizeStage extends Stage {
             )
             git.pushRef(MASTER_BRANCH)
             git.switchToExistingBranch(project.gitReleaseBranch)
-            git.createTag(project.targetTag)
-            git.pushBranchWithTags(project.gitReleaseBranch)
+            if (!git.remoteTagExists(project.targetTag)) {
+                git.createTag(project.targetTag)
+            }
+            // To overwrite the existing tag (if redeploy)
+            git.pushForceBranchWithTags(project.gitReleaseBranch)
         }
     }
 

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -53,17 +53,7 @@ class InitStage extends Stage {
         // to concurrent releases).
         def envState = loadEnvState(logger, buildParams.targetEnvironment)
 
-        logger.startClocked("git-releasemanager-${STAGE_NAME}")
-        // git checkout
-        def gitReleaseBranch = GitService.getReleaseBranch(buildParams.version)
-        if (!Project.isWorkInProgress(buildParams.version)) {
-            if (Project.isPromotionMode(buildParams.targetEnvironmentToken)) {
-                checkOutRepoInPromotionMode(git, buildParams, logger, gitReleaseBranch)
-            } else {
-                checkOutRepoInNotPromotionMode(git, gitReleaseBranch, logger)
-            }
-        }
-        logger.debugClocked("git-releasemanager-${STAGE_NAME}")
+        checkOutReleaseManagerRepository(buildParams, git, logger)
 
         logger.debug 'Load build params and metadata file information'
         project.init()
@@ -145,7 +135,7 @@ class InitStage extends Stage {
         return stageToStartAgent
     }
 
-    private Closure buildCheckOutClousure(repos, logger, envState, util) {
+    private Closure buildCheckOutClousure(repos, logger, envState, MROPipelineUtil util) {
         @SuppressWarnings('Indentation')
         Closure checkoutClosure =
             {
@@ -440,23 +430,59 @@ class InitStage extends Stage {
         }
     }
 
-    private void checkOutRepoInNotPromotionMode(GitService git, String gitReleaseBranch, Logger logger) {
+    private void checkOutReleaseManagerRepository(def buildParams, def git,
+                                                  ILogger logger) {
+        logger.startClocked("git-releasemanager-${STAGE_NAME}")
+        if (!Project.isWorkInProgress(buildParams.version)) {
+            def gitReleaseBranch = GitService.getReleaseBranch(buildParams.version)
+            logger.debug("Release Manager branch to checkout: ${gitReleaseBranch}")
+            if (Project.isPromotionMode(buildParams.targetEnvironmentToken)) {
+                checkOutRepoInPromotionMode(git, buildParams, gitReleaseBranch, logger)
+            } else {
+                checkOutRepoInNotPromotionMode(git, gitReleaseBranch, false, logger)
+            }
+        } else {
+            // Here is the difference with respect to deploy-to-D:
+            // The branch to be used is obtained from buildParams.changeId, not from buildParams.version ( = WIP ).
+            def gitReleaseBranch = GitService.getReleaseBranch(buildParams.changeId)
+            logger.info("Release branch that should be used if available: ${gitReleaseBranch}")
+            checkOutRepoInNotPromotionMode(git, gitReleaseBranch, true, logger)
+        }
+        logger.debugClocked("git-releasemanager-${STAGE_NAME}")
+
+    }
+
+    private void checkOutRepoInNotPromotionMode(GitService git,
+                                                String gitReleaseBranch,
+                                                boolean isWorkInProgress,
+                                                Logger logger) {
         if (git.remoteBranchExists(gitReleaseBranch)) {
-            logger.info("Checkout release manager repository @ ${gitReleaseBranch}")
+            logger.info("Checkout release manager repository branch ${gitReleaseBranch}")
             git.checkout(
                 "*/${gitReleaseBranch}",
                 [[$class: 'LocalBranch', localBranch: gitReleaseBranch]],
                 script.scm.userRemoteConfigs
             )
+            project.setGitReleaseBranch(gitReleaseBranch)
         } else {
-            git.checkoutNewLocalBranch(gitReleaseBranch)
+            // If we are still in WIP and there is no branch for current release,
+            // do not create it. We use if only if it exists. We use master if it does not exist.
+            if (! isWorkInProgress) {
+                logger.info("Creating release manager repository branch: ${gitReleaseBranch}")
+                git.checkoutNewLocalBranch(gitReleaseBranch)
+                project.setGitReleaseBranch(gitReleaseBranch)
+            } else {
+                logger.info("Since no deploy was done to D (branch ${gitReleaseBranch} does not exist), "+
+                    "using master branch for developer preview.")
+                project.setGitReleaseBranch("master")
+            }
         }
     }
 
     private void checkOutRepoInPromotionMode(GitService git,
                                              Map buildParams,
-                                             Logger logger,
-                                             String gitReleaseBranch) {
+                                             String gitReleaseBranch,
+                                             Logger logger) {
         def tagList = git.readBaseTagList(
             buildParams.version,
             buildParams.changeId,

--- a/src/org/ods/orchestration/scheduler/LeVADocumentScheduler.groovy
+++ b/src/org/ods/orchestration/scheduler/LeVADocumentScheduler.groovy
@@ -201,8 +201,7 @@ class LeVADocumentScheduler extends DocGenScheduler {
             (DocumentType.TIR as String)    : ["${DocumentType.TIR}_P"],
             (DocumentType.OVERALL_TIR as String)    : ["${DocumentType.TIR}_P"],
             (DocumentType.IVR as String)    : ["${DocumentType.IVR}_P"],
-            (DocumentType.OVERALL_IVR as String)    : ["${DocumentType.IVR}_P"],
-            (DocumentType.DIL as String)    : ["${DocumentType.DIL}_P"]
+            (DocumentType.OVERALL_IVR as String)    : ["${DocumentType.IVR}_P"]
         ]
     ]
 

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -350,7 +350,10 @@ class JiraUseCase {
     }
 
     void updateJiraReleaseStatusResult(String message, boolean isError) {
-        if (!this.jira) return
+        if (!this.jira) {
+            logger.warn("JiraUseCase: jira has an invalid value.")
+            return
+        }
 
         def status = isError ? 'Failed' : 'Successful'
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -218,83 +218,122 @@ class MROPipelineUtil extends PipelineUtil {
         return [
             repo.id,
             {
-                this.logger.startClocked("${repo.id}-scm-checkout")
-                def scm = null
-                def scmBranch = repo.branch
-                if (this.project.isPromotionMode) {
-                    scm = checkoutTagInRepoDir(repo, this.project.baseTag)
-                    scmBranch = this.project.gitReleaseBranch
-                } else {
-                    if (this.project.isWorkInProgress) {
-                        scm = checkoutBranchInRepoDir(repo, repo.branch)
-                    } else {
-                        // check if release manager repo already has a release branch
-                        if (git.remoteBranchExists(this.project.gitReleaseBranch)) {
-                            try {
-                                scm = checkoutBranchInRepoDir(repo, this.project.gitReleaseBranch)
-                            } catch (ex) {
-                                this.logger.warn """
-                                Checkout of '${this.project.gitReleaseBranch}' for repo '${repo.id}' failed.
-                                Attempting to checkout '${repo.branch}' and create the release branch from it.
-                                """
-                                // Possible reasons why this might happen:
-                                // * Release branch manually created in RM repo
-                                // * Repo is added to metadata.yml file on a release branch
-                                // * Release branch has been deleted in repo
-                                scm = checkoutBranchInRepoDir(repo, repo.branch)
-                                steps.dir("${REPOS_BASE_DIR}/${repo.id}") {
-                                    git.checkoutNewLocalBranch(this.project.gitReleaseBranch)
-                                }
-                            }
-                        } else {
-                            scm = checkoutBranchInRepoDir(repo, repo.branch)
-                            steps.dir("${REPOS_BASE_DIR}/${repo.id}") {
-                                git.checkoutNewLocalBranch(this.project.gitReleaseBranch)
-                            }
-                        }
-                        scmBranch = this.project.gitReleaseBranch
-                    }
-                }
-                this.logger.debugClocked("${repo.id}-scm-checkout")
-
-                // in case of a re-checkout, scm.GIT_COMMIT  still points
-                // to the old commit.
-                def commit = scm.GIT_COMMIT
-                def prevCommit = scm.GIT_PREVIOUS_COMMIT
-                def lastSuccessCommit =  scm.GIT_PREVIOUS_SUCCESSFUL_COMMIT
-                if (recheckout) {
-                    steps.dir("${REPOS_BASE_DIR}/${repo.id}") {
-                        commit = git.getCommitSha()
-                        prevCommit = scm.GIT_COMMIT
-                        lastSuccessCommit = scm.GIT_COMMIT
-                    }
-                }
-
-                repo.data.git = [
-                    branch: scmBranch,
-                    commit: commit,
-                    previousCommit: prevCommit,
-                    previousSucessfulCommit: lastSuccessCommit,
-                    url: scm.GIT_URL,
-                    baseTag: this.project.baseTag,
-                    targetTag: this.project.targetTag
-                ]
-                def repoPath = "${this.steps.env.WORKSPACE}/${REPOS_BASE_DIR}/${repo.id}"
-                loadPipelineConfig(repoPath, repo)
-                if (this.project.isAssembleMode) {
-                    if (this.project.forceGlobalRebuild) {
-                        this.logger.debug('Project forces global rebuild ...')
-                    } else {
-                        this.steps.dir(repoPath) {
-                            this.logger.startClocked("${repo.id}-resurrect-data")
-                            this.logger.debug('Checking if repo can be resurrected from previous build ...')
-                            amendRepoForResurrectionIfEligible(repo)
-                            this.logger.debugClocked("${repo.id}-resurrect-data")
-                        }
-                    }
-                }
+                checkoutNotReleaseManagerRepo(repo, recheckout)
             }
         ]
+    }
+
+    void checkoutNotReleaseManagerRepo(Map repo, boolean recheckout = false) {
+        this.logger.startClocked("${repo.id}-scm-checkout")
+        def scm = null
+        def scmBranch = repo.branch
+        if (this.project.isPromotionMode) {
+            this.logger.info("Since in promotion mode, checking out tag ${this.project.baseTag}")
+            scm = checkoutTagInRepoDir(repo, this.project.baseTag)
+            scmBranch = this.project.gitReleaseBranch
+        } else {
+            Map scmResult = checkOutNotReleaseManagerRepoInNotPromotionMode(repo, this.project.isWorkInProgress)
+            scm = scmResult.scm
+            scmBranch = scmResult.scmBranch
+        }
+        this.logger.debugClocked("${repo.id}-scm-checkout")
+
+        // in case of a re-checkout, scm.GIT_COMMIT  still points
+        // to the old commit.
+        def commit = scm.GIT_COMMIT
+        def prevCommit = scm.GIT_PREVIOUS_COMMIT
+        def lastSuccessCommit =  scm.GIT_PREVIOUS_SUCCESSFUL_COMMIT
+        if (recheckout) {
+            steps.dir("${REPOS_BASE_DIR}/${repo.id}") {
+                commit = git.getCommitSha()
+                prevCommit = scm.GIT_COMMIT
+                lastSuccessCommit = scm.GIT_COMMIT
+            }
+        }
+
+        repo.data.git = [
+            branch: scmBranch,
+            commit: commit,
+            previousCommit: prevCommit,
+            previousSucessfulCommit: lastSuccessCommit,
+            url: scm.GIT_URL,
+            baseTag: this.project.baseTag,
+            targetTag: this.project.targetTag
+        ]
+        def repoPath = "${this.steps.env.WORKSPACE}/${REPOS_BASE_DIR}/${repo.id}"
+        loadPipelineConfig(repoPath, repo)
+        if (this.project.isAssembleMode) {
+            if (this.project.forceGlobalRebuild) {
+                this.logger.debug('Project forces global rebuild ...')
+            } else {
+                this.steps.dir(repoPath) {
+                    this.logger.startClocked("${repo.id}-resurrect-data")
+                    this.logger.debug('Checking if repo can be resurrected from previous build ...')
+                    amendRepoForResurrectionIfEligible(repo)
+                    this.logger.debugClocked("${repo.id}-resurrect-data")
+                }
+            }
+        }
+    }
+
+    private Map checkOutNotReleaseManagerRepoInNotPromotionMode(Map repo, boolean isWorkInProgress) {
+        Map scmResult = [ : ]
+        String gitReleaseBranch = this.project.gitReleaseBranch
+        if ("master" == gitReleaseBranch) {
+            gitReleaseBranch = repo.branch
+        }
+
+        // check if release manager repo already has a release branch
+        if (git.remoteBranchExists(gitReleaseBranch)) {
+            try {
+                scmResult.scm = checkoutBranchInRepoDir(repo, gitReleaseBranch)
+                scmResult.scmBranch = gitReleaseBranch
+            } catch (ex) {
+                if (! isWorkInProgress) {
+                    this.logger.warn """
+                                Checkout of '${gitReleaseBranch}' for repo '${repo.id}' failed.
+                                Attempting to checkout '${repo.branch}' and create the release branch from it.
+                                """
+                    // Possible reasons why this might happen:
+                    // * Release branch manually created in RM repo
+                    // * Repo is added to metadata.yml file on a release branch
+                    // * Release branch has been deleted in repo
+
+                    scmResult.scm = createBranchFromDefaultBranch(repo, gitReleaseBranch)
+                    scmResult.scmBranch = gitReleaseBranch
+                } else {
+                    this.logger.warn """
+                                Checkout of '${gitReleaseBranch}' for repo '${repo.id}' failed.
+                                Attempting to checkout branch '${repo.branch}'.
+                                """
+                    scmResult.scm = checkoutBranchInRepoDir(repo, repo.branch)
+                    scmResult.scmBranch = repo.branch
+                }
+            }
+        } else {
+            if (! isWorkInProgress) {
+                scmResult.scm = createBranchFromDefaultBranch(repo, gitReleaseBranch)
+                scmResult.scmBranch = gitReleaseBranch
+            } else {
+                this.logger.info("Since in WIP and no release branch exists (${this.project.gitReleaseBranch}), checking out branch ${repo.branch} for repo ${repo.id}")
+                scmResult.scm = checkoutBranchInRepoDir(repo, repo.branch)
+                scmResult.scmBranch = repo.branch
+            }
+        }
+        return scmResult
+    }
+
+    private def createBranchFromDefaultBranch(Map repo, String branchName) {
+        this.logger.info("Creating branch ${branchName} from branch ${repo.branch} for repo ${repo.id} ")
+        def scm = checkoutBranchInRepoDir(repo, repo.branch)
+        if (repo.branch != branchName) {
+            steps.dir("${REPOS_BASE_DIR}/${repo.id}") {
+                git.checkoutNewLocalBranch(branchName)
+            }
+        } else {
+            this.logger.info("No need to create branch ${branchName} for repo ${repo.id} ")
+        }
+        return scm
     }
 
     def checkoutTagInRepoDir(Map repo, String tag) {

--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -242,6 +242,13 @@ class GitService {
         )
     }
 
+    def pushForceBranchWithTags(String name) {
+        script.sh(
+            script: "git push -f --tags origin ${name}",
+            label: "Push branch ${name} with tags and force"
+        )
+    }
+
     boolean remoteTagExists(String name) {
         def tagStatus = script.sh(
             script: "git ls-remote --exit-code --tags origin ${name} &>/dev/null",

--- a/test/groovy/org/ods/PipelineScript.groovy
+++ b/test/groovy/org/ods/PipelineScript.groovy
@@ -17,7 +17,7 @@ class PipelineScript {
             "getEnvironment" : { [ : ] }
     ]
 
-    def scm
+    def scm = [ "userRemoteConfigs" : "none" ]
 
     def currentBuild = [:]
 

--- a/test/groovy/org/ods/orchestration/InitStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/InitStageSpec.groovy
@@ -1,0 +1,98 @@
+package org.ods.orchestration
+
+import org.ods.PipelineScript
+import org.ods.orchestration.scheduler.LeVADocumentScheduler
+import org.ods.orchestration.usecase.JiraUseCase
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.PipelinePhaseLifecycleStage
+import org.ods.orchestration.util.Project
+import org.ods.services.GitService
+import org.ods.services.ServiceRegistry
+import org.ods.util.ILogger
+import org.ods.util.IPipelineSteps
+import org.ods.util.Logger
+import org.ods.util.PipelineSteps
+import util.SpecHelper
+
+import static util.FixtureHelper.createProject
+
+class InitStageSpec extends SpecHelper {
+    Project project
+    InitStage initStage
+    IPipelineSteps steps
+    PipelineScript script
+    MROPipelineUtil util
+    JiraUseCase jira
+    GitService gitService
+    ILogger logger
+
+    def phase = MROPipelineUtil.PipelinePhases.BUILD
+
+    def setup() {
+        script = new PipelineScript()
+        steps = Mock(PipelineSteps)
+        project = Spy(createProject())
+        util = Mock(MROPipelineUtil)
+        jira = Mock(JiraUseCase)
+        gitService = Mock(GitService)
+        logger = new Logger(script, true)
+        createService()
+        initStage = Spy(new InitStage(script, project, project.repositories, null))
+    }
+
+    ServiceRegistry createService() {
+        def registry = ServiceRegistry.instance
+
+        registry.add(PipelineSteps, steps)
+        registry.add(MROPipelineUtil, util)
+        registry.add(JiraUseCase, jira)
+        registry.add(Logger, logger)
+
+        return registry
+    }
+
+    def "checkOutReleaseManagerRepo_WhenBranchExists"() {
+        given:
+        Map buildParams = [ : ]
+        buildParams.version = "WIP"
+        buildParams.changeId = "1.0.0"
+        buildParams.targetEnvironmentToken = "D"
+        when:
+        initStage.checkOutReleaseManagerRepository(buildParams, gitService, logger)
+
+        then:
+        1 * gitService.remoteBranchExists("release/${buildParams.changeId}") >> true
+        1 * gitService.checkout("*/release/${buildParams.changeId}", _, _)
+    }
+
+    def "checkOutReleaseManagerRepo_WhenBranchNotExistsAndWIP"() {
+        given:
+        Map buildParams = [ : ]
+        buildParams.version = "WIP"
+        buildParams.changeId = "1.0.0"
+        buildParams.targetEnvironmentToken = "D"
+        when:
+        initStage.checkOutReleaseManagerRepository(buildParams, gitService, logger)
+
+        then:
+        1 * gitService.remoteBranchExists("release/${buildParams.changeId}") >> false
+        1 * project.setGitReleaseBranch("master")
+    }
+
+    def "checkOutReleaseManagerRepo_WhenBranchNotExistsAndNoWip"() {
+        given:
+        Map buildParams = [ : ]
+        buildParams.version = "1.0.0"
+        buildParams.changeId = "1.0.0"
+        buildParams.targetEnvironmentToken = "D"
+        String gitReleaseBranch = "release/${buildParams.changeId}"
+        when:
+        initStage.checkOutReleaseManagerRepository(buildParams, gitService, logger)
+
+        then:
+        1 * gitService.remoteBranchExists(gitReleaseBranch) >> false
+        1 * gitService.checkoutNewLocalBranch(gitReleaseBranch)
+        1 * project.setGitReleaseBranch(gitReleaseBranch)
+    }
+
+}

--- a/test/groovy/org/ods/orchestration/scheduler/LeVADocumentSchedulerSpec.groovy
+++ b/test/groovy/org/ods/orchestration/scheduler/LeVADocumentSchedulerSpec.groovy
@@ -6821,7 +6821,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6927,7 +6926,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 
@@ -6995,7 +6993,6 @@ class LeVADocumentSchedulerSpec extends SpecHelper {
 
         then:
         1 * usecase.invokeMethod("createIVR", [[:], data] as Object[])
-        1 * usecase.invokeMethod("createDIL", [[:], data] as Object[])
         0 * usecase.invokeMethod(*_)
     }
 

--- a/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
@@ -2695,8 +2695,9 @@ class ProjectSpec extends SpecHelper {
             [(key): [ documents: docs, status: status, key: key ]]
         }
 
-        def data = [(Project.JiraDataItem.TYPE_DOCS):
-            issue('done1', Project.JiraDataItem.ISSUE_STATUS_DONE, ['CSD', 'SSDS']) +
+        def data = [
+            (Project.JiraDataItem.TYPE_DOCS): issue(
+                      'done1', Project.JiraDataItem.ISSUE_STATUS_DONE, ['CSD', 'SSDS']) +
                 issue('done2', Project.JiraDataItem.ISSUE_STATUS_DONE, ['DTP']) +
                 issue('canceled', Project.JiraDataItem.ISSUE_STATUS_DONE, ['DTP']) +
                 issue('undone1', 'WORK IN PROGress', ['CSD', 'SSDS']) +
@@ -2841,4 +2842,25 @@ class ProjectSpec extends SpecHelper {
         RuntimeException ex = thrown()
         ex.message == 'Error with testIssue key: NET-137, no component assigned or it is wrong.'
     }
+
+    def "load build param - rePromote field"() {
+        when:
+        steps.env.rePromote = rePromoteInput
+        def result = Project.loadBuildParams(steps)
+
+        then:
+        result.rePromote == rePromoteOutput
+
+        where:
+        rePromoteInput  || rePromoteOutput
+        null            || true
+        ""              || true
+        "true"          || true
+        "True"          || true
+        "TRUE"          || true
+        "false"         || false
+        "False"         || false
+        "FALSE"         || false
+    }
+
 }


### PR DESCRIPTION
Cherry pick of https://github.com/opendevstack/ods-jenkins-shared-library/pull/933 for 4.x branch

- [x] Removes DIL from the set of docs generated for enviroment P ([914](https://github.com/opendevstack/ods-jenkins-shared-library/pull/914))
- [x] Developer preview uses the release branch if exists, the branch in Release Manager s metadata.yml cfg if not ([#920](https://github.com/opendevstack/ods-jenkins-shared-library/pull/920/))
- [x] Allow to redeploy to D, Q and P, by setting repromote to true by default and creating tags only if they do not exist ([#926](https://github.com/opendevstack/ods-jenkins-shared-library/pull/926))
