### PR TITLE
Update deprecated apiVersion in ocp templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
+* Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 
 ## [4.3.4] - 2024-02-20
 

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -948,7 +948,7 @@ class OpenShiftService {
     @NonCPS
     private String buildConfigBinaryYml(String name, Map<String,String> labels, String tag) {
         """\
-          apiVersion: v1
+          apiVersion: build.openshift.io/v1
           kind: BuildConfig
           metadata:
             labels: {${labels.collect { k, v -> "${k}: '${v}'" }.join(', ')}}
@@ -982,7 +982,7 @@ class OpenShiftService {
     @NonCPS
     private String imageStreamYml(String name, Map<String,String> labels) {
         """\
-          apiVersion: v1
+          apiVersion: image.openshift.io/v1
           kind: ImageStream
           metadata:
             labels: {${labels.collect { k, v -> "${k}: '${v}'" }.join(', ')}}


### PR DESCRIPTION
Fix https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072 for ods-jenkins-shared-library repository