### PR TITLE
COntext variables nexusUsername and nexusPassword are set again by nexusService

### DIFF
--- a/src/org/ods/services/NexusService.groovy
+++ b/src/org/ods/services/NexusService.groovy
@@ -56,6 +56,16 @@ class NexusService {
         } else {
             throw new IllegalArgumentException("Environment variable 'NEXUS_URL' is required")
         }
+        if (env.NEXUS_USERNAME?.trim()) {
+            config.nexusUsername = env.NEXUS_USERNAME.trim()
+        } else {
+            throw new IllegalArgumentException('NEXUS_USERNAME is required, but not set')
+        }
+        if (env.NEXUS_PASSWORD?.trim()) {
+            config.nexusPassword = env.NEXUS_PASSWORD.trim()
+        } else {
+            throw new IllegalArgumentException('NEXUS_PASSWORD is required, but not set')
+        }
         config
     }
 


### PR DESCRIPTION
This is because some quickstarters need that variables, and they are going to use the developer user with only read only