### PR TITLE
Fix helm release - Check pod status after deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Improve Document Generation Experience ([#991](https://github.com/opendevstack/ods-jenkins-shared-library/issues/991))
 - Update Reference Documents & Base Documents sections ([#994](https://github.com/opendevstack/ods-jenkins-shared-library/issues/994))
 - Updated functional tests after fix SSDS appendix per gamp and RA chapter 5 ([#103](https://github.com/opendevstack/ods-document-generation-templates/issues/103))
+- Fix helm release - Check pod status after deployment ([#1005](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1005))
+
 
 ### Fixed
 - Change default registry to match Openshift 4 ([#983] (https://github.com/opendevstack/ods-jenkins-shared-library/issues/983))


### PR DESCRIPTION
This PR will add the same fix we have made in the past for tailor deployment.
The issue is that some pods take time to reach 'running' state and the pipeline fails in case it is not quick enough.

This fix is needed for the new version of PostgreSQL quickstarter (uses Helm out of the box)

Test done:
- [x] Release successfully to D/Q/P with new PostgreSQL component (uses helm) and a tailor based component (docker-plain).

@serverhorror @metmajer 