### PR TITLE
Workaround for bitbucket trouble with git-notes

### DIFF
--- a/src/org/ods/services/GitService.groovy
+++ b/src/org/ods/services/GitService.groovy
@@ -150,7 +150,10 @@ class GitService {
 
         return (gitCommitSubject.contains('[ciskip]')
                  || gitCommitSubject.contains('[skipci]')
-                 || gitCommitSubject.contains('***noci***'))
+                 || gitCommitSubject.contains('***noci***')
+                //  Workaround for Bitbucket git-notes behaviour - reference:
+                // https://github.com/semantic-release/semantic-release/discussions/2017#discussioncomment-995308
+                 || gitCommitSubject.contains("Notes added by 'git notes add'"))
     }
     void checkout(
         String branch,


### PR DESCRIPTION
Context: Bitbucket is generating ghost commits that have the commit message "Notes added by 'git notes add'" if git-notes is used (e.g. with semantic-release). To prevent Jenkins starting builds that will result in failure because there is nothing to build, the build should be stopped when those commits are coming in.
Reference: https://github.com/semantic-release/semantic-release/discussions/2017#discussioncomment-995308