### PR TITLE
Updated LevaDocumentUseCase to use poo property value correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Fail builds when aqua scan detects remotely exploitable security vulnerabilities with solutions ([#1147](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1147))
+* Even if the POO property is set a true, this information is not present in the RA generated ([#1154](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1154))
 
 ### Added
 * In the release manager pipeline, use the default integration branch for component ([#1144](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1144)) 

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -646,8 +646,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!sections."sec4s2s2") sections."sec4s2s2" = [:]
 
-        if (this.project.getProjectProperties()."PROJECT.USES_POO" != null &&
-            Boolean.valueOf(this.project.getProjectProperties()."PROJECT.USES_POO".toString()) == Boolean.TRUE) {
+        if (Boolean.valueOf(this.project.getProjectProperties()."PROJECT.USES_POO") == Boolean.TRUE) {
             sections."sec4s2s2" = [
                 usesPoo          : "true",
                 lowDescription   : this.project.getProjectProperties()."PROJECT.POO_CAT.LOW",

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -646,7 +646,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!sections."sec4s2s2") sections."sec4s2s2" = [:]
 
-        if (Boolean.valueOf(this.project.getProjectProperties()."PROJECT.USES_POO") == Boolean.TRUE) {
+        if (Boolean.valueOf(this.project.getProjectProperties()."PROJECT.USES_POO")) {
             sections."sec4s2s2" = [
                 usesPoo          : "true",
                 lowDescription   : this.project.getProjectProperties()."PROJECT.POO_CAT.LOW",

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -646,7 +646,8 @@ class LeVADocumentUseCase extends DocGenUseCase {
 
         if (!sections."sec4s2s2") sections."sec4s2s2" = [:]
 
-        if (this.project.getProjectProperties()."PROJECT.USES_POO" == "true") {
+        if (this.project.getProjectProperties()."PROJECT.USES_POO" != null &&
+            this.project.getProjectProperties()."PROJECT.USES_POO".toString().equalsIgnoreCase("true")) {
             sections."sec4s2s2" = [
                 usesPoo          : "true",
                 lowDescription   : this.project.getProjectProperties()."PROJECT.POO_CAT.LOW",

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -647,7 +647,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
         if (!sections."sec4s2s2") sections."sec4s2s2" = [:]
 
         if (this.project.getProjectProperties()."PROJECT.USES_POO" != null &&
-            this.project.getProjectProperties()."PROJECT.USES_POO".toString().equalsIgnoreCase("true")) {
+            Boolean.valueOf(this.project.getProjectProperties()."PROJECT.USES_POO".toString()) == Boolean.TRUE) {
             sections."sec4s2s2" = [
                 usesPoo          : "true",
                 lowDescription   : this.project.getProjectProperties()."PROJECT.POO_CAT.LOW",

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1957,4 +1957,41 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         true  | CSD as String  | "IN PROGRESS" | "2"    || true
     }
 
+    @Unroll
+    def "fillRASections update section sec4s2s2 according to project property PROJECT.USES_POO"() {
+        given:
+        def sections = ["sec4s2s2":[]]
+        def risks = [[:]]
+        def proposedMeasuresDesription = [[:]]
+        def low = "low"
+        def medium = "medium"
+        def high = "high"
+        def project = Mock(Project)
+        jiraUseCase = Spy(new JiraUseCase(project, steps, util, Mock(JiraService), logger))
+        usecase = Spy(new LeVADocumentUseCase(project, steps, util, docGen, jenkins, jiraUseCase, junit, levaFiles, nexus, os, pdf, sq, bbt, logger))
+
+        when:
+        usecase.fillRASections(sections, risks, proposedMeasuresDesription)
+
+        then:
+        project.getProjectProperties() >> [
+            "PROJECT.NON-GXP_EVALUATION" : "",
+            "PROJECT.USES_POO" : poo,
+            "PROJECT.POO_CAT.LOW" : low,
+            "PROJECT.POO_CAT.MEDIUM" : medium,
+            "PROJECT.POO_CAT.HIGH": high
+        ]
+
+        and:
+        sections.sec4s2s2 == expectedResult
+
+        where:
+        poo             |  expectedResult
+        "true"          |  [usesPoo:"true", lowDescription:"low", mediumDescription:"medium", highDescription:"high"]
+        "false"         |  [:]
+        "TRUE"          |  [usesPoo:"true", lowDescription:"low", mediumDescription:"medium", highDescription:"high"]
+        "FALSE"         |  [:]
+        "invalidValue"  |  [:]
+        null            |  [:]
+    }
 }

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1,32 +1,53 @@
 package org.ods.orchestration.usecase
 
 import groovy.json.JsonSlurper
-import groovy.util.logging.Log
 import groovy.util.logging.Slf4j
 import org.apache.commons.io.FileUtils
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-import org.ods.util.ILogger
-import org.ods.services.ServiceRegistry
-import spock.lang.Unroll
-
+import org.ods.orchestration.service.DocGenService
+import org.ods.orchestration.service.JiraService
+import org.ods.orchestration.service.LeVADocumentChaptersFileService
+import org.ods.orchestration.util.DocumentHistory
+import org.ods.orchestration.util.MROPipelineUtil
+import org.ods.orchestration.util.PDFUtil
+import org.ods.orchestration.util.Project
+import org.ods.orchestration.util.SortUtil
 import org.ods.services.JenkinsService
 import org.ods.services.NexusService
 import org.ods.services.OpenShiftService
-import org.ods.orchestration.service.*
-import org.ods.orchestration.util.*
+import org.ods.services.ServiceRegistry
+import org.ods.util.ILogger
 import org.ods.util.IPipelineSteps
 import org.ods.util.Logger
+import spock.lang.Unroll
+import util.FixtureHelper
+import util.SpecHelper
 
-import javax.swing.text.Document
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 
-import static org.ods.orchestration.usecase.DocumentType.*
+import static org.ods.orchestration.usecase.DocumentType.CFTP
+import static org.ods.orchestration.usecase.DocumentType.CFTR
 import static org.ods.orchestration.usecase.DocumentType.CSD
-import static util.FixtureHelper.*
-
-import util.*
+import static org.ods.orchestration.usecase.DocumentType.DIL
+import static org.ods.orchestration.usecase.DocumentType.DTP
+import static org.ods.orchestration.usecase.DocumentType.DTR
+import static org.ods.orchestration.usecase.DocumentType.IVP
+import static org.ods.orchestration.usecase.DocumentType.IVR
+import static org.ods.orchestration.usecase.DocumentType.OVERALL_DTR
+import static org.ods.orchestration.usecase.DocumentType.OVERALL_TIR
+import static org.ods.orchestration.usecase.DocumentType.RA
+import static org.ods.orchestration.usecase.DocumentType.SSDS
+import static org.ods.orchestration.usecase.DocumentType.TCP
+import static org.ods.orchestration.usecase.DocumentType.TCR
+import static org.ods.orchestration.usecase.DocumentType.TIP
+import static org.ods.orchestration.usecase.DocumentType.TIR
+import static org.ods.orchestration.usecase.DocumentType.TRC
+import static util.FixtureHelper.createJUnitXMLTestResults
+import static util.FixtureHelper.createProject
+import static util.FixtureHelper.createProjectBuildEnvironment
+import static util.FixtureHelper.createSockShopJUnitXmlTestResults
 
 @Slf4j
 class LeVADocumentUseCaseSpec extends SpecHelper {
@@ -1993,5 +2014,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         "FALSE"         |  [:]
         "invalidValue"  |  [:]
         null            |  [:]
+        true            |  [usesPoo:"true", lowDescription:"low", mediumDescription:"medium", highDescription:"high"]
+        false           |  [:]
     }
 }


### PR DESCRIPTION
Even if the POO property is set a true, this information is not present in the RA generated