### PR TITLE
release 4.4.0

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -8,7 +8,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v4.1.2
       - uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: 'CHANGELOG.md'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4.1.0
+              uses: actions/checkout@v4.1.2
 
             - name: check the value of github.workspace and runner.temp
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
+* Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 
 ## [4.3.4] - 2024-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
+* Add Openshift appDomain context value in Quickstarter pipeline, optimize the way to get appDomain from cluster ([#997](https://github.com/opendevstack/ods-quickstarters/issues/997))
 * Fix excessive number of Api calls to Jira to retrieve the last document version ([#654](https://github.com/opendevstack/ods-jenkins-shared-library/issues/654))
 
 ## [4.3.4] - 2024-02-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 ## Unreleased
 
+### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
-* Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
-* Add Openshift appDomain context value in Quickstarter pipeline, optimize the way to get appDomain from cluster ([#997](https://github.com/opendevstack/ods-quickstarters/issues/997))
+
+### Added
+* add dependency updates for Gradle via dependabot ([#1040](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1040))
+
+### Changed
+* Enhance SSDS Document Generation Performance using New Atlassian APIs ([#1084](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1084))
+
+## [4.4.0] - 2024-04-22
+
+### Fixed
+* Fix documentation refers to qs with prefix infra- however there are only inf- quickstarters  ([#1060](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1060))
 * Fix excessive number of Api calls to Jira to retrieve the last document version ([#654](https://github.com/opendevstack/ods-jenkins-shared-library/issues/654))
+
+### Added
+* Add Openshift appDomain context value in Quickstarter pipeline, optimize the way to get appDomain from cluster ([#997](https://github.com/opendevstack/ods-quickstarters/issues/997))
+
+### Changed
+* Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
 
 ## [4.3.4] - 2024-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))
+* Fix excessive number of Api calls to Jira to retrieve the last document version ([#654](https://github.com/opendevstack/ods-jenkins-shared-library/issues/654))
 
 ## [4.3.4] - 2024-02-20
 

--- a/docs/modules/jenkins-shared-library/pages/component-pipeline.adoc
+++ b/docs/modules/jenkins-shared-library/pages/component-pipeline.adoc
@@ -17,7 +17,7 @@ odsComponentPipeline(
     // 'release/': 'test'
   ]
 ) { context ->
-  odsComponentStageImportOpenShiftImageOrElse(context) {
+  odsComponentFindOpenShiftImageOrElse(context) {
     stage('Build') {
       // custom stage
     }

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -2,7 +2,6 @@ package org.ods.component
 
 import org.ods.util.ShellWithRetry
 import org.ods.util.Logger
-import org.ods.services.ServiceRegistry
 import org.ods.services.BitbucketService
 import org.ods.services.GitService
 import org.ods.services.NexusService
@@ -11,6 +10,8 @@ import com.cloudbees.groovy.cps.NonCPS
 import groovy.json.JsonSlurperClassic
 import groovy.json.JsonOutput
 import java.util.concurrent.ExecutionException
+import org.ods.util.IPipelineSteps
+import org.ods.util.PipelineSteps
 
 @SuppressWarnings(['MethodCount', 'UnnecessaryObjectReferences'])
 class Context implements IContext {
@@ -23,6 +24,7 @@ class Context implements IContext {
     private final def script
     // config is a map of config properties to customise the behaviour.
     private final Map config
+    private final IPipelineSteps steps
     private final Logger logger
     // artifact store, the interface to MRP
     private final def artifactUriStore = [builds: [:], deployments: [:]]
@@ -37,6 +39,7 @@ class Context implements IContext {
         this.config = config
         this.logger = logger
         this.localCheckoutEnabled = localCheckoutEnabled
+        this.steps = new PipelineSteps(script)
     }
 
     def assemble() {
@@ -571,17 +574,11 @@ class Context implements IContext {
     }
 
     String getOpenshiftApplicationDomain () {
-        if (!config.environment) {
-            logger.debug('Could not get application domain, as no environment is available')
-            return ''
+        def appDomain = appDomain
+        if (!appDomain) {
+            this.appDomain = appDomain = OpenShiftService.getApplicationDomain(steps)
         }
-        if (!this.appDomain) {
-            logger.startClocked("${config.componentId}-get-oc-app-domain")
-            this.appDomain = ServiceRegistry.instance.get(OpenShiftService).
-                getApplicationDomain(config.targetProject)
-            logger.debugClocked("${config.componentId}-get-oc-app-domain")
-        }
-        this.appDomain
+        return appDomain
     }
 
     // set the rollout retry

--- a/src/org/ods/component/ScanWithTrivyStage.groovy
+++ b/src/org/ods/component/ScanWithTrivyStage.groovy
@@ -60,7 +60,7 @@ class ScanWithTrivyStage extends Stage {
         String errorMessages = ''
         int returnCode = scanViaCli(options.scanners, options.vulType, options.format,
             options.additionalFlags, options.reportFile, options.nexusDataBaseRepository,
-            openShift.getApplicationDomain(context.cdProject))
+            openShift.getApplicationDomain())
         if ([TrivyService.TRIVY_SUCCESS].contains(returnCode)) {
             try {
                 URI reportUriNexus = archiveReportInNexus(options.reportFile, options.nexusReportRepository)

--- a/src/org/ods/orchestration/service/JiraService.groovy
+++ b/src/org/ods/orchestration/service/JiraService.groovy
@@ -91,6 +91,41 @@ class JiraService {
     }
 
     @NonCPS
+    void setIssueLabels(String issueIdOrKey, List names) {
+        if (!issueIdOrKey?.trim()) {
+            throw new IllegalArgumentException('Error: unable to set labels for Jira issue. \'issueIdOrKey\' is undefined.')
+        }
+
+        if (names == null) {
+            throw new IllegalArgumentException('Error: unable to set labels for Jira issue. \'names\' is undefined.')
+        }
+
+        def response = Unirest.put("${this.baseURL}/rest/api/2/issue/{issueIdOrKey}")
+            .routeParam("issueIdOrKey", issueIdOrKey)
+            .basicAuth(this.username, this.password)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .body(JsonOutput.toJson(
+                [
+                    fields: [
+                        labels: names
+                    ]
+                ]
+            ))
+            .asString()
+
+        response.ifFailure {
+            def message = "Error: unable to set labels for Jira issue. Jira responded with code: '${response.getStatus()}' and message: '${response.getBody()}'."
+
+            if (response.getStatus() == 404) {
+                message = "Error: unable to set labels for Jira issue. Jira could not be found at: '${this.baseURL}'."
+            }
+
+            throw new RuntimeException(message)
+        }
+    }
+
+    @NonCPS
     void appendCommentToIssue(String issueIdOrKey, String comment) {
         if (!issueIdOrKey?.trim()) {
             throw new IllegalArgumentException('Error: unable to append comment to Jira issue. \'issueIdOrKey\' is undefined.')

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -3,6 +3,7 @@ package org.ods.orchestration.usecase
 import com.cloudbees.groovy.cps.NonCPS
 import org.ods.orchestration.parser.JUnitParser
 import org.ods.orchestration.service.JiraService
+import org.ods.orchestration.util.ConcurrentCache
 import org.ods.util.IPipelineSteps
 import org.ods.util.ILogger
 import org.ods.orchestration.util.MROPipelineUtil
@@ -35,6 +36,7 @@ class JiraUseCase {
     private AbstractJiraUseCaseSupport support
     private MROPipelineUtil util
     private ILogger logger
+    private ConcurrentCache docVersions
 
     JiraUseCase(Project project, IPipelineSteps steps, MROPipelineUtil util, JiraService jira, ILogger logger) {
         this.project = project
@@ -42,6 +44,25 @@ class JiraUseCase {
         this.util = util
         this.jira = jira
         this.logger = logger
+
+        def computeIfAbsent = { key ->
+            def documentationTrackingIssueFields =
+                this.project.getJiraFieldsForIssueType(IssueTypes.DOCUMENTATION_TRACKING)
+            def documentVersionField = documentationTrackingIssueFields[CustomIssueFields.DOCUMENT_VERSION].id as String
+            def version = 0L
+            def versionField =
+                this.jira.getTextFieldsOfIssue(key as String, [documentVersionField])?.getAt(documentVersionField)
+            if (versionField) {
+                try {
+                    version = versionField.toLong()
+                } catch (NumberFormatException _) {
+                    version = 0L
+                }
+            }
+            return version
+        }
+
+        this.docVersions = new ConcurrentCache<String, Long>(computeIfAbsent)
     }
 
     void setSupport(AbstractJiraUseCaseSupport support) {
@@ -55,30 +76,26 @@ class JiraUseCase {
         def matchedHandler = { result ->
             result.each { testIssue, testCase ->
                 def issueLabels = [TestIssueLabels.Succeeded as String]
-                if (testCase.skipped || testCase.error || testCase.failure) {
-                    if (testCase.error) {
-                        issueLabels = [TestIssueLabels.Error as String]
-                    }
-
-                    if (testCase.failure) {
-                        issueLabels = [TestIssueLabels.Failed as String]
-                    }
-
-                    if (testCase.skipped) {
-                        issueLabels = [TestIssueLabels.Skipped as String]
-                    }
+                if (testCase.error) {
+                    issueLabels = [TestIssueLabels.Error as String]
                 }
 
-                this.jira.removeLabelsFromIssue(testIssue.key, TestIssueLabels.values().collect { it.toString() })
-                this.jira.addLabelsToIssue(testIssue.key, issueLabels)
+                if (testCase.failure) {
+                    issueLabels = [TestIssueLabels.Failed as String]
+                }
+
+                if (testCase.skipped) {
+                    issueLabels = [TestIssueLabels.Skipped as String]
+                }
+
+                this.jira.setIssueLabels(testIssue.key, issueLabels)
             }
         }
 
         // Handle Jira test issues for which no corresponding test exists in testResults
         def unmatchedHandler = { result ->
             result.each { testIssue ->
-                this.jira.removeLabelsFromIssue(testIssue.key, TestIssueLabels.values().collect { it.toString() })
-                this.jira.addLabelsToIssue(testIssue.key, [TestIssueLabels.Missing as String])
+                this.jira.setIssueLabels(testIssue.key, [TestIssueLabels.Missing as String])
             }
         }
 
@@ -388,29 +405,15 @@ class JiraUseCase {
     }
 
     Long getLatestDocVersionId(List<Map> trackingIssues) {
-        def documentationTrackingIssueFields = this.project.getJiraFieldsForIssueType(IssueTypes.DOCUMENTATION_TRACKING)
-        def documentVersionField = documentationTrackingIssueFields[CustomIssueFields.DOCUMENT_VERSION].id as String
-
-        // We will use the biggest ID available
+        logger.debug("Cache of versions from doc tracking issues: ${docVersions}")
         def versionList = trackingIssues.collect { issue ->
-            def versionNumber = 0L
-
-            def version = this.jira.getTextFieldsOfIssue(issue.key as String, [documentVersionField])?.getAt(documentVersionField)
-            if (version) {
-                try {
-                    versionNumber = version.toLong()
-                } catch (NumberFormatException _) {
-                    this.logger.warn("Document tracking issue '${issue.key}' does not contain a valid numerical" +
-                        " version. It contains value '${version}'.")
-                }
-            }
-
-            return versionNumber
+            docVersions.get(issue.key)
         }
 
+        // We will use the biggest ID available
         def result = versionList.max()
-        logger.debug("Retrieved max doc version ${versionList.max()} from doc tracking issues " +
-            "${trackingIssues.collect { it.key } }")
+        logger.debug("Retrieved max doc version ${result} from doc tracking issues " +
+            "${trackingIssues.collect { it.key }}")
 
         return result
     }

--- a/src/org/ods/orchestration/util/ConcurrentCache.groovy
+++ b/src/org/ods/orchestration/util/ConcurrentCache.groovy
@@ -1,0 +1,31 @@
+package org.ods.orchestration.util
+
+import com.cloudbees.groovy.cps.NonCPS
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.function.Function
+
+class ConcurrentCache<K, V> {
+
+    private final ConcurrentMap<K, V> cache
+    private final Function<? super K, ? extends V> computeIfAbsent
+
+    ConcurrentCache(Function<? super K, ? extends V> computeIfAbsent,
+                    int initialCapacity = 64, float loadFactor = 0.75f, int concurrencyLevel = 1) {
+        this.cache = new ConcurrentHashMap(initialCapacity, loadFactor, concurrencyLevel)
+        this.computeIfAbsent = computeIfAbsent
+    }
+
+    @NonCPS
+    def get(K key) {
+        cache.computeIfAbsent(key, this.computeIfAbsent)
+    }
+
+    @NonCPS
+    @Override
+    String toString() {
+        return cache.toString()
+    }
+
+}

--- a/src/org/ods/quickstarter/Context.groovy
+++ b/src/org/ods/quickstarter/Context.groovy
@@ -145,4 +145,9 @@ class Context implements IContext {
         config.odsGitRef
     }
 
+    @NonCPS
+    String getAppDomain() {
+        config.appDomain
+    }
+
 }

--- a/src/org/ods/quickstarter/IContext.groovy
+++ b/src/org/ods/quickstarter/IContext.groovy
@@ -71,4 +71,7 @@ interface IContext {
     // alias for odsGitRef
     String getGitBranch()
 
+    // get app domain of the Openshift cluster
+    String getAppDomain()
+
 }

--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -2,20 +2,20 @@ package org.ods.quickstarter
 
 import org.ods.services.BitbucketService
 import org.ods.services.NexusService
-
-import org.ods.util.Logger
-import org.ods.util.ILogger
+import org.ods.services.OpenShiftService
+import org.ods.util.IPipelineSteps
+import org.ods.util.PipelineSteps
 
 class Pipeline implements Serializable {
 
     private final def script
     private final Map config
-    private final ILogger logger
+    private final IPipelineSteps steps
 
     Pipeline(def script, Map config) {
         this.script = script
         this.config = config
-        this.logger = new Logger(script, false)
+        this.steps = new PipelineSteps(script)
     }
 
     @SuppressWarnings(['AbcMetric', 'UnnecessaryObjectReferences'])
@@ -99,6 +99,10 @@ class Pipeline implements Serializable {
         }
     }
 
+    private initappDomain() {
+        config.appDomain = OpenShiftService.getApplicationDomain(steps)
+    }
+
     private onAgentNode(Map config, Closure block) {
         if (!config.podContainers) {
             if (!config.containsKey('alwaysPullImage')) {
@@ -148,6 +152,7 @@ class Pipeline implements Serializable {
             annotations: config.annotations,
         ) {
             script.node(podLabel) {
+                initappDomain()
                 IContext context = new Context(config)
                 block(context)
             }

--- a/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
+++ b/src/org/ods/quickstarter/RenderJenkinsfileStage.groovy
@@ -20,7 +20,7 @@ class RenderJenkinsfileStage extends Stage {
         def target = "${context.targetDir}/${config.target}"
         script.sh(
             script: """
-            sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.sourceDir}|g; s|@git_url_http@|${context.gitUrlHttp}|g; s|@ods_namespace@|${context.odsNamespace}|g; s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g; s|@agent_image_tag@|${context.agentImageTag}|g; s|@shared_library_ref@|${context.sharedLibraryRef}|g' ${source} > ${target}
+            sed 's|@project_id@|${context.projectId}|g; s|@component_id@|${context.componentId}|g; s|@component_type@|${context.sourceDir}|g; s|@git_url_http@|${context.gitUrlHttp}|g; s|@ods_namespace@|${context.odsNamespace}|g; s|@ods_image_tag@|${context.odsImageTag}|g; s|@ods_git_ref@|${context.odsGitRef}|g; s|@agent_image_tag@|${context.agentImageTag}|g; s|@shared_library_ref@|${context.sharedLibraryRef}|g; s|@app_domain@|${context.appDomain}|g' ${source} > ${target}
             """,
             label: "Render '${config.source}' to '${config.target}'"
         )

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -948,7 +948,7 @@ class OpenShiftService {
     @NonCPS
     private String buildConfigBinaryYml(String name, Map<String,String> labels, String tag) {
         """\
-          apiVersion: v1
+          apiVersion: build.openshift.io/v1
           kind: BuildConfig
           metadata:
             labels: {${labels.collect { k, v -> "${k}: '${v}'" }.join(', ')}}
@@ -982,7 +982,7 @@ class OpenShiftService {
     @NonCPS
     private String imageStreamYml(String name, Map<String,String> labels) {
         """\
-          apiVersion: v1
+          apiVersion: image.openshift.io/v1
           kind: ImageStream
           metadata:
             labels: {${labels.collect { k, v -> "${k}: '${v}'" }.join(', ')}}

--- a/src/org/ods/services/OpenShiftService.groovy
+++ b/src/org/ods/services/OpenShiftService.groovy
@@ -9,8 +9,6 @@ import org.ods.util.ILogger
 import org.ods.util.IPipelineSteps
 import org.ods.util.PodData
 
-import java.security.SecureRandom
-
 @SuppressWarnings(['ClassSize', 'MethodCount'])
 @TypeChecked
 class OpenShiftService {
@@ -51,6 +49,18 @@ class OpenShiftService {
         ).toString().trim()
     }
 
+    static String getConsoleUrl(IPipelineSteps steps) {
+        String routeUrl = steps.sh(
+            script: 'oc whoami --show-console',
+            label: 'Get OpenShift Console URL',
+            returnStdout: true
+        )
+        if (!routeUrl) {
+            throw new RuntimeException ("Cannot get cluster console url!")
+        }
+        return routeUrl.trim()
+    }
+
     static boolean tooManyEnvironments(IPipelineSteps steps, String projectId, Integer limit) {
         steps.sh(
             returnStdout: true,
@@ -69,30 +79,15 @@ class OpenShiftService {
         exists
     }
 
-    static String getApplicationDomainOfProject(IPipelineSteps steps, String project) {
-        if (!envExists(steps, project)) {
-            String currentClusterUrl = getApiUrl(steps)
-            throw new IOException ("OCP project ${project} on server ${currentClusterUrl}" +
-                ' does not exist - cannot create route to retrieve host / domain name!' +
-                ' If this is needed, please create project on cluster!')
+    static String getApplicationDomain(IPipelineSteps steps) {
+        def routeUrl = getConsoleUrl(steps)
+
+        def routePrefixLength = routeUrl.indexOf('.')
+        if (routePrefixLength < 0) {
+            throw new RuntimeException ("Route does not contain a dot: ${routeUrl}")
         }
-        def routeName = 'test-route-' + (System.currentTimeMillis() +
-            new SecureRandom().nextInt(1000))
-        steps.sh (
-            script: "oc -n ${project} create route edge ${routeName} --service=dummy --port=80 | true",
-            label: "create dummy route for extraction (${routeName})"
-        )
-        def routeUrl = steps.sh (
-            script: "oc -n ${project} get route ${routeName} -o jsonpath='{.spec.host}'",
-            returnStdout: true,
-            label: 'get cluster route domain'
-        ).toString().trim()
-        def routePrefixLength = "${routeName}-${project}".length() + 1
-        def openShiftPublicHost = routeUrl[routePrefixLength..-1]
-        steps.sh (
-            script: "oc -n ${project} delete route ${routeName} | true",
-            label: "delete dummy route for extraction (${routeName})"
-        )
+
+        def openShiftPublicHost = routeUrl[routePrefixLength+1..-1]
         return openShiftPublicHost
     }
 
@@ -168,7 +163,7 @@ class OpenShiftService {
         def excludeFlag = target.exclude ? "--exclude ${target.exclude}" : ''
         def includeArg = target.include ?: ''
         def paramFileFlag = paramFile ? "--param-file ${paramFile}" : ''
-        params << "ODS_OPENSHIFT_APP_DOMAIN=${getApplicationDomain(project)}".toString()
+        params << "ODS_OPENSHIFT_APP_DOMAIN=${getApplicationDomain()}".toString()
         def paramFlags = params.collect { "--param ${it}" }.join(' ')
         def preserveFlags = preserve.collect { "--preserve ${it}" }.join(' ')
         doTailorApply(project, "${selectorFlag} ${excludeFlag} ${paramFlags} ${preserveFlags} ${paramFileFlag} ${tailorPrivateKeyFlag} ${verifyFlag} --ignore-unknown-parameters ${includeArg}")
@@ -474,8 +469,8 @@ class OpenShiftService {
         m
     }
 
-    String getApplicationDomain(String project) {
-        getApplicationDomainOfProject(steps, project)
+    String getApplicationDomain() {
+        getApplicationDomain(steps)
     }
 
     // imageInfoForImageUrl expects an image URL like one of the following:
@@ -1332,7 +1327,7 @@ class OpenShiftService {
         }
 
         // Replace values from envParams with parameters, and add parameters into template.
-        envParams['ODS_OPENSHIFT_APP_DOMAIN'] = getApplicationDomain(project)
+        envParams['ODS_OPENSHIFT_APP_DOMAIN'] = getApplicationDomain()
         def templateParams = ''
         def sedReplacements = ''
         envParams.each { key, val ->

--- a/test/groovy/org/ods/component/ContextSpec.groovy
+++ b/test/groovy/org/ods/component/ContextSpec.groovy
@@ -4,7 +4,9 @@ import org.ods.PipelineScript
 import org.ods.util.ILogger
 import org.ods.util.Logger
 import org.ods.util.ShellWithRetry
+import org.ods.util.IPipelineSteps
 import spock.lang.*
+import org.ods.services.OpenShiftService
 
 class ContextSpec extends Specification {
 
@@ -152,6 +154,21 @@ class ContextSpec extends Specification {
             }
         }
         uut.determineEnvironment()
+    }
+
+    def "get openshift cluster domain"() {
+        given:
+        def steps = Stub(IPipelineSteps)
+        GroovySpy(OpenShiftService, constructorArgs: [steps, new Logger(steps, false)], global: true)
+        def context = new Context(steps, null, logger)
+        def expectedDomain = 'apps.openshift.com'
+        OpenShiftService.getApplicationDomain(_) >> expectedDomain
+
+        when:
+        def domain = context.getOpenshiftApplicationDomain()
+
+        then:
+        domain == expectedDomain
     }
 
 }

--- a/test/groovy/org/ods/orchestration/service/JiraServiceSpec.groovy
+++ b/test/groovy/org/ods/orchestration/service/JiraServiceSpec.groovy
@@ -216,6 +216,162 @@ class JiraServiceSpec extends SpecHelper {
         stopServer(server)
     }
 
+    Map setIssueLabelsRequestData(Map mixins = [:]) {
+        def result = [
+            data: [
+                issueIdOrKey: "JIRA-123",
+                names: ["Label-A", "Label-B", "Label-C"]
+            ],
+            headers: [
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            ],
+            password: "password",
+            username: "username"
+        ]
+
+        result.body = JsonOutput.toJson([
+            fields: [
+                labels: result.data.names
+            ]
+        ])
+
+        result.path = "/rest/api/2/issue/${result.data.issueIdOrKey}"
+
+        return result << mixins
+    }
+
+    Map setIssueLabelsResponseData(Map mixins = [:]) {
+        def result = [
+            status: 200
+        ]
+
+        return result << mixins
+    }
+
+    def "set issue labels with invalid issueIdOrKey"() {
+        given:
+        def request = setIssueLabelsRequestData()
+        def response = setIssueLabelsResponseData()
+
+        def server = createServer(WireMock.&put, request, response)
+        def service = createService(server.port(), request.username, request.password)
+
+        when:
+        service.setIssueLabels(null, request.data.names)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Error: unable to set labels for Jira issue. 'issueIdOrKey' is undefined."
+
+        when:
+        service.setIssueLabels(" ", request.data.names)
+
+        then:
+        e = thrown(IllegalArgumentException)
+        e.message == "Error: unable to set labels for Jira issue. 'issueIdOrKey' is undefined."
+    }
+
+    def "set issue labels with invalid names"() {
+        given:
+        def request = setIssueLabelsRequestData()
+        def response = setIssueLabelsResponseData()
+
+        def server = createServer(WireMock.&put, request, response)
+        def service = createService(server.port(), request.username, request.password)
+
+        when:
+        service.setIssueLabels(request.data.issueIdOrKey, null)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Error: unable to set labels for Jira issue. 'names' is undefined."
+    }
+
+    def "set issue labels"() {
+        given:
+        def request = setIssueLabelsRequestData()
+        def response = setIssueLabelsResponseData()
+
+        def server = createServer(WireMock.&put, request, response)
+        def service = createService(server.port(), request.username, request.password)
+
+        when:
+        service.setIssueLabels(request.data.issueIdOrKey, request.data.names)
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        stopServer(server)
+    }
+
+    def "set issue labels to empty list"() {
+        given:
+        def request = setIssueLabelsRequestData([
+            body: JsonOutput.toJson([
+                fields: [
+                    labels: []
+                ]
+            ])
+        ])
+        def response = setIssueLabelsResponseData()
+
+        def server = createServer(WireMock.&put, request, response)
+        def service = createService(server.port(), request.username, request.password)
+
+        when:
+        service.setIssueLabels(request.data.issueIdOrKey, [])
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        stopServer(server)
+    }
+
+    def "set issue labels with HTTP 404 failure"() {
+        given:
+        def request = setIssueLabelsRequestData()
+        def response = setIssueLabelsResponseData([
+            status: 404
+        ])
+
+        def server = createServer(WireMock.&put, request, response)
+        def service = createService(server.port(), request.username, request.password)
+
+        when:
+        service.setIssueLabels(request.data.issueIdOrKey, request.data.names)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message == "Error: unable to set labels for Jira issue. Jira could not be found at: 'http://localhost:${server.port()}'."
+
+        cleanup:
+        stopServer(server)
+    }
+
+    def "set issue labels with HTTP 500 failure"() {
+        given:
+        def request = setIssueLabelsRequestData()
+        def response = setIssueLabelsResponseData([
+            body: "Sorry, doesn't work!",
+            status: 500
+        ])
+
+        def server = createServer(WireMock.&put, request, response)
+        def service = createService(server.port(), request.username, request.password)
+
+        when:
+        service.setIssueLabels(request.data.issueIdOrKey, request.data.names)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message == "Error: unable to set labels for Jira issue. Jira responded with code: '${response.status}' and message: 'Sorry, doesn\'t work!'."
+
+        cleanup:
+        stopServer(server)
+    }
 
     Map appendCommentToIssueRequestData(Map mixins = [:]) {
         def result = [

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -48,29 +48,24 @@ class JiraUseCaseSpec extends SpecHelper {
         usecase.applyXunitTestResultsAsTestIssueLabels(testIssues, testResults)
 
         then:
-        1 * jira.removeLabelsFromIssue("JIRA-1", { return it == TestIssueLabels.values()*.toString() })
-        1 * jira.addLabelsToIssue("JIRA-1", ["Succeeded"])
-        0 * jira.addLabelsToIssue("JIRA-1", _)
+        1 * jira.setIssueLabels("JIRA-1", ["Succeeded"])
+        0 * jira.setIssueLabels("JIRA-1", _)
 
         then:
-        1 * jira.removeLabelsFromIssue("JIRA-2", { it == TestIssueLabels.values()*.toString() })
-        1 * jira.addLabelsToIssue("JIRA-2", ["Error"])
-        0 * jira.addLabelsToIssue("JIRA-2", _)
+        1 * jira.setIssueLabels("JIRA-2", ["Error"])
+        0 * jira.setIssueLabels("JIRA-2", _)
 
         then:
-        1 * jira.removeLabelsFromIssue("JIRA-3", { it == TestIssueLabels.values()*.toString() })
-        1 * jira.addLabelsToIssue("JIRA-3", ["Failed"])
-        0 * jira.addLabelsToIssue("JIRA-3", _)
+        1 * jira.setIssueLabels("JIRA-3", ["Failed"])
+        0 * jira.setIssueLabels("JIRA-3", _)
 
         then:
-        1 * jira.removeLabelsFromIssue("JIRA-4", { it == TestIssueLabels.values()*.toString() })
-        1 * jira.addLabelsToIssue("JIRA-4", ["Skipped"])
-        0 * jira.addLabelsToIssue("JIRA-4", _)
+        1 * jira.setIssueLabels("JIRA-4", ["Skipped"])
+        0 * jira.setIssueLabels("JIRA-4", _)
 
         then:
-        1 * jira.removeLabelsFromIssue("JIRA-5", { it == TestIssueLabels.values()*.toString() })
-        1 * jira.addLabelsToIssue("JIRA-5", ["Missing"])
-        0 * jira.addLabelsToIssue("JIRA-5", _)
+        1 * jira.setIssueLabels("JIRA-5", ["Missing"])
+        0 * jira.setIssueLabels("JIRA-5", _)
     }
 
     def "check Jira issue matches test case"() {

--- a/test/groovy/org/ods/orchestration/util/ConcurrentCacheSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ConcurrentCacheSpec.groovy
@@ -1,0 +1,30 @@
+package org.ods.orchestration.util
+
+import util.SpecHelper
+
+class ConcurrentCacheSpec extends SpecHelper {
+
+    def "Return value from cache"() {
+        given:
+            def cache = new ConcurrentCache<String, Long>({ key -> 123456L })
+
+        when:
+            def result = cache.get("key")
+
+        then:
+            123456L == result
+    }
+
+    def "Output toString"() {
+        given:
+            def cache = new ConcurrentCache<String, Long>({ key -> 123456L })
+            cache.get("key")
+
+        when:
+            def result = cache.toString()
+
+        then:
+            "{key=123456}" == result
+    }
+
+}

--- a/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
+++ b/test/groovy/org/ods/services/OpenShiftServiceSpec.groovy
@@ -566,4 +566,63 @@ class OpenShiftServiceSpec extends SpecHelper {
           'Deployment'      |   'rs'
     }
 
+    def "getConsoleUrl from cluster"() {
+        given:
+        def steps = Stub(IPipelineSteps)
+        def service = new OpenShiftService(steps, new Logger(steps, false))
+        def routeUrl = 'https://console-openshift-console.apps.openshift.com'
+        steps.sh( { it.script == 'oc whoami --show-console' } ) >> routeUrl
+
+        when:
+        def result = service.getConsoleUrl(steps)
+
+        then: 
+        result == routeUrl
+    }
+
+    @Unroll
+    def "getConsoleUrl from cluster if null or empty"() {
+        given:
+        def steps = Stub(IPipelineSteps)
+        def service = new OpenShiftService(steps, new Logger(steps, false))
+        steps.sh(_) >> routeUrl
+
+        when:
+        def result = service.getConsoleUrl(steps)
+
+        then:
+        thrown(RuntimeException)
+
+        where:
+        routeUrl << [null, '']
+    }
+
+    def "getApplicationDomain from consoleUrl"() {
+        given:
+        def steps = Stub(IPipelineSteps)
+        GroovySpy(OpenShiftService, constructorArgs: [steps, new Logger(steps, false)], global: true)
+        def routeUrl = 'https://console-openshift-console.apps.openshift.com'
+        def expectedDomain = "apps.openshift.com"
+        OpenShiftService.getConsoleUrl(_) >> routeUrl
+
+        when:
+        def domain = OpenShiftService.getApplicationDomain(steps)
+
+        then:
+        domain == expectedDomain
+    }
+
+    def "getApplicationDomain from consoleUrl if no dot"() {
+        given:
+        def steps = Stub(IPipelineSteps)
+        GroovySpy(OpenShiftService, constructorArgs: [steps, new Logger(steps, false)], global: true)
+        def routeUrl = 'https://console-openshift-console-apps-openshift-com'
+        OpenShiftService.getConsoleUrl(_) >> routeUrl
+
+        when:
+        def domain = OpenShiftService.getApplicationDomain(steps)
+
+        then:
+        thrown(RuntimeException)
+    }
 }


### PR DESCRIPTION
## [4.4.0] - 2024-04-22

### Fixed
* Fix documentation refers to qs with prefix infra- however there are only inf- quickstarters  ([#1060](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1060))
* Fix excessive number of Api calls to Jira to retrieve the last document version ([#654](https://github.com/opendevstack/ods-jenkins-shared-library/issues/654))

### Added
* Add Openshift appDomain context value in Quickstarter pipeline, optimize the way to get appDomain from cluster ([#997](https://github.com/opendevstack/ods-quickstarters/issues/997))

### Changed
* Update api version in ocp templates for image, buildconfig, route and deploymentconfig ([#1072](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1072))