### PR TITLE
Remove code taking predecessor links into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
+* Ignore links from predecessor issues since all links are now duplicated ([#1231](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1231))
 
 ## [4.9.1] - 2025-8-11
 ### Fixed

--- a/src/org/ods/orchestration/util/Project.groovy
+++ b/src/org/ods/orchestration/util/Project.groovy
@@ -2126,11 +2126,7 @@ class Project {
                         def expandedPredecessors = predecessors.collect { predecessor ->
                             expandPredecessor(issueType, issueKey, predecessor)
                         }.flatten()
-                        // Get old links from predecessor (just one allowed)
-                        def predecessorIssue = savedData.get(issueType).get(predecessors.first())
-                        def updatedIssue = mergeJiraItemLinks(predecessorIssue, issue, discontinuations)
-
-                        [(issueKey): (updatedIssue + [expandedPredecessors: expandedPredecessors])]
+                        [(issueKey): (issue + [expandedPredecessors: expandedPredecessors])]
                     }
                 }
                 [(issueType): updatedIssues]


### PR DESCRIPTION
Fix some old issues linked to predecessors appearing in some documents by removing code taking predecessor links into account