### PR TITLE
Pass inherited branches config to Aqua Stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * Fix branch mapping logic to ensure correct environment assignment ([#1263](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1263))
 * Fix Nexus not accepting npm artifacts when uploaded through odsComponentStageUploadToNexus ([#1268](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1268))
+* Aqua Stage is being skipped when branches are not eligable ([#1170](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1170))
 
 ## [4.12.1] - 2026-04-10
 ### Fixed

--- a/test/groovy/vars/OdsComponentStageScanWithAquaSpec.groovy
+++ b/test/groovy/vars/OdsComponentStageScanWithAquaSpec.groovy
@@ -310,4 +310,57 @@ class OdsComponentStageScanWithAquaSpec extends PipelineSpockTestBase {
         assertJobStatusSuccess()
     }
 
+    def "forwards branches config into ScanWithAquaStage"() {
+        given:
+        def c = config + [environment: 'dev']
+        IContext context = new Context(null, c, logger)
+        def aquaConfigMapName = ScanWithAquaStage.AQUA_CONFIG_MAP_NAME
+
+        OpenShiftService openShiftService = Stub(OpenShiftService.class)
+        openShiftService.getConfigMapData('ods', aquaConfigMapName) >> [
+            enabled: true, alertEmails: "mail1@mail.com", url: "http://aqua", registry: "internal"
+        ]
+        openShiftService.getConfigMapData("foo", aquaConfigMapName) >> [enabled: true]
+        ServiceRegistry.instance.add(OpenShiftService, openShiftService)
+
+        NexusService nexusService = Stub(NexusService.class)
+        ServiceRegistry.instance.add(NexusService, nexusService)
+
+        and: "mock the stage constructor and validate inherited config"
+        GroovyMock(ScanWithAquaStage, global: true)
+        ScanWithAquaStage.getAQUA_CONFIG_MAP_NAME() >> aquaConfigMapName
+
+        when:
+        def script = loadScript('vars/odsComponentStageScanWithAqua.groovy')
+        script.call(
+            context,
+            [
+                imageLabels: [JENKINS_MASTER_OPENSHIFT_BUILD_NAMESPACE: 'ods'],
+                resourceName: 'my-image',
+                branches: ['master', 'release/']
+            ]
+        )
+
+        then:
+        1 * new ScanWithAquaStage(
+            _,
+            _,
+            {
+                it.resourceName == 'my-image' &&
+                    it.branches == ['master', 'release/']
+            },
+            _,
+            _,
+            _,
+            _,
+            _,
+            _,
+            _
+        ) >> Stub(ScanWithAquaStage) {
+            execute() >> null
+        }
+        printCallStack()
+        assertJobStatusSuccess()
+    }
+
 }

--- a/vars/odsComponentStageScanWithAqua.groovy
+++ b/vars/odsComponentStageScanWithAqua.groovy
@@ -82,6 +82,9 @@ def call(IContext context, Map config = [:]) {
         if (config.resourceName) {
             inheritedConfig.resourceName = config.resourceName
         }
+        if (config.branches) {
+            inheritedConfig.branches = config.branches
+        }
         if (enabledInCluster && enabledInProject) {
             new ScanWithAquaStage(this,
                 context,


### PR DESCRIPTION
While debugging an issue where the Aqua stage was ALWAYS run even when the build-stage was not, I stumbled over the issues that the inherited branches config is not being passed to the new Aqua stage that is created.

I tested it on a running jenkins setup, and can say that with this change, I see the following log output:
```
Skipping stage 'Build OpenShift Image (app-backend-base)' for branch 'prettier' as it is not covered by: 'main', 'review'.

Skipping stage 'Aqua Security Scan' for branch 'prettier' as it is not covered by: 'main', 'review'.
```

I know that a test for this case is missing, but I was not able to install JDK 11 locally, and with any newer JDK version I could not get groovy to work.

Any support on the testing front is greatly appreciated.

PS: Without this change, the truncated logs looks like this:
```
Skipping stage 'Build OpenShift Image (app-backend-base)' for branch 'prettier' as it is not covered by: 'main', 'review'.

oc -n ods get ConfigMap/aqua -o json

...

Skipping as imageRef could not be retrieved. Possible reasons are:
-> The aqua stage runs before the image build stage and hence no new image was created yet.
-> The image build stage was not executed because the image was imported.
-> The aqua stage and the image build stage have different values for 'resourceName' set.
```

The problem is, that the OpenShift image is not being build because of the branches setup, but then the AquaScan is started here: 
https://github.com/opendevstack/ods-jenkins-shared-library/blob/f5f9d14ca9887c721d9afe17c09b7f5c19a5bde8/vars/odsComponentStageBuildOpenShiftImage.groovy#L27

Another idea would be not to run the Aqua stage at all when the build stage is not executed.