### PR TITLE
added condition for ods-infra components in orchestration deploy stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix documentation refers to qs with prefix infra- however there are only inf- quickstarters  ([#1060](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1060))
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * Aqua scanner and Helm deployment conflict fix for jenkins shared library ([#1067](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1067))
+* Fix ods-infra components require OpenShift projects in Deploy stage ([#1047](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1047))
 
 ## [4.3.3] - 2023-11-07
 

--- a/src/org/ods/orchestration/DeployStage.groovy
+++ b/src/org/ods/orchestration/DeployStage.groovy
@@ -88,7 +88,9 @@ class DeployStage extends Stage {
                 def targetEnvironment = project.buildParams.targetEnvironment
                 def targetProject = project.targetProject
                 def installableRepos = this.project.repositories.findAll { repo ->
-                    MROPipelineUtil.PipelineConfig.INSTALLABLE_REPO_TYPES.contains(repo.type)
+                    if (repo.type?.toLowerCase() != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_INFRA){
+                        MROPipelineUtil.PipelineConfig.INSTALLABLE_REPO_TYPES.contains(repo.type)
+                    }
                 }
                 logger.info("Deploying project '${project.key}' into environment '${targetEnvironment}'" +
                     " installable repos? ${installableRepos.size()}")


### PR DESCRIPTION
Closes #1047

With this change, ods-infra type components will not require to login into Openshift clusters in depoyment stage when promoting. If ods or ods-service type components are in the same "bundle" the login will still happen.