### PR TITLE
Do not retrieve components from Jira when using an alternate Jira project and not generating documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Do not retrieve components from Jira when using an alternate Jira project and not generating documentation ([#1211](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1211))
 
 ### Added
 

--- a/src/org/ods/orchestration/usecase/JiraUseCase.groovy
+++ b/src/org/ods/orchestration/usecase/JiraUseCase.groovy
@@ -368,7 +368,7 @@ class JiraUseCase {
     void updateJiraReleaseStatusBuildNumber() {
         if (!this.jira) return
 
-        def projectKey = this.project.key
+        def projectKey = this.project.jiraProjectKey
         def changeId = this.project.buildParams.changeId
         def fields = [buildNumber: "${this.project.buildParams.version}-${this.steps.env.BUILD_NUMBER}"]
         this.jira.updateReleaseStatusIssue(projectKey, changeId, fields)

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -461,9 +461,11 @@ class Project {
                 result[type] = data[type].findAll { k, v -> isIssueWIP(v) }.keySet() as List<String>
             }
         }
-        def docs = computeWIPDocChapters(data)
-        if (docs != null) {
-            result[JiraDataItem.TYPE_DOCS] = docs.keySet() as List<String>
+        if (this.hasCapability('LeVADocs')) {
+            def docs = computeWIPDocChapters(data)
+            if (docs != null) {
+                result[JiraDataItem.TYPE_DOCS] = docs.keySet() as List<String>
+            }
         }
 
         return result

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -1191,14 +1191,15 @@ class Project {
          ]
      }
      * If jira or JiraUsecase is not enabled -> Empty map
+     * If jiraProjectKey differs from project key and LeVADocs capability is disabled -> Empty map
      * Otherwise, check from Jira
      * @result The call results, and empty if not enabled
      * @throw ComponentMismatchException if there is a component mismatch
      */
     Map getComponentsFromJira() {
-        if (!this.jiraUseCase) return [:]
+        if (!this.jiraUseCase || (this.key != this.jiraProjectKey && !this.hasCapability('LeVADocs'))) return [:]
 
-        return jiraUseCase.getComponents(this.key, this.data.buildParams.changeId, this.isWorkInProgress)
+        return jiraUseCase.getComponents(this.jiraProjectKey, this.data.buildParams.changeId, this.isWorkInProgress)
     }
 
     protected Map loadJiraData(String projectKey) {


### PR DESCRIPTION
When using an alternate Jira project, component retrieval may fail. However, we don't need to retrieve the components if we aren't generating documentation.