### PR TITLE
Don't try to load component data for excluded infrastructure components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * In test results, labels not related to execution persist ([#1138](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1138))
+* Fix excluded ods-infra components failing on deploy stage ([#1139](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1139))
 
 ## [4.5.3] - 2024-07-08
 

--- a/src/org/ods/orchestration/DeployStage.groovy
+++ b/src/org/ods/orchestration/DeployStage.groovy
@@ -142,23 +142,34 @@ class DeployStage extends Stage {
     }
 
     private void loadOdsInfraTypeData (Map repo) {
-        if (repo.data == null) { repo.data = [:] }
         ILogger logger = ServiceRegistry.instance.get(Logger)
-        def steps = ServiceRegistry.instance.get(PipelineSteps)
+        if (repo.include) {
+            if (repo.data == null) {
+                repo.data = [:]
+            }
+            def steps = ServiceRegistry.instance.get(PipelineSteps)
 
-        // collect test results
-        if (repo.data.tests == null) { repo.data.tests = [:] }
-        repo.data.tests << [installation: getTestResults(steps, repo, Project.TestType.INSTALLATION)]
+            // collect test results
+            if (repo.data.tests == null) {
+                repo.data.tests = [:]
+            }
+            repo.data.tests << [installation: getTestResults(steps, repo, Project.TestType.INSTALLATION)]
 
-        // collect log data
-        if (repo.data.logs == null) { repo.data.logs = [:] }
-        repo.data.logs << [created: getLogReports(steps, repo, Project.LogReportType.CHANGES)]
-        repo.data.logs << [target: getLogReports(steps, repo, Project.LogReportType.TARGET)]
-        repo.data.logs << [state: getLogReports(steps, repo, Project.LogReportType.STATE)]
-        if (repo.data.logs.state.content) {
-            repo.data.logs.state.content = JsonOutput.prettyPrint(repo.data.logs.state.content[0])
+            // collect log data
+            if (repo.data.logs == null) {
+                repo.data.logs = [:]
+            }
+            repo.data.logs << [created: getLogReports(steps, repo, Project.LogReportType.CHANGES)]
+            repo.data.logs << [target: getLogReports(steps, repo, Project.LogReportType.TARGET)]
+            repo.data.logs << [state: getLogReports(steps, repo, Project.LogReportType.STATE)]
+            if (repo.data.logs.state.content) {
+                repo.data.logs.state.content = JsonOutput.prettyPrint(repo.data.logs.state.content[0])
+            } else {
+                logger.warn("No log state for ${repo.data} found!")
+            }
         } else {
-            logger.warn("No log state for ${repo.data} found!")
+            logger.debug("Include flag is set to false so not loading ODS Infrastructure/Configuration Management " +
+                "component type data for '${repo.id}'")
         }
     }
 


### PR DESCRIPTION
After adding the ability to include and exclude components from a release, an issue appeared for the ods-infra components when they are excluded. Since in the postActions of the deployment stage, tries to find some files that are not present in the excluded ods-infra components.

In order to avoid this issue, we add a validation so that the stashed files are only checked in case the repo is included, otherwise it is skipped.