### PR TITLE
Fix Finalize stage for ods-library components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * In test results, labels not related to execution persist ([#1138](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1138))
 * Fix excluded ods-infra components failing on deploy stage ([#1139](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1139))
+* Fix Finalize stage for ods-library components ([#1140](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1140))
 
 ## [4.5.3] - 2024-07-08
 

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -204,6 +204,7 @@ class FinalizeStage extends Stage {
             if (repo.include) {
                 def repoType = repo.type?.toLowerCase()
                 if ((repoType != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_TEST &&
+                    repoType != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_LIB &&
                     repoType != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_INFRA &&
                     repoType != MROPipelineUtil.PipelineConfig.REPO_TYPE_ODS_SAAS_SERVICE)) {
                     repoIntegrateTasks << [(repo.id): { doIntegrateIntoMainBranches(steps, repo, git) }]

--- a/test/groovy/org/ods/orchestration/FinalizeStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/FinalizeStageSpec.groovy
@@ -125,4 +125,27 @@ class FinalizeStageSpec extends SpecHelper {
         1 * gitService.createTag(project.targetTag)
         1 * gitService.pushForceBranchWithTags(project.gitReleaseBranch)
     }
+
+    def "integrateIntoMainBranchRepos if repo of type is #type"() {
+        given:
+        def repos = project.data.metadata.repositories
+        repos.each { repo ->
+            repo.type = type
+        }
+
+        def finalStageNotInstallable = Spy(new FinalizeStage(script, project, repos))
+
+        when:
+        finalStageNotInstallable.integrateIntoMainBranchRepos(steps, gitService)
+
+        then:
+        0 * script.parallel([:])
+
+        where:
+        type                | _
+        'ods-test'          | _
+        'ods-library'       | _
+        'ods-infra'         | _
+        'ods-saas-service'  | _
+    }
 }

--- a/test/groovy/org/ods/orchestration/FinalizeStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/FinalizeStageSpec.groovy
@@ -139,7 +139,7 @@ class FinalizeStageSpec extends SpecHelper {
         finalStageNotInstallable.integrateIntoMainBranchRepos(steps, gitService)
 
         then:
-        0 * script.parallel([:])
+        0 * finalStageNotInstallable.doIntegrateIntoMainBranches(_)
 
         where:
         type                | _


### PR DESCRIPTION
In the FinalizeStage, if a component of the type 'ods-library' is included, the stage fails during the Deploy to D/Q/P. This is because it tries to find deployment files, which are not created in an 'ods-library'.