### PR TITLE
Deploy into Q fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add project property PROJECT.IS_GXP ([#963](https://github.com/opendevstack/ods-jenkins-shared-library/pull/963))
+- Deploy into Q without git tags fails ([#967](https://github.com/opendevstack/ods-jenkins-shared-library/issues/967))
 
 ## [4.1] - 2022-11-17
 

--- a/src/org/ods/orchestration/InitStage.groovy
+++ b/src/org/ods/orchestration/InitStage.groovy
@@ -54,9 +54,11 @@ class InitStage extends Stage {
         def envState = loadEnvState(logger, buildParams.targetEnvironment)
 
         def hasErrorsDuringCheckout = false
+        def checkOutException = null
         try {
             checkOutReleaseManagerRepository(buildParams, git, logger)
-        } catch (Exception) {
+        } catch (Exception e) {
+            checkOutException = new RuntimeException("Error during the checkout of the release manager repository", e)
             hasErrorsDuringCheckout = true
         }
 


### PR DESCRIPTION
Updated InitStage.groovy to show a correct exception when fails the checkout of the release repository