### PR TITLE
Preserve quickstarter files in case a repository already contain files with same names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Enhance SSDS Document Generation Performance using New Atlassian APIs ([#1084](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1084))
 * Deprecation of vuln-type and scanners config in Trivy ([#1150](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1150))
 * Use riskPriority value as number instead of its value as text in RA ([#1156](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1156))
+* Preserve quickstarter files in case a repository already contain files with same names ([#1165](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1165))
 
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))

--- a/src/org/ods/quickstarter/PushToRemoteStage.groovy
+++ b/src/org/ods/quickstarter/PushToRemoteStage.groovy
@@ -42,7 +42,7 @@ class PushToRemoteStage extends Stage {
                       git remote add origin ${context.gitUrlHttp}
                     else
                       echo "Upgrading existing project: ${context.gitUrlHttp}"
-                      mv "\$clonedGitFolderName"/* .
+                      mv -n "\$clonedGitFolderName"/* .
                       mv "\$clonedGitFolderName"/.[!.]* .
                     fi
                     rm -rf \$clonedGitFolderName


### PR DESCRIPTION
Preserve quickstarter files in case a repository already contain files with same names since now all components start with a README.md file but we want to keep the README from the quickstarters if they have them.