### PR TITLE
fixed branchToEnvironmentMapping example in doc

### DIFF
--- a/docs/modules/jenkins-shared-library/pages/component-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/component-pipeline.adoc
@@ -14,7 +14,7 @@ odsComponentPipeline(
   imageStreamTag: 'ods/jenkins-agent-golang:3.x',
   branchToEnvironmentMapping: [
     'master': 'dev',
-    // 'release/*': 'test'
+    // 'release/': 'test'
   ]
 ) { context ->
   odsComponentStageImportOpenShiftImageOrElse(context) {
@@ -28,7 +28,7 @@ odsComponentPipeline(
 }
 ----
 
-The version in `@Library` can be any Git revsison, such as a branch (e.g. `master` or `2.x`), a tag (e.g. `v2.0`) or even a specific commit.
+The version in `@Library` can be any Git revision, such as a branch (e.g. `master` or `2.x`), a tag (e.g. `v2.0`) or even a specific commit.
 
 There are many built-in stages like `odsComponentStageScanWithSonar` that you can use, please see <<_stages,Stages>> for more details.
 


### PR DESCRIPTION
In the doc of the component pipeline there is this branchToEnvironmentMapping example shown, which still shows `release/*` even though this got apparently changed to `release/` meanwhile and is not supported.

