### PR TITLE
Remove support for the url repository field in metadata.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - Fix when the git checkout raise an Exception, the RM is not informed because the Registry is not initialized. ([#938]https://github.com/opendevstack/ods-jenkins-shared-library/issues/938)
 - Fixed document history path in IVP and IVR ([#944](https://github.com/opendevstack/ods-jenkins-shared-library/pull/944))
 - Fixed redeploy to P ([#947](https://github.com/opendevstack/ods-jenkins-shared-library/pull/947))
+- Remove support for the url repository field in metadata.yml ([#954](https://github.com/opendevstack/ods-jenkins-shared-library/pull/954))
 
 ## [3.0] - 2020-08-11
 

--- a/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/orchestration-pipeline.adoc
@@ -29,7 +29,6 @@ name: Project Phoenix
 
 repositories:
   - id: A
-    url: https://github.com/my-org/my-repo-A.git
     branch: master
   - id: B
     name: my-repo-B
@@ -52,7 +51,6 @@ name: Project Phoenix
 
 repositories:
   - id: A
-    url: https://github.com/my-org/my-repo-A.git
     branch: master
     type: ods
   - id: B
@@ -91,7 +89,7 @@ This type designates ODS components designed for _library components_. Such comp
 
 === Automated Resolution of Repository Git URL
 
-If no `url` parameter is provided for a repository configuration in a release manager component's `metadata.yml`, the library will attempt to resolve it based on the component's *origin remote URL* and one of the following:
+The library will attempt to resolve the repository URL based on the component's *origin remote URL* and one of the following:
 
 1) If the `name` parameter is provided, and not empty, the last path part of the URL is resolved to `${repo-name}.git`.
 2) If no `name` parameter is provided, the last path part of the URL is resolved to `${project-id}-${repo-id}.git` (which is the repository name pattern used with *OpenDevStack*). Here `${project-id}` refers to the lowercase value of the top-level `id` attribute in `metadata.yml`.

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -1386,21 +1386,16 @@ class Project {
                 repo.type = MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_CODE
             }
 
-            // Resolve repo URL, if not provided
-            if (!repo.url?.trim()) {
-                this.logger.debug("Could not determine Git URL for repo '${repo.id}' " +
-                        'from project meta data. Attempting to resolve automatically...')
-
-                def gitURL = this.getGitURLFromPath(this.steps.env.WORKSPACE, 'origin')
-                if (repo.name?.trim()) {
-                    repo.url = gitURL.resolve("${repo.name}.git").toString()
-                    repo.remove('name')
-                } else {
-                    repo.url = gitURL.resolve("${result.id.toLowerCase()}-${repo.id}.git").toString()
-                }
-
-                this.logger.debug("Resolved Git URL for repo '${repo.id}' to '${repo.url}'")
+            // Resolve repo URL
+            def gitURL = this.getGitURLFromPath(this.steps.env.WORKSPACE, 'origin')
+            if (repo.name?.trim()) {
+                repo.url = gitURL.resolve("${repo.name}.git").toString()
+                repo.remove('name')
+            } else {
+                repo.url = gitURL.resolve("${result.id.toLowerCase()}-${repo.id}.git").toString()
             }
+
+            this.logger.debug("Resolved Git URL for repo '${repo.id}' to '${repo.url}'")
 
             // Resolve repo branch, if not provided
             if (!repo.branch?.trim()) {

--- a/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
@@ -338,7 +338,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             environments:
               prod:
                 apiUrl: ${configuredProdApiUrl}
@@ -369,7 +368,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - Zephyr
               - LeVADocs:
@@ -405,7 +403,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - Zephyr
               - LeVADocs:
@@ -445,7 +442,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - Zephyr
               - LeVADocs:
@@ -1467,7 +1463,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - LeVADocs:
                   GAMPCategory: 5
@@ -1496,7 +1491,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - LeVADocs:
                   GAMPCategory: 5
@@ -1521,7 +1515,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - LeVADocs:
                   GAMPCategory: 1
@@ -1549,7 +1542,6 @@ class ProjectSpec extends SpecHelper {
             repositories:
               - id: A
                 name: A
-                url: http://git.com
             capabilities:
               - LeVADocs:
         """


### PR DESCRIPTION
This field was never really supported. Removing it now to avoid problems with the R2P Flexible Workflow.