### PR TITLE
In the release manager pipeline, use the default integration branch for component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+* In the release manager pipeline, use the default integration branch for component ([#1144](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1144)) 
 
 ### Changed
 * Enhance SSDS Document Generation Performance using New Atlassian APIs ([#1084](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1084))

--- a/src/org/ods/orchestration/BuildStage.groovy
+++ b/src/org/ods/orchestration/BuildStage.groovy
@@ -134,7 +134,7 @@ class BuildStage extends Stage {
         def index = 1
         def sanitizedRepos = failedRepos.collect { it ->
             (index++) + ".\tRepository id: " + it.id +
-            "\n\tBranch: " + it.branch + "\n\tRepository type: " + it.type }
+            "\n\tBranch: " + it.defaultBranch + "\n\tRepository type: " + it.type }
             .join("\n\n")
         return sanitizedRepos
     }

--- a/src/org/ods/orchestration/FinalizeStage.groovy
+++ b/src/org/ods/orchestration/FinalizeStage.groovy
@@ -156,7 +156,7 @@ class FinalizeStage extends Stage {
         return [(repo.id): {
             steps.dir("${steps.env.WORKSPACE}/${MROPipelineUtil.REPOS_BASE_DIR}/${repo.id}") {
                 if (project.isWorkInProgress) {
-                    String branchName = repo.data.git.branch ?: repo.branch
+                    String branchName = repo.data.git.branch ?: repo.defaultBranch
                     git.pushRef(branchName)
                 } else if (project.isAssembleMode) {
                     if (!git.remoteTagExists(project.targetTag)) {
@@ -226,7 +226,7 @@ class FinalizeStage extends Stage {
                 if (steps.fileExists('openshift-exported/template.yml')) {
                     filesToCheckout << 'openshift-exported/template.yml'
                 }
-                git.mergeIntoMainBranch(project.gitReleaseBranch, repo.branch, filesToCheckout)
+                git.mergeIntoMainBranch(project.gitReleaseBranch, repo.defaultBranch, filesToCheckout)
             }
         }
     }

--- a/src/org/ods/orchestration/usecase/BitbucketTraceabilityUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/BitbucketTraceabilityUseCase.groovy
@@ -96,7 +96,8 @@ class BitbucketTraceabilityUseCase {
         int reposSize = repos.size()
         for (def i = 0; i < reposSize; i++) {
             def repository = repos[i]
-            result << [repo: "${project.data.metadata.id.toLowerCase()}-${repository.id}", branch: repository.branch]
+            result << [repo: "${project.data.metadata.id.toLowerCase()}-${repository.id}",
+                       defaultBranch: repository.defaultBranch]
         }
         return result
     }

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -289,7 +289,7 @@ class MROPipelineUtil extends PipelineUtil {
         String gitReleaseBranch = this.project.gitReleaseBranch
         if ("master" == gitReleaseBranch) {
             //TODO: still using only master for RM?
-            repo.defaultBranch = bbs.getDefaultBranch(this.project.getId(), repo.id)
+            repo.defaultBranch = bbs.getDefaultBranch(this.project.getKey(), repo.id)
             gitReleaseBranch = repo.defaultBranch
         }
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -287,7 +287,7 @@ class MROPipelineUtil extends PipelineUtil {
         Map scmResult = [ : ]
         def bbs = ServiceRegistry.instance.get(BitbucketService)
         String gitReleaseBranch = this.project.gitReleaseBranch
-        repo.defaultBranch = bbs.getDefaultBranch(this.project.getKey(), repo.id)
+        repo.defaultBranch = bbs.getDefaultBranch(repo.id)
         if ("master" == gitReleaseBranch) {
             //TODO: still using only master for RM?
             gitReleaseBranch = repo.defaultBranch

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -284,10 +284,11 @@ class MROPipelineUtil extends PipelineUtil {
 
     private Map checkOutNotReleaseManagerRepoInNotPromotionMode(Map repo, boolean isWorkInProgress) {
         Map scmResult = [ : ]
+        def bbs = ServiceRegistry.instance.get(BitbucketService)
         String gitReleaseBranch = this.project.gitReleaseBranch
         if ("master" == gitReleaseBranch) {
             //TODO: still using only master for RM?
-            repo.defaultBranch = this.project.services.bitbucket.getDefaultBranch(this.project.getId(),repo.id)
+            repo.defaultBranch = bbs.getDefaultBranch(this.project.getId(), repo.id)
             gitReleaseBranch = repo.defaultBranch
         }
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -287,13 +287,10 @@ class MROPipelineUtil extends PipelineUtil {
         Map scmResult = [ : ]
         def bbs = ServiceRegistry.instance.get(BitbucketService)
         String gitReleaseBranch = this.project.gitReleaseBranch
+        repo.defaultBranch = bbs.getDefaultBranch(this.project.getKey(), repo.id)
         if ("master" == gitReleaseBranch) {
             //TODO: still using only master for RM?
-            logger.info("gitReleaseBranch ${gitReleaseBranch}")
-            repo.defaultBranch = bbs.getDefaultBranch(this.project.getKey(), repo.id)
-            logger.info("repo.defaultBranch ${repo.defaultBranch}")
             gitReleaseBranch = repo.defaultBranch
-            logger.info("gitReleaseBranch ${gitReleaseBranch}")
         }
 
         // check if release manager repo already has a release branch

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -289,7 +289,6 @@ class MROPipelineUtil extends PipelineUtil {
         String gitReleaseBranch = this.project.gitReleaseBranch
         repo.defaultBranch = bbs.getDefaultBranch(repo.id)
         if ("master" == gitReleaseBranch) {
-            //TODO: still using only master for RM?
             gitReleaseBranch = repo.defaultBranch
         }
 

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -10,6 +10,7 @@ import org.ods.orchestration.dependency.DependencyGraph
 import org.ods.orchestration.dependency.Node
 import org.ods.services.OpenShiftService
 import org.ods.services.ServiceRegistry
+import org.ods.services.BitbucketService
 import org.ods.orchestration.phases.DeployOdsComponent
 import org.ods.orchestration.phases.FinalizeOdsComponent
 import org.ods.orchestration.phases.FinalizeNonOdsComponent

--- a/src/org/ods/orchestration/util/MROPipelineUtil.groovy
+++ b/src/org/ods/orchestration/util/MROPipelineUtil.groovy
@@ -289,8 +289,11 @@ class MROPipelineUtil extends PipelineUtil {
         String gitReleaseBranch = this.project.gitReleaseBranch
         if ("master" == gitReleaseBranch) {
             //TODO: still using only master for RM?
+            logger.info("gitReleaseBranch ${gitReleaseBranch}")
             repo.defaultBranch = bbs.getDefaultBranch(this.project.getKey(), repo.id)
+            logger.info("repo.defaultBranch ${repo.defaultBranch}")
             gitReleaseBranch = repo.defaultBranch
+            logger.info("gitReleaseBranch ${gitReleaseBranch}")
         }
 
         // check if release manager repo already has a release branch

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -2020,7 +2020,7 @@ class Project {
 
         // Resolve repo branch, if not provided
         if (repo.branch?.trim()) {
-            throw new Exception("Error branch is set") //TODO: better exception
+            throw new IllegalArgumentException("Deprecated branch field is set")
         }
     }
 

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -2018,9 +2018,10 @@ class Project {
 
         this.logger.debug("Resolved Git URL for repo '${repo.id}' to '${repo.url}'")
 
-        // Resolve repo branch, if not provided
+        // Fail the RM pipeline if the old branch flag is in use
         if (repo.branch?.trim()) {
-            throw new IllegalArgumentException("Deprecated branch field is set")
+            throw new IllegalArgumentException("Deprecated branch field is set in 'metadata.yml' " +
+                "inside Release Manager component for repo '${repo.id}'")
         }
     }
 

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -2019,12 +2019,9 @@ class Project {
         this.logger.debug("Resolved Git URL for repo '${repo.id}' to '${repo.url}'")
 
         // Resolve repo branch, if not provided
-        if (!repo.branch?.trim()) {
-            this.logger.debug("Could not determine Git branch for repo '${repo.id}' " +
-                "from project meta data. Assuming 'master'.")
-            repo.branch = 'master'
+        if (repo.branch?.trim()) {
+            throw new Exception("Error branch is set") //TODO: better exception
         }
-        this.logger.debug("Set default (used for WIP) git branch for repo '${repo.id}' to ${repo.branch} ")
     }
 
     void addDefaults(String component) {

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -321,6 +321,7 @@ class BitbucketService {
 
     String getDefaultBranch(String projectKey, String repo) {
         logger.debugClocked("defaultbranch-${projectKey}-${repo}")
+        String displayId = ""
         withTokenCredentials { username, token ->
             def maxAttempts = 3
             def retries = 0
@@ -337,13 +338,11 @@ class BitbucketService {
                                 --header ${authHeader} \\
                                 ${bitbucketUrl}/rest/api/1.0/projects/${projectKey}/repos/${projectKey}-${repo}/branches/default"""
                     ).trim()
-                    logger.info(res)
                     try {
                         // call readJSON inside of withCredentials block,
                         // otherwise token will be displayed in output
                         def js = script.readJSON(text: res)
-                        logger.info(js['displayId'])
-                        return js['displayId']
+                        displayId = js['displayId']
                     } catch (Exception ex) {
                         logger.warn "Could not understand API response. Error was: ${ex}"
                     }
@@ -353,6 +352,7 @@ class BitbucketService {
             }
         }
         logger.debugClocked("defaultbranch-${projectKey}-${projectKey}-${repo}")
+        return displayId
     }
 
     /**

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -346,11 +346,11 @@ class BitbucketService {
                         logger.warn "Could not understand API response. Error was: ${ex}"
                     }
                 } catch (err) {
-                    logger.warn("Could not get Bitbucket repo '${repoSlug}' default branch due to: ${err}")
+                    logger.warn("Could not get Bitbucket repo '${projectKey}-${repo}' default branch due to: ${err}")
                 }
             }
         }
-        logger.debugClocked("defaultbranch-${projectKey}-${repoSlug}")
+        logger.debugClocked("defaultbranch-${projectKey}-${projectKey}-${repo}")
     }
 
     /**

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -324,7 +324,6 @@ class BitbucketService {
         withTokenCredentials { username, token ->
             def maxAttempts = 3
             def retries = 0
-            def payload = "{\"state\":\"${state}\",\"key\":\"${buildName}\",\"name\":\"${buildName}\",\"url\":\"${buildUrl}\"}"
             while (retries++ < maxAttempts) {
                 try {
                     def authHeader = '\"Authorization: Bearer $TOKEN\"' // codenarc-disable GStringExpressionWithinString

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -335,7 +335,7 @@ class BitbucketService {
                                 -sS \\
                                 --request GET \\
                                 --header ${authHeader} \\
-                                ${bitbucketUrl}rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/branches/default"""
+                                ${bitbucketUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/branches/default"""
                     ).trim()
                     try {
                         // call readJSON inside of withCredentials block,

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -329,7 +329,7 @@ class BitbucketService {
                     def authHeader = '\"Authorization: Bearer $TOKEN\"' // codenarc-disable GStringExpressionWithinString
                     res = script.sh(
                         returnStdout: true,
-                        label: 'Set bitbucket build status via API',
+                        label: 'Get bitbucket repo default branch via API',
                         script: """curl \\
                                 --fail \\
                                 -sS \\

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -319,8 +319,9 @@ class BitbucketService {
         logger.debugClocked("buildstatus-${buildName}-${state}")
     }
 
-    String getDefaultBranch(String projectKey, String repo) {
-        logger.debugClocked("defaultbranch-${projectKey}-${repo}")
+    @SuppressWarnings('LineLength')
+    String getDefaultBranch(String repo) {
+        logger.debugClocked("defaultbranch-${project}-${repo}")
         String displayId = ""
         withTokenCredentials { username, token ->
             def maxAttempts = 3
@@ -336,22 +337,23 @@ class BitbucketService {
                                 -sS \\
                                 --request GET \\
                                 --header ${authHeader} \\
-                                ${bitbucketUrl}/rest/api/1.0/projects/${projectKey}/repos/${projectKey}-${repo}/branches/default"""
+                                ${bitbucketUrl}/rest/api/1.0/projects/${project}/repos/${project}-${repo}/branches/default"""
                     ).trim()
                     try {
                         // call readJSON inside of withCredentials block,
                         // otherwise token will be displayed in output
                         def js = script.readJSON(text: res)
                         displayId = js['displayId']
+                        return displayId
                     } catch (Exception ex) {
                         logger.warn "Could not understand API response. Error was: ${ex}"
                     }
                 } catch (err) {
-                    logger.warn("Could not get Bitbucket repo '${projectKey}-${repo}' default branch due to: ${err}")
+                    logger.warn("Could not get Bitbucket repo '${project}-${repo}' default branch due to: ${err}")
                 }
             }
         }
-        logger.debugClocked("defaultbranch-${projectKey}-${projectKey}-${repo}")
+        logger.debugClocked("defaultbranch-${project}-${project}-${repo}")
         return displayId
     }
 

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -327,7 +327,7 @@ class BitbucketService {
             while (retries++ < maxAttempts) {
                 try {
                     def authHeader = '\"Authorization: Bearer $TOKEN\"' // codenarc-disable GStringExpressionWithinString
-                    res = script.sh(
+                    def res = script.sh(
                         returnStdout: true,
                         label: 'Get bitbucket repo default branch via API',
                         script: """curl \\

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -337,10 +337,12 @@ class BitbucketService {
                                 --header ${authHeader} \\
                                 ${bitbucketUrl}/rest/api/1.0/projects/${projectKey}/repos/${projectKey}-${repo}/branches/default"""
                     ).trim()
+                    logger.info(res)
                     try {
                         // call readJSON inside of withCredentials block,
                         // otherwise token will be displayed in output
                         def js = script.readJSON(text: res)
+                        logger.info(js['displayId'])
                         return js['displayId']
                     } catch (Exception ex) {
                         logger.warn "Could not understand API response. Error was: ${ex}"

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -319,6 +319,40 @@ class BitbucketService {
         logger.debugClocked("buildstatus-${buildName}-${state}")
     }
 
+    String getDefaultBranch(String projectKey, String repoSlug) {
+        withTokenCredentials { username, token ->
+            def maxAttempts = 3
+            def retries = 0
+            def payload = "{\"state\":\"${state}\",\"key\":\"${buildName}\",\"name\":\"${buildName}\",\"url\":\"${buildUrl}\"}"
+            while (retries++ < maxAttempts) {
+                try {
+                    def authHeader = '\"Authorization: Bearer $TOKEN\"' // codenarc-disable GStringExpressionWithinString
+                    res = script.sh(
+                        returnStdout: true,
+                        label: 'Set bitbucket build status via API',
+                        script: """curl \\
+                                --fail \\
+                                -sS \\
+                                --request GET \\
+                                --header ${authHeader} \\
+                                ${bitbucketUrl}rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/branches/default"""
+                    ).trim()
+                    try {
+                        // call readJSON inside of withCredentials block,
+                        // otherwise token will be displayed in output
+                        def js = script.readJSON(text: res)
+                        return js['displayId']
+                    } catch (Exception ex) {
+                        logger.warn "Could not understand API response. Error was: ${ex}"
+                    }
+                } catch (err) {
+                    logger.warn("Could not get Bitbucket repo '${repoSlug}' default branch due to: ${err}")
+                }
+            }
+        }
+        logger.debugClocked("buildstatus-${buildName}-${state}")
+    }
+
     /**
      * Creates a code insight report in bitbucket via API.
      * For further information visit https://developer.atlassian.com/server/bitbucket/how-tos/code-insights/
@@ -484,7 +518,7 @@ repos/${repo}/commits/${gitCommit}/reports/${data.key}"""
 
     @NonCPS
     Map getMergedPullRequestsForIntegrationBranch(String token, Map repo, int limit, int nextPageStart){
-        String qParams = "state=MERGED&order=OLDEST&at=refs/heads/${repo.branch}"
+        String qParams = "state=MERGED&order=OLDEST&at=refs/heads/${repo.defaultBranch}"
         String request = "${bitbucketUrl}/rest/api/1.0/projects/${project}/repos/${repo.repo}/pull-requests?${qParams}"
         return queryRepo(token, request, limit, nextPageStart)
     }

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -320,6 +320,7 @@ class BitbucketService {
     }
 
     String getDefaultBranch(String projectKey, String repoSlug) {
+        logger.debugClocked("defaultbranch-${projectKey}-${repoSlug}")
         withTokenCredentials { username, token ->
             def maxAttempts = 3
             def retries = 0
@@ -350,7 +351,7 @@ class BitbucketService {
                 }
             }
         }
-        logger.debugClocked("buildstatus-${buildName}-${state}")
+        logger.debugClocked("defaultbranch-${projectKey}-${repoSlug}")
     }
 
     /**

--- a/src/org/ods/services/BitbucketService.groovy
+++ b/src/org/ods/services/BitbucketService.groovy
@@ -319,8 +319,8 @@ class BitbucketService {
         logger.debugClocked("buildstatus-${buildName}-${state}")
     }
 
-    String getDefaultBranch(String projectKey, String repoSlug) {
-        logger.debugClocked("defaultbranch-${projectKey}-${repoSlug}")
+    String getDefaultBranch(String projectKey, String repo) {
+        logger.debugClocked("defaultbranch-${projectKey}-${repo}")
         withTokenCredentials { username, token ->
             def maxAttempts = 3
             def retries = 0
@@ -335,7 +335,7 @@ class BitbucketService {
                                 -sS \\
                                 --request GET \\
                                 --header ${authHeader} \\
-                                ${bitbucketUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}/branches/default"""
+                                ${bitbucketUrl}/rest/api/1.0/projects/${projectKey}/repos/${projectKey}-${repo}/branches/default"""
                     ).trim()
                     try {
                         // call readJSON inside of withCredentials block,

--- a/test/groovy/org/ods/orchestration/BuildStageSpec.groovy
+++ b/test/groovy/org/ods/orchestration/BuildStageSpec.groovy
@@ -140,17 +140,17 @@ Please follow these steps to resolve and restart your deployment:
         given:
         project.data.buildParams.version = testVersion
         def testRepos = [
-            [id       : "golang", branch: "master", type: "ods",
+            [id       : "golang", defaultBranch: "master", type: "ods",
              data     : [openshift  : [builds   : [], deployments: [:], tailorFailure: true,
                                        documents: [:]],
                          failedStage: "odsPipeline error"],
              doInstall: true],
-            [id       : "other", branch: "master", type: "ods",
+            [id       : "other", defaultBranch: "master", type: "ods",
              data     : [openshift  : [builds   : [], deployments: [:],
                                        documents: [:]],
                          failedStage: "odsPipeline error"],
              doInstall: true],
-            [id       : "third", branch: "master", type: "ods",
+            [id       : "third", defaultBranch: "master", type: "ods",
              data     : [openshift  : [builds   : [], deployments: [:], tailorFailure: true,
                                        documents: [:]],
                          failedStage: "odsPipeline error"],

--- a/test/groovy/org/ods/orchestration/usecase/BitbucketTraceabilityUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/BitbucketTraceabilityUseCaseSpec.groovy
@@ -67,6 +67,7 @@ class BitbucketTraceabilityUseCaseSpec extends Specification {
         project.data.buildParams.targetEnvironmentToken = "D"
         project.data.buildParams.version = "WIP"
         project.data.buildParams.releaseStatusJiraIssueKey = "${PROJECT_KEY}-123"
+        project.repositories.forEach { repo -> repo.defaultBranch = "master"}
         return project
     }
 

--- a/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
@@ -1499,7 +1499,6 @@ class ProjectSpec extends SpecHelper {
         // Verify annotations to the metadata.yml file are made
         def expected = new Yaml().load(new File(Project.METADATA_FILE_NAME).text)
         expected.repositories.each { repo ->
-            repo.branch = "master"
             repo.include = true
             repo.data = [ documents: [:], openshift: [:] ]
             repo.url = "https://github.com/my-org/net-${repo.id}.git"


### PR DESCRIPTION
The Release Manager only considers code on a repository's default (integration) branch for creating a release bundle; users who want to modify this location need to do so by changing the repository's default branch directly in Bitbucket