### PR TITLE
Fix sonarqube report process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add component information in automatic release close notes ([#1254](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1254))
 
 ### Fixed
+* Fix sonarqube report process ([#1255](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1255))
 * Log correct error message for wrong preview-branch value ([#1249](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1249))
 * Fail the pipeline when no version specified for a deploy to Q, P ([#1248](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1248))
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -278,7 +278,7 @@ class ScanWithSonarStage extends Stage {
         )
         steps.sh(
             label: 'Move and rename report to artifacts dir',
-            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
+            script: "mv sonarqube-report_fail.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
                     "echo 'Failed to move report'"
         )
         

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -278,29 +278,27 @@ class ScanWithSonarStage extends Stage {
         )
         steps.sh(
             label: 'Move and rename report to artifacts dir',
-            script: "mv sonarqube-report_fail.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
+            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
                     "echo 'Failed to move report'"
         )
         
         try {
             steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
-        } catch (Exception e) {
-            logger.warn "Failed to archive artifacts: ${e.message}"
-        }
 
-        def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
-        context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)
+            def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
+            context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)
 
-        try {
             steps.stash(
                 name: "${sonarqubeStashPath}",
                 includes: "artifacts/sonarqube-report-*"
             )
+
+            context.addArtifactURI('sonarqube-report', targetReport)
         } catch (Exception e) {
-            logger.warn "Failed to stash artifacts: ${e.message}"
+            logger.warn "Failed to archive or stash artifacts: ${e.message}"
         }
         
-        context.addArtifactURI('sonarqube-report', targetReport)
+        
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -281,15 +281,25 @@ class ScanWithSonarStage extends Stage {
             script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
                     "echo 'Failed to move report'"
         )
-        steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
+        
+        try {
+            steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
+        } catch (Exception e) {
+            logger.warn "Failed to archive artifacts: ${e.message}"
+        }
 
         def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
         context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)
 
-        steps.stash(
-            name: "${sonarqubeStashPath}",
-            includes: "artifacts/sonarqube-report-*"
-        )
+        try {
+            steps.stash(
+                name: "${sonarqubeStashPath}",
+                includes: "artifacts/sonarqube-report-*"
+            )
+        } catch (Exception e) {
+            logger.warn "Failed to stash artifacts: ${e.message}"
+        }
+        
         context.addArtifactURI('sonarqube-report', targetReport)
     }
 

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -283,18 +283,18 @@ class ScanWithSonarStage extends Stage {
         )
         
         try {
-            steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report_fail-*")
+            steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
 
-            def sonarqubeStashPath = "sonarqube-report_fail-${context.componentId}-${context.buildNumber}"
+            def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
             context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)
 
             steps.stash(
                 name: "${sonarqubeStashPath}",
-                includes: "artifacts/sonarqube-report_fail-*"
+                includes: "artifacts/sonarqube-report-*"
 
             )
 
-            context.addArtifactURI('sonarqube-report_fail', targetReport)
+            context.addArtifactURI('sonarqube-report', targetReport)
         } catch (Exception e) {
             logger.warn "Failed to archive or stash artifacts: ${e.message}"
         }

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -278,10 +278,10 @@ class ScanWithSonarStage extends Stage {
         )
         steps.sh(
             label: 'Move and rename report to artifacts dir',
-            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} || " +
-                    "(echo 'Failed to move report')"
+            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
+                    "echo 'Failed to move report'"
         )
-        steps.archiveArtifacts(artifacts: "${steps.env.WORKSPACE}/artifacts/sonarqube-report-*")
+        steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
 
         def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
         context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -281,7 +281,6 @@ class ScanWithSonarStage extends Stage {
             script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
                     "echo 'Failed to move report'"
         )
-        
         try {
             steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
 
@@ -298,8 +297,6 @@ class ScanWithSonarStage extends Stage {
         } catch (Exception e) {
             logger.warn "Failed to archive or stash artifacts: ${e.message}"
         }
-        
-        
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -156,6 +156,10 @@ class ScanWithSonarStage extends Stage {
             targetReport
         )
 
+        // Upload report to Nexus and create Bitbucket code insight
+        URI nexusUri = generateAndArchiveReportInNexus(targetReport,
+            context.sonarQubeNexusRepository ? context.sonarQubeNexusRepository : DEFAULT_NEXUS_REPOSITORY)
+
         // We need always the QG to put in insight report in Bitbucket
         def qualityGateResult = getQualityGateResult(
             sonarProjectKey,
@@ -165,9 +169,6 @@ class ScanWithSonarStage extends Stage {
             privateToken
         ).toUpperCase()
 
-        // Upload report to Nexus and create Bitbucket code insight
-        URI nexusUri = generateAndArchiveReportInNexus(targetReport,
-            context.sonarQubeNexusRepository ? context.sonarQubeNexusRepository : DEFAULT_NEXUS_REPOSITORY)
         createBitbucketCodeInsightReport(qualityGateResult, nexusUri.toString(), sonarProjectKey,
             context.sonarQubeEdition, sonarProperties['sonar.branch.name'].toString())
 
@@ -277,9 +278,10 @@ class ScanWithSonarStage extends Stage {
         )
         steps.sh(
             label: 'Move and rename report to artifacts dir',
-            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport}"
+            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} || " +
+                    "(echo 'Failed to move report'"
         )
-        steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
+        steps.archiveArtifacts(artifacts: "${steps.env.WORKSPACE}/artifacts/sonarqube-report-*")
 
         def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
         context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)
@@ -380,7 +382,7 @@ class ScanWithSonarStage extends Stage {
     }
 
     private URI generateAndArchiveReportInNexus(String targetReport, nexusRepository) {
-        def reportPath = "artifacts/${targetReport}"
+        def reportPath = "${steps.env.WORKSPACE}/artifacts/${targetReport}"
         def reportBytes = steps.readFile(file: reportPath, encoding: "ISO-8859-1") as String
         byte[] pdfBytes = reportBytes.getBytes("ISO-8859-1")
 

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -278,7 +278,7 @@ class ScanWithSonarStage extends Stage {
         )
         steps.sh(
             label: 'Move and rename report to artifacts dir',
-            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
+            script: "mv sonarqube-report_force_fail.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
                     "echo 'Failed to move report'"
         )
         

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -279,7 +279,7 @@ class ScanWithSonarStage extends Stage {
         steps.sh(
             label: 'Move and rename report to artifacts dir',
             script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} || " +
-                    "(echo 'Failed to move report'"
+                    "(echo 'Failed to move report')"
         )
         steps.archiveArtifacts(artifacts: "${steps.env.WORKSPACE}/artifacts/sonarqube-report-*")
 

--- a/src/org/ods/component/ScanWithSonarStage.groovy
+++ b/src/org/ods/component/ScanWithSonarStage.groovy
@@ -278,22 +278,23 @@ class ScanWithSonarStage extends Stage {
         )
         steps.sh(
             label: 'Move and rename report to artifacts dir',
-            script: "mv sonarqube-report_force_fail.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
+            script: "mv sonarqube-report.pdf ${steps.env.WORKSPACE}/artifacts/${targetReport} 2>&1 || " +
                     "echo 'Failed to move report'"
         )
         
         try {
-            steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report-*")
+            steps.archiveArtifacts(artifacts: "artifacts/sonarqube-report_fail-*")
 
-            def sonarqubeStashPath = "sonarqube-report-${context.componentId}-${context.buildNumber}"
+            def sonarqubeStashPath = "sonarqube-report_fail-${context.componentId}-${context.buildNumber}"
             context.addArtifactURI('sonarqubeScanStashPath', sonarqubeStashPath)
 
             steps.stash(
                 name: "${sonarqubeStashPath}",
-                includes: "artifacts/sonarqube-report-*"
+                includes: "artifacts/sonarqube-report_fail-*"
+
             )
 
-            context.addArtifactURI('sonarqube-report', targetReport)
+            context.addArtifactURI('sonarqube-report_fail', targetReport)
         } catch (Exception e) {
             logger.warn "Failed to archive or stash artifacts: ${e.message}"
         }


### PR DESCRIPTION
Fix SonarQube report process:
- Ensure the report to Nexus is uploaded.
- Use an absolute path for the Nexus file upload
- Upload the report to Nexus before dealing with Quality Gate
- Encapsulate archiving in a try-catch to continue the SonarQube stage even if this fails
- Show when SonarQube report move fails
