### PR TITLE
Bugfix for TRC document references wrong Reference Documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Update TRC reference document with SSDS and TCP ([#1189](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1189))
 
 ### Added
 * add devcontainer setup ([#1172](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1172))

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1783,6 +1783,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
             DocumentType.CFTR,
             DocumentType.TIR,
             DocumentType.TIP,
+            DocumentType.TCP,
         ]
 
         referencedDcocs.collectEntries { DocumentType dt ->

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1715,7 +1715,7 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
         def versions = useCase.getReferencedDocumentsVersion()
 
         then:
-        8 * useCase.getDocumentTrackingIssuesForHistory(_, _) >> []
+        9 * useCase.getDocumentTrackingIssuesForHistory(_, _) >> []
         versions == [
             CSD: 'ConfigItem / See version created within this change',
             CSD_version: 'WIP/3',

--- a/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
+++ b/test/groovy/org/ods/orchestration/usecase/LeVADocumentUseCaseSpec.groovy
@@ -1736,7 +1736,9 @@ class LeVADocumentUseCaseSpec extends SpecHelper {
             TIR: 'ConfigItem / See version created within this change',
             TIR_version: 'WIP/2',
             TIP: 'ConfigItem / See version created within this change',
-            TIP_version: 'WIP/2'
+            TIP_version: 'WIP/2',
+            TCP: 'ConfigItem / See version created within this change',
+            TCP_version: 'WIP/2'
         ]
     }
 


### PR DESCRIPTION
In the Traceability Document, in section 2 Reference Documents, we need to remove the following references:

- Combined Functional and Requirements Testing Plan

And add the following references instead:

- System and Software Design Specification incl. Source Code Review Plan
- Test Cases Plan