### PR TITLE
Sort requirement unit tests in TCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 * Enhance SSDS Document Generation Performance using New Atlassian APIs ([#1084](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1084))
 * Simplify successor management since now issue links are no longer inherited ([#1116](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1116))
+* Sort unit test keys associated with requirements in TCR ([#1192](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1116))
 
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))

--- a/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/LeVADocumentUseCase.groovy
@@ -1194,7 +1194,7 @@ class LeVADocumentUseCase extends DocGenUseCase {
                 description : this.convertImages(r.description ?: ''),
                 techSpecs   : r.techSpecs.join(", "),
                 risks       : (r.getResolvedTechnicalSpecifications().risks + r.risks).flatten().unique().join(", "),
-                tests       : testWithoutUnit.join(", "),
+                tests       : testWithoutUnit.sort().join(", "),
                 predecessors: predecessors,
             ]
         }


### PR DESCRIPTION
Sort unit tests associated to the requirements in the TCR so that they appear always in the same order.