### PR TITLE
Fix image thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Fix blurred images retrieved from Jira in the document chapters ([1022](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1022))
 ### Added
 
 ### Changed

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -95,7 +95,7 @@ class JiraUseCase {
     @NonCPS
     String convertHTMLImageSrcIntoBase64Data(String html) {
         def server = this.jira.baseURL
-
+        html = this.thumbnailImageReplacement(html)
         def pattern = ~/src="(${server}.*?\.(?:gif|GIF|jpg|JPG|jpeg|JPEG|png|PNG))"/
         def result = html.replaceAll(pattern) { match ->
             def src = match[1]
@@ -201,7 +201,6 @@ class JiraUseCase {
                 contentField == field.key && field.value
             }
             content = content ? content.getValue() : ""
-
             this.thumbnailImageReplacement(content)
 
             def documentTypes = (issue.fields.labels ?: [])
@@ -431,12 +430,13 @@ class JiraUseCase {
     }
 
     @NonCPS
-    private thumbnailImageReplacement(content) {
+    def thumbnailImageReplacement(content) {
         def matcher = content =~ /<a.*id="(.*)_thumb".*href="(.*?)"/
         matcher.each {
             def imageMatcher = content =~ /<a.*id="${it[1]}_thumb".*src="(.*?)"/
             content = content.replace(imageMatcher[0][1], it[2])
         }
+        return content
     }
 
 }

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -990,4 +990,18 @@ class JiraUseCaseSpec extends SpecHelper {
         then:
         result == "<img src=\"data:${contentType};base64,${binaryDataCoded}\" imagetext=\"something.png\">aaa<img src=\"data:${contentType};base64,${binaryDataCoded}\" imagetext=\"something2.png\">"
     }
+
+    def "remove thumbnail from image urls"() {
+        given:
+        def usecase = Spy(new JiraUseCase(project, steps, util, jira, logger))
+        def initialHtml = "<p><span class=\"image-wrap\" style=\"\"><a id=\"10007_thumb\" href=\"https://jira-url/secure/attachment/10007/10007_file-name.png\" title=\"file-name.png\" file-preview-type=\"image\" file-preview-id=\"10007\" file-preview-title=\"file-name.png\"><img src=\"https://jira-url/secure/thumbnail/10007/_thumb_10007.png\" style=\"border: 0px solid black\" role=\"presentation\"/></a></span></p>"
+        def finalHtml = "<p><span class=\"image-wrap\" style=\"\"><a id=\"10007_thumb\" href=\"https://jira-url/secure/attachment/10007/10007_file-name.png\" title=\"file-name.png\" file-preview-type=\"image\" file-preview-id=\"10007\" file-preview-title=\"file-name.png\"><img src=\"https://jira-url/secure/attachment/10007/10007_file-name.png\" style=\"border: 0px solid black\" role=\"presentation\"/></a></span></p>"
+
+        when: 'we replace the thumbnail image for the good one'
+        def result = usecase.thumbnailImageReplacement(initialHtml)
+
+        then: 'the result if the snippet with the good url'
+        result == finalHtml
+
+    }
 }


### PR DESCRIPTION
Fix an existing problem with the information provided to render the pdf contains url that points to the thumbnails.
With this fix, we use the right url.