### PR TITLE
In test results, labels not related to execution persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
+* In test results, labels not related to execution persist ([#1138](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1138))
 
 ## [4.5.3] - 2024-07-08
 

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -85,6 +85,9 @@ class JiraUseCase {
         // Handle Jira test issues for which a corresponding test exists in testResults
         def matchedHandler = { result ->
             result.each { testIssue, testCase ->
+                // Remove all the results from preceding executions
+                this.jira.removeLabelsFromIssue(testIssue.key, TestIssueLabels.values().collect() { it.name() })
+
                 def issueLabels = [TestIssueLabels.Succeeded as String]
                 if (testCase.error) {
                     issueLabels = [TestIssueLabels.Error as String]
@@ -98,14 +101,16 @@ class JiraUseCase {
                     issueLabels = [TestIssueLabels.Skipped as String]
                 }
 
-                this.jira.setIssueLabels(testIssue.key, issueLabels)
+                this.jira.addLabelsToIssue(testIssue.key, issueLabels)
             }
         }
 
         // Handle Jira test issues for which no corresponding test exists in testResults
         def unmatchedHandler = { result ->
             result.each { testIssue ->
-                this.jira.setIssueLabels(testIssue.key, [TestIssueLabels.Missing as String])
+                // Remove all the results from preceding executions
+                this.jira.removeLabelsFromIssue(testIssue.key, TestIssueLabels.values().collect() { it.name() })
+                this.jira.addLabelsToIssue(testIssue.key, [TestIssueLabels.Missing as String])
             }
         }
 

--- a/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/JiraUseCaseSpec.groovy
@@ -48,24 +48,29 @@ class JiraUseCaseSpec extends SpecHelper {
         usecase.applyXunitTestResultsAsTestIssueLabels(testIssues, testResults)
 
         then:
-        1 * jira.setIssueLabels("JIRA-1", ["Succeeded"])
-        0 * jira.setIssueLabels("JIRA-1", _)
+        1 * jira.removeLabelsFromIssue("JIRA-1", ['Error', 'Failed', 'Missing', 'Skipped', 'Succeeded'])
+        1 * jira.addLabelsToIssue("JIRA-1", ["Succeeded"])
+        0 * jira.addLabelsToIssue("JIRA-1", _)
 
         then:
-        1 * jira.setIssueLabels("JIRA-2", ["Error"])
-        0 * jira.setIssueLabels("JIRA-2", _)
+        1 * jira.removeLabelsFromIssue("JIRA-2", ['Error', 'Failed', 'Missing', 'Skipped', 'Succeeded'])
+        1 * jira.addLabelsToIssue("JIRA-2", ["Error"])
+        0 * jira.addLabelsToIssue("JIRA-2", _)
 
         then:
-        1 * jira.setIssueLabels("JIRA-3", ["Failed"])
-        0 * jira.setIssueLabels("JIRA-3", _)
+        1 * jira.removeLabelsFromIssue("JIRA-3", ['Error', 'Failed', 'Missing', 'Skipped', 'Succeeded'])
+        1 * jira.addLabelsToIssue("JIRA-3", ["Failed"])
+        0 * jira.addLabelsToIssue("JIRA-3", _)
 
         then:
-        1 * jira.setIssueLabels("JIRA-4", ["Skipped"])
-        0 * jira.setIssueLabels("JIRA-4", _)
+        1 * jira.removeLabelsFromIssue("JIRA-4", ['Error', 'Failed', 'Missing', 'Skipped', 'Succeeded'])
+        1 * jira.addLabelsToIssue("JIRA-4", ["Skipped"])
+        0 * jira.addLabelsToIssue("JIRA-4", _)
 
         then:
-        1 * jira.setIssueLabels("JIRA-5", ["Missing"])
-        0 * jira.setIssueLabels("JIRA-5", _)
+        1 * jira.removeLabelsFromIssue("JIRA-5",['Error', 'Failed', 'Missing', 'Skipped', 'Succeeded'])
+        1 * jira.addLabelsToIssue("JIRA-5", ["Missing"])
+        0 * jira.addLabelsToIssue("JIRA-5", _)
     }
 
     def "check Jira issue matches test case"() {


### PR DESCRIPTION
Adding the result of tests all the labels were removed. Now the labels persist and only the labels regarding the execution are pruned.