### PR TITLE
cURL command fix for the sonarqube quality gate report retrieval

### DIFF
--- a/src/org/ods/services/SonarQubeService.groovy
+++ b/src/org/ods/services/SonarQubeService.groovy
@@ -87,15 +87,16 @@ class SonarQubeService {
         String gitBranch,
         String bitbucketPullRequestKey) {
         withSonarServerConfig { hostUrl, authToken ->
-            def getStatusUrl = "${hostUrl}/api/qualitygates/project_status?projectKey=${projectKey}"
+            def getStatusUrl = "${hostUrl}/api/qualitygates/project_status"
+            def urlEncodingFlags = "--data-urlencode projectKey=${projectKey}"
             if (bitbucketPullRequestKey && (sonarQubeEdition != 'community')) {
-                getStatusUrl += "&pullRequest=" << bitbucketPullRequestKey
+                urlEncodingFlags += " --data-urlencode pullRequest=${bitbucketPullRequestKey}"
             } else if (sonarQubeEdition != 'community') {
-                getStatusUrl += "&branch=" << gitBranch
+                urlEncodingFlags += " --data-urlencode branch=${gitBranch}"
             }
             script.sh(
                 label: 'Get status of quality gate',
-                script: "curl -s -u ${authToken}: ${getStatusUrl}",
+                script: "curl -s -u ${authToken}: --url ${getStatusUrl} ${urlEncodingFlags}",
                 returnStdout: true
             )
         }


### PR DESCRIPTION
This PR provides a fully functional fix by using flags for URL encoded parameters when using cURL CLI, in this case for the retrieval of the sonarqube quality gate report. Followup bug fix for #1016. 

Indeed now we use flags for all attributes in this cURL command, and I would strongly recommend doing that and avoid weird URL encoding bugs, for example.