### PR TITLE
fix release manager rollout image listing when using Helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Helm Deployment Strategy handle race condition when rollout strategy promoting previous version image ([#1182](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1182))
 
 ### Added
 * add devcontainer setup ([#1172](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1172))

--- a/src/org/ods/component/HelmDeploymentStrategy.groovy
+++ b/src/org/ods/component/HelmDeploymentStrategy.groovy
@@ -208,7 +208,11 @@ class HelmDeploymentStrategy extends AbstractDeploymentStrategy {
                 // However, it doesn't matter which pod is the right one, if they all have the same images.
                 def sameImages = haveSameImages(latestPods)
                 if (!sameImages) {
-                    throw new RuntimeException("Unable to determine the most recent Pod. Multiple pods running with the same latest creation timestamp and different images found for ${resourceName}")
+                    throw new RuntimeException(
+                        "Unable to determine the most recent Pod. " +
+                        "Multiple pods running with the same latest creation timestamp " +
+                        "and different images found for ${resourceName}"
+                    )
                 }
                 // TODO: Once the orchestration pipeline can deal with multiple replicas,
                 // update this to store multiple pod artifacts.
@@ -249,8 +253,8 @@ class HelmDeploymentStrategy extends AbstractDeploymentStrategy {
     }
 
     /**
-     * Selects the items in the iterable which when passed as a parameter to the supplied closure return the maximum value.
-     * A null return value represents the least possible return value,
+     * Selects the items in the iterable which when passed as a parameter to the supplied closure
+     * return the maximum value. A null return value represents the least possible return value,
      * so any item for which the supplied closure returns null, won't be selected (unless all items return null).
      * The return list contains all the elements that returned the maximum value.
      *

--- a/src/org/ods/component/HelmDeploymentStrategy.groovy
+++ b/src/org/ods/component/HelmDeploymentStrategy.groovy
@@ -199,12 +199,13 @@ class HelmDeploymentStrategy extends AbstractDeploymentStrategy {
 
                 // We need to find the pod that was created as a result of the deployment.
                 // The previous pod may still be alive when we use a rollout strategy.
-                // We can tell one from the other using their creation timestamp
+                // We can tell one from the other using their creation timestamp,
+                // being the most recent the one we are interested in.
                 def latestPods = getLatestPods(podData)
                 // While very unlikely, it may happen that there is more than one pod with the same timestamp.
                 // Note that timestamp resolution is seconds.
                 // If that happens, we are unable to know which is the correct pod.
-                // However, we it doesn't matter which pod is the right one, if they all have the same images.
+                // However, it doesn't matter which pod is the right one, if they all have the same images.
                 def sameImages = haveSameImages(latestPods)
                 if (!sameImages) {
                     throw new RuntimeException("Unable to determine the most recent Pod. Multiple pods running with the same latest creation timestamp and different images found for ${resourceName}")
@@ -285,6 +286,7 @@ class HelmDeploymentStrategy extends AbstractDeploymentStrategy {
      */
     @NonCPS
     private static boolean areEqual(Iterable iterable, Closure equals) {
+        def equal = true
         if (iterable) {
             def first = true
             def base = null
@@ -293,10 +295,10 @@ class HelmDeploymentStrategy extends AbstractDeploymentStrategy {
                     base = it
                     first = false
                 } else if (!equals(base, it)) {
-                    return false
+                    equal = false
                 }
             }
         }
-        return true
+        return equal
     }
 }

--- a/src/org/ods/component/HelmDeploymentStrategy.groovy
+++ b/src/org/ods/component/HelmDeploymentStrategy.groovy
@@ -264,21 +264,15 @@ class HelmDeploymentStrategy extends AbstractDeploymentStrategy {
      */
     @NonCPS
     private static List maxElements(Iterable iterable, Closure getValue) {
-        List elements = null
         if (!iterable) {
-            return []
+            return [] // Return an empty list if the iterable is null or empty
         }
-        def maxValue = null;
-        iterable.each {
-            def value = getValue(it)
-            if (!elements || value > maxValue) {
-                maxValue = value
-                elements = [it]
-            } else if (value == maxValue) {
-                elements += it
-            }
-        }
-        return elements
+
+        // Find the maximum value using the closure
+        def maxValue = iterable.collect(getValue).max()
+
+        // Find all elements with the maximum value
+        return iterable.findAll { getValue(it) == maxValue }
     }
 
     /**

--- a/src/org/ods/util/PodData.groovy
+++ b/src/org/ods/util/PodData.groovy
@@ -17,6 +17,8 @@ class PodData {
 
     // podMetaDataCreationTimestamp equals .metadata.creationTimestamp.
     // Example: 2020-11-02T10:57:35Z
+    // We can use String to compare timestamps in this case,
+    // because ISO 8601 timestamps are designed to be sortable as strings.
     String podMetaDataCreationTimestamp
 
     // deploymentId is the name of the pod manager, such as the ReplicaSet or

--- a/test/groovy/org/ods/component/HelmDeploymentStrategySpec.groovy
+++ b/test/groovy/org/ods/component/HelmDeploymentStrategySpec.groovy
@@ -205,11 +205,11 @@ class HelmDeploymentStrategySpec extends PipelineSpockTestBase {
 
 
         then:
+        printCallStack()
         def e = thrown(RuntimeException)
-        e.message == "Unable to determine the most recent Pod. Multiple pods running with the same latest creation timestamp and different images found for bar"
 
-        // TODO question: is this expected that still pipeline is successful?
-        assertJobStatusSuccess()
+        assert e.message == "Unable to determine the most recent Pod. Multiple pods running with the same latest creation timestamp and different images found for bar"
+
     }
 
 }


### PR DESCRIPTION
Relates to https://github.com/opendevstack/ods-quickstarters/issues/1013 , as this bug must be fixed.

The issue happens rarely but impacts the use of Helm strategy within the Release Manager usage; it is a race condition happening when having rollout defined as deployment strategy, and with the provided fix we make sure we always get the latest expected image.

FYI, the fix has also been tested internally, thanks to @BraisVQ 