### PR TITLE
Fixed document history path in IVP and IVR (EDPC-1384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - fix nexus pypi upload ([#812](https://github.com/opendevstack/ods-jenkins-shared-library/issues/812))
 - Fix return image build info in odsComponentStageBuildOpenShiftImage ([#909](https://github.com/opendevstack/ods-jenkins-shared-library/issues/909))
 - Fixed errors in library (Null pointers and Serialization) ([#941](https://github.com/opendevstack/ods-jenkins-shared-library/pull/941))
+- Fixed document history path in IVP and IVR ([#944](https://github.com/opendevstack/ods-jenkins-shared-library/pull/944))
 
 ## [3.0] - 2020-08-11
 

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -685,9 +685,9 @@ class LeVADocumentUseCase extends DocGenUseCase {
                     ]
                 }),
                 testsOdsService: testsOfRepoTypeOdsService,
-                testsOdsCode   : testsOfRepoTypeOdsCode
-            ],
-            documentHistory: docHistory?.getDocGenFormat() ?: [],
+                testsOdsCode   : testsOfRepoTypeOdsCode,
+                documentHistory: docHistory?.getDocGenFormat() ?: []
+            ]
         ]
 
         def uri = this.createDocument(documentType, null, data_, [:], null, getDocumentTemplateName(documentType), watermarkText)
@@ -760,9 +760,9 @@ class LeVADocumentUseCase extends DocGenUseCase {
                     statement: discrepancies.conclusion.statement
                 ],
                 testsOdsService   : testsOfRepoTypeOdsService,
-                testsOdsCode      : testsOfRepoTypeOdsCode
-            ],
-            documentHistory: docHistory?.getDocGenFormat() ?: [],
+                testsOdsCode      : testsOfRepoTypeOdsCode,
+                documentHistory   : docHistory?.getDocGenFormat() ?: []
+            ]
         ]
 
         def files = data.tests.installation.testReportFiles.collectEntries { file ->

--- a/test/resources/wiremock/LevaDocUseCaseFunctTest/FRML24113/IVP/WIP/docgen/mappings/document-34c5b1f3-eb8e-4eda-8533-0ed4624af96d.json
+++ b/test/resources/wiremock/LevaDocUseCaseFunctTest/FRML24113/IVP/WIP/docgen/mappings/document-34c5b1f3-eb8e-4eda-8533-0ed4624af96d.json
@@ -98,7 +98,7 @@
                                 "sec9": {
                                     "number": "9",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Reference Documents",
                                     "documents": [
@@ -116,7 +116,7 @@
                                 "sec8s2": {
                                     "number": "8.2",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Abbreviations",
                                     "documents": [
@@ -134,7 +134,7 @@
                                 "sec8s1": {
                                     "number": "8.1",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Definitions",
                                     "documents": [
@@ -152,7 +152,7 @@
                                 "sec2": {
                                     "number": "2",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Scope",
                                     "documents": [
@@ -170,7 +170,7 @@
                                 "sec10": {
                                     "number": "10",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Document History",
                                     "documents": [
@@ -188,7 +188,7 @@
                                 "sec12s2": {
                                     "number": "12.2",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Configuration database CMDB",
                                     "documents": [
@@ -206,7 +206,7 @@
                                 "sec12s1": {
                                     "number": "12.1",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Operational documents on system level",
                                     "documents": [
@@ -230,90 +230,90 @@
                                 }
                             ],
                             "testsOdsService": [
-                                
+
                             ],
                             "testsOdsCode": [
-                                
+
+                            ],
+                            "documentHistory": [
+                                {
+                                    "entryId": 1,
+                                    "rational": "Initial document version."
+                                },
+                                {
+                                    "entryId": 2,
+                                    "rational": "Modifications for project version '2.0'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "entryId": 3,
+                                    "rational": "Modifications for project version '3.0'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "entryId": 4,
+                                    "rational": "Modifications for project version '4.0'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "entryId": 5,
+                                    "rational": "Modifications for project version '4.0'. This document version invalidates the changes done in document version '4'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                }
                             ]
-                        },
-                        "documentHistory": [
-                            {
-                                "entryId": 1,
-                                "rational": "Initial document version."
-                            },
-                            {
-                                "entryId": 2,
-                                "rational": "Modifications for project version '2.0'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "entryId": 3,
-                                "rational": "Modifications for project version '3.0'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "entryId": 4,
-                                "rational": "Modifications for project version '4.0'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "entryId": 5,
-                                "rational": "Modifications for project version '4.0'. This document version invalidates the changes done in document version '4'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
+                        }
                     }
                 },
                 "ignoreArrayOrder": true,

--- a/test/resources/wiremock/LevaDocUseCaseFunctTest/FRML24113/IVR/WIP/docgen/mappings/document-3e2b46f3-4b67-4518-a15b-636e9558e626.json
+++ b/test/resources/wiremock/LevaDocUseCaseFunctTest/FRML24113/IVR/WIP/docgen/mappings/document-3e2b46f3-4b67-4518-a15b-636e9558e626.json
@@ -98,7 +98,7 @@
                                 "sec9": {
                                     "number": "9",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Reference Documents",
                                     "documents": [
@@ -116,7 +116,7 @@
                                 "sec8s2": {
                                     "number": "8.2",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Abbreviations",
                                     "documents": [
@@ -134,7 +134,7 @@
                                 "sec8s1": {
                                     "number": "8.1",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Definitions",
                                     "documents": [
@@ -152,7 +152,7 @@
                                 "sec2": {
                                     "number": "2",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Scope",
                                     "documents": [
@@ -170,7 +170,7 @@
                                 "sec10": {
                                     "number": "10",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Document History",
                                     "documents": [
@@ -188,7 +188,7 @@
                                 "sec12s2": {
                                     "number": "12.2",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Configuration database CMDB",
                                     "documents": [
@@ -206,7 +206,7 @@
                                 "sec12s1": {
                                     "number": "12.1",
                                     "predecessors": [
-                                        
+
                                     ],
                                     "heading": "Operational documents on system level",
                                     "documents": [
@@ -234,7 +234,7 @@
                             ],
                             "numAdditionalTests": 0,
                             "testFiles": [
-                                
+
                             ],
                             "discrepancies": "The following major discrepancies were found during testing. Unexecuted tests: FRML24113-179.",
                             "conclusion": {
@@ -242,72 +242,72 @@
                                 "statement": "Some discrepancies found as tests were not executed."
                             },
                             "testsOdsService": [
-                                
+
                             ],
                             "testsOdsCode": [
-                                
+
+                            ],
+                            "documentHistory": [
+                                {
+                                    "entryId": 1,
+                                    "rational": "Initial document version."
+                                },
+                                {
+                                    "entryId": 2,
+                                    "rational": "Modifications for project version '2.0'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "entryId": 3,
+                                    "rational": "Modifications for project version '3.0'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "entryId": 4,
+                                    "rational": "Modifications for project version '4.0'.",
+                                    "issueType": [
+                                        {
+                                            "type": "documentation chapters",
+                                            "added": [
+
+                                            ],
+                                            "changed": [
+
+                                            ],
+                                            "discontinued": [
+
+                                            ]
+                                        }
+                                    ]
+                                }
                             ]
-                        },
-                        "documentHistory": [
-                            {
-                                "entryId": 1,
-                                "rational": "Initial document version."
-                            },
-                            {
-                                "entryId": 2,
-                                "rational": "Modifications for project version '2.0'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "entryId": 3,
-                                "rational": "Modifications for project version '3.0'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "entryId": 4,
-                                "rational": "Modifications for project version '4.0'.",
-                                "issueType": [
-                                    {
-                                        "type": "documentation chapters",
-                                        "added": [
-                                            
-                                        ],
-                                        "changed": [
-                                            
-                                        ],
-                                        "discontinued": [
-                                            
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
+                        }
                     }
                 },
                 "ignoreArrayOrder": true,


### PR DESCRIPTION
With version 1.2 of templates and shared 4.x the Document History is empty in IVP and IVR