### PR TITLE
Add support for git submodules in Quickstarters

### DIFF
--- a/src/org/ods/quickstarter/Pipeline.groovy
+++ b/src/org/ods/quickstarter/Pipeline.groovy
@@ -85,7 +85,7 @@ class Pipeline implements Serializable {
             // Execute user-defined stages.
             block(context)
 
-            new PushToRemoteStage(script, context).execute()
+            new PushToRemoteStage(script, context, config).execute()
         }
     }
 

--- a/src/org/ods/quickstarter/PushToRemoteStage.groovy
+++ b/src/org/ods/quickstarter/PushToRemoteStage.groovy
@@ -48,10 +48,24 @@ class PushToRemoteStage extends Stage {
                     rm -rf \$clonedGitFolderName
                     git config user.email "undefined"
                     git config user.name "ODS System User"
+                    """,
+                    label: 'Copy quickstarter files'
+                )
+                config?.gitSubModules?.each { submodule ->
+                    script.sh(
+                        script: """
+                        echo "Adding ${submodule.name} git submodule"
+                        git submodule add -b ${submodule.branch} ${submodule.url} ${submodule.folder}
+                        """,
+                        label: 'Add submodule to quickstarter files'
+                    )
+                }
+                script.sh(
+                    script: """
                     git add --all .
                     git commit -m "Initial OpenDevStack commit"
                     """,
-                    label: 'Copy and commit quickstarter files'
+                    label: 'Commit quickstarter files'
                 )
             }
             script.echo("Pushing quickstarter git repo to ${context.gitUrlHttp}")

--- a/test/groovy/org/ods/PipelineScript.groovy
+++ b/test/groovy/org/ods/PipelineScript.groovy
@@ -39,6 +39,9 @@ class PipelineScript {
         body()
     }
 
+    def usernamePassword(def foo) {
+    }
+
     def sh(def foo) {
         return "test"
     }
@@ -96,8 +99,16 @@ class PipelineScript {
 
     }
 
+    def writeFile (Map args) {
+
+    }
+
     def readJSON (Map args) {
 
+    }
+
+    def dir(def foo, Closure body) {
+        body()
     }
 
     def withSonarQubeEnv(String conf, Closure closure) {

--- a/test/groovy/org/ods/quickstarter/PushToRemoteStageSpec.groovy
+++ b/test/groovy/org/ods/quickstarter/PushToRemoteStageSpec.groovy
@@ -1,0 +1,55 @@
+package org.ods.quickstarter
+
+import org.ods.PipelineScript
+
+import util.SpecHelper
+
+
+class PushToRemoteStageSpec extends SpecHelper {
+    PushToRemoteStage pushToRemoteStage
+    IContext context
+    PipelineScript script
+
+    def setup() {
+        script = Spy(new PipelineScript())
+        context = new Context([targetDir: 'fake-dir', cdUserCredentialsId: 'credentials-id', bitbucketUrl: 'http://fake-url'])
+    }
+
+    def "successful execution without git submodules"() {
+        given:
+            pushToRemoteStage = Spy(new PushToRemoteStage(script, context, [:]))
+
+        when:
+            pushToRemoteStage.run()
+
+        then:
+            1 * script.fileExists(_) >> false
+            1 * script.echo("Initializing quickstarter git repo ${context.targetDir} @${context.gitUrlHttp}")
+            1 * script.sh({ it.label == 'Copy quickstarter files' })
+            0 * script.sh({ it.label == 'Add submodule to quickstarter files' })
+            1 * script.sh({ it.label == 'Commit quickstarter files' })
+            1 * script.echo("Pushing quickstarter git repo to ${context.gitUrlHttp}")
+            1 * script.sh({ it.label == 'Push to remote' })
+    }
+
+    def "successful execution with git submodules"() {
+        given:
+            pushToRemoteStage = Spy(new PushToRemoteStage(script, context, [
+                gitSubModules: [
+                    [name: 'submodule', url: 'https://fake-submodule.git', branch: 'master', folder: 'src/code']
+                ],
+            ]))
+
+        when:
+            pushToRemoteStage.run()
+
+        then:
+            1 * script.fileExists(_) >> false
+            1 * script.echo("Initializing quickstarter git repo ${context.targetDir} @${context.gitUrlHttp}")
+            1 * script.sh({ it.label == 'Copy quickstarter files' })
+            1 * script.sh({ it.label == 'Add submodule to quickstarter files' })
+            1 * script.sh({ it.label == 'Commit quickstarter files' })
+            1 * script.echo("Pushing quickstarter git repo to ${context.gitUrlHttp}")
+            1 * script.sh({ it.label == 'Push to remote' })
+    }
+}


### PR DESCRIPTION
Some new quickstarters are using git submodules to manage some parts of the code. This requires some modifications to manage the creation of the submodules during the quickstarter provisioning. 

Example of how to integrate them in a quickstarter:

`odsQuickstarterPipeline(
  [
  	imageStreamTag: "${odsNamespace}/jenkins-agent-nodejs22:${agentImageTag}",
  	gitSubModules: [
  		[name: 'appShell', url: 'https://repo-submodule.git', branch: 'master', folder: 'src/submodule']
  	],
  ]
) { context ->`

