### PR TITLE
Fix NPE when the test type is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
+* Fix NPE when the test type is null ([#1146](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1146))
 
 ## [4.5.4] - 2024-07-17
 

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -548,7 +548,7 @@ class Project {
     boolean hasGivenTypes(List<String> testTypes, testIssue) {
         def result = true
         if (testTypes) {
-            result = testTypes*.toLowerCase().contains(testIssue.testType.toLowerCase())
+            result = testTypes*.toLowerCase().contains(testIssue.testType?.toLowerCase())
         }
         return result
     }

--- a/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
+++ b/test/groovy/org/ods/orchestration/util/ProjectSpec.groovy
@@ -3254,4 +3254,22 @@ class ProjectSpec extends SpecHelper {
         !result
     }
 
+    def "check hasGivenTypes"() {
+        given:
+        def projectObj = new Project(steps, logger)
+
+        when:
+        def resulFromExecution = projectObj.hasGivenTypes(testTypes, testIssue)
+
+        then:
+        result == resulFromExecution
+
+        where:
+        testTypes                                               |   testIssue                   |   result
+        ['Unit', 'Integration', 'Installation', 'Acceptance']   |   [testType: 'Unit']          |   true
+        ['Integration', 'Installation', 'Acceptance']           |   [testType: 'Unit']          |   false
+        ['Unit', 'Integration', 'Installation', 'Acceptance']   |   [testType: null]            |   false
+        ['Unit', 'Integration', 'Installation', 'Acceptance']   |   [:]                         |   false
+    }
+
 }


### PR DESCRIPTION
When a Jira issue of type test doesn't have filled the "Test Level" field, a NPE occurs.

`Caused: java.lang.IllegalStateException: Error: Creating document of type 'DTP' for project 'rodip' in phase 'Build' and stage 'POST_START' has failed: Cannot invoke method toLowerCase() on null object.`