### PR TITLE
Fix/levadoc templates config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix errors when the templatesVersion is not set or set as number ([#](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1000))
 - Fix Component fails to deploy with more than one DeploymentConfig([#981](https://github.com/opendevstack/ods-jenkins-shared-library/issues/981)) 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Fix errors when the templatesVersion is not set or set as number ([#](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1000))
+- Fix errors when the templatesVersion is not set or set as number ([#1000](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1000))
 - Fix Component fails to deploy with more than one DeploymentConfig([#981](https://github.com/opendevstack/ods-jenkins-shared-library/issues/981)) 
 
 ### Fixed

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1211,7 +1211,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
     String getDocumentTemplatesVersion() {
         def capability = this.project.getCapability('LeVADocs')
-        return capability.templatesVersion
+        return capability.templatesVersion ? "${capability.templatesVersion}": Project.DEFAULT_TEMPLATE_VERSION
     }
 
     boolean shouldCreateArtifact (String documentType, Map repo) {

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -1096,7 +1096,7 @@ class Project {
         if (!this.jiraUseCase) return false
         if (!this.jiraUseCase.jira) return false
         def levaDocsCapability = this.getCapability('LeVADocs')
-        if (levaDocsCapability.templatesVersion == '1.0') {
+        if (levaDocsCapability && levaDocsCapability?.templatesVersion == '1.0') {
             return false
         }
         return this.jiraUseCase.jira.isVersionEnabledForDelta(projectKey, versionName)

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -1433,6 +1433,7 @@ class Project {
             if (!templatesVersion) {
                 levaDocsCapability.LeVADocs.templatesVersion = DEFAULT_TEMPLATE_VERSION
             }
+            levaDocsCapability.LeVADocs.templatesVersion = "${levaDocsCapability.LeVADocs.templatesVersion}"
         }
 
         if (result.environments == null) {


### PR DESCRIPTION
When the LeVADoc capabilities were disabled and the jira service is enabled in the metadata.yaml there where some exceptions that were rose due to some checks of the templates version.
The version of the templates is expected to be a string, but the user can change it to a number in the metadata.yaml, this generates an error
This pull request fix both problems