### PR TITLE
#1260 Improves/fixes Trivy Stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update automatic release component information with N/A when pipelines have not run yet ([#1257](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1257))
 * Enhance Helm strategy and support of Statefullset/Cronjob ([#1253](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1253))
 * Add component information in automatic release close notes ([#1254](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1254))
+* Improve Trivy Stage by being able to use severity thresholds ([#1262](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1262))
 
 ### Fixed
 * Fail pipeline when deploying with issues in progress ([#1258](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1258))

--- a/docs/modules/jenkins-shared-library/partials/odsComponentStageScanWithTrivy.adoc
+++ b/docs/modules/jenkins-shared-library/partials/odsComponentStageScanWithTrivy.adoc
@@ -80,6 +80,6 @@ _String_
 
 | *scanners* +
 _String_
-|Comma-separated list of what security issues to detect. Defaults to `vuln,config,secret,license`.
+|Comma-separated list of what security issues to detect. Defaults to `vuln,misconfig,secret,license`.
 
 |===

--- a/src/org/ods/component/ScanWithTrivyOptions.groovy
+++ b/src/org/ods/component/ScanWithTrivyOptions.groovy
@@ -14,7 +14,7 @@ class ScanWithTrivyOptions extends Options {
     String format
 
     /**
-     * Comma-separated list of what security issues to detect. Defaults to `vuln,config,secret,license`. */
+     * Comma-separated list of what security issues to detect. Defaults to `vuln,misconfig,secret,license`. */
     String scanners
 
     /**

--- a/src/org/ods/component/ScanWithTrivyStage.groovy
+++ b/src/org/ods/component/ScanWithTrivyStage.groovy
@@ -27,7 +27,6 @@ class ScanWithTrivyStage extends Stage {
         if (!config.resourceName) {
             config.resourceName = context.componentId
         }
-        // check format
         if (!config.format) {
             config.format = 'cyclonedx'
         }
@@ -57,59 +56,31 @@ class ScanWithTrivyStage extends Stage {
     }
 
     protected run() {
-        String errorMessages = ''
-        int returnCode = scanViaCli(options.scanners, options.pkgType, options.format,
-            options.additionalFlags, options.reportFile, options.nexusDataBaseRepository,
-            openShift.getApplicationDomain())
-        if ([TrivyService.TRIVY_SUCCESS].contains(returnCode)) {
-            try {
-                URI reportUriNexus = archiveReportInNexus(options.reportFile, options.nexusReportRepository)
-                createBitbucketCodeInsightReport(options.nexusReportRepository ? reportUriNexus.toString() : null,
-                    returnCode, errorMessages)
-                archiveReportInJenkins(!context.triggeredByOrchestrationPipeline, options.reportFile)
-            } catch (err) {
-                logger.warn("Error archiving the Trivy reports due to: ${err}")
-            }
-        } else {
-            errorMessages += "<li>Error executing Trivy CLI</li>"
-            createBitbucketCodeInsightReport(errorMessages)
+        String flags = options.additionalFlags.collect { " $it" }.join("")
+        int returnCode = trivy.scan(
+            options.resourceName,
+            options.scanners,
+            options.pkgType,
+            options.format,
+            flags,
+            options.reportFile,
+            options.nexusDataBaseRepository,
+            openShift.getApplicationDomain()
+        )
+        try {
+            URI reportUriNexus = archiveReportInNexus()
+            createBitbucketCodeInsightReport(reportUriNexus?.toString(), returnCode)
+            archiveReportInJenkins(!context.triggeredByOrchestrationPipeline, options.reportFile)
+        } catch (Exception err) {
+            logger.warn("Error archiving the Trivy reports due to: ${err}")
+            createBitbucketCodeInsightErrorReport("<li>Error archiving Trivy report: ${err.message}</li>")
         }
-        return
     }
 
-    @SuppressWarnings('ParameterCount')
-    private int scanViaCli(String scanners, String pkgType, String format,
-        List<String> additionalFlags, String reportFile, String nexusDataBaseRepository, String openshiftAppDomain) {
-        logger.startClocked(options.resourceName)
-        String flags = ""
-        additionalFlags.each { flag ->
-            flags += " " + flag
-        }
-        int returnCode = trivy.scanViaCli(scanners, pkgType, format, flags, reportFile,
-            nexusDataBaseRepository, openshiftAppDomain)
-        switch (returnCode) {
-            case TrivyService.TRIVY_SUCCESS:
-                logger.info "Finished scan via Trivy CLI successfully!"
-                break
-            case TrivyService.TRIVY_OPERATIONAL_ERROR:
-                logger.info "An error occurred in processing the scan request " +
-                    "(e.g. invalid command line options, operational error)."
-                break
-            default:
-                logger.info "An unknown return code was returned: ${returnCode}"
-        }
-        logger.infoClocked(options.resourceName, "Trivy scan (via CLI)")
-        return returnCode
-    }
-
-    @SuppressWarnings('ParameterCount')
-    private createBitbucketCodeInsightReport(String nexusUrlReport, int returnCode, String messages) {
-        String title = "Trivy Security"
-        String details = "Please visit the following link to review the Trivy Security scan report:"
-        String result = returnCode == 0 ? "PASS" : "FAIL"
+    private void createBitbucketCodeInsightReport(String nexusUrlReport, int returnCode) {
         def data = [
             key: BITBUCKET_TRIVY_REPORT_KEY,
-            title: title,
+            title: "Trivy Security",
             link: nexusUrlReport,
             otherLinks: [
                 [
@@ -118,65 +89,44 @@ class ScanWithTrivyStage extends Stage {
                     link: nexusUrlReport
                 ]
             ],
-            details: details,
-            result: result,
+            details: "Please visit the following link to review the Trivy Security scan report:",
+            result: returnCode == TrivyService.TRIVY_SUCCESS ? "PASS" : "FAIL",
         ]
-
-        if (messages) {
-            data.put("messages", [
-                [ title: "Messages", value: prepareMessageToBitbucket(messages), ]
-            ])
-        }
-
         bitbucket.createCodeInsightReport(data, context.repoName, context.gitCommit)
     }
 
-    private createBitbucketCodeInsightReport(String messages) {
-        String title = "Trivy Security"
-        String details = "There was some problems with Trivy:"
-
-        String result = "FAIL"
-
+    private void createBitbucketCodeInsightErrorReport(String errorMessages) {
         def data = [
             key: BITBUCKET_TRIVY_REPORT_KEY,
-            title: title,
+            title: "Trivy Security",
             messages: [
                 [
                     title: "Messages",
-                    value: prepareMessageToBitbucket(messages)
+                    value: prepareMessageToBitbucket(errorMessages)
                 ]
             ],
-            details: details,
-            result: result,
+            details: "There was some problems with Trivy:",
+            result: "FAIL",
         ]
-
         bitbucket.createCodeInsightReport(data, context.repoName, context.gitCommit)
     }
 
-    private String prepareMessageToBitbucket(String message = "") {
+    private static String prepareMessageToBitbucket(String message = "") {
         return message?.replaceAll("<li>", "")?.replaceAll("</li>", ". ")
     }
 
-    @SuppressWarnings('ReturnNullFromCatchBlock')
-    private URI archiveReportInNexus(String reportFile, nexusReportRepository) {
-        try {
-            URI report = nexus.storeArtifact(
-                "${nexusReportRepository}",
-                "${context.projectId}/${this.options.resourceName}/" +
-                    "${new Date().format('yyyy-MM-dd')}-${context.buildNumber}/trivy",
-                "${reportFile}",
-                (steps.readFile(file: reportFile) as String).bytes, "json")
-
-            logger.info "Report stored in: ${report}"
-
-            return report
-        } catch (err) {
-            logger.warn("Error archiving the Trivy reports in Nexus due to: ${err}")
-            return null
-        }
+    private URI archiveReportInNexus() {
+        URI report = nexus.storeArtifact(
+            options.nexusReportRepository,
+            "${context.projectId}/${options.resourceName}/" +
+                "${new Date().format('yyyy-MM-dd')}-${context.buildNumber}/trivy",
+            options.reportFile,
+            (steps.readFile(file: options.reportFile) as String).bytes, "json")
+        logger.info "Report stored in: ${report}"
+        return report
     }
 
-    private archiveReportInJenkins(boolean archive, String reportFile) {
+    private void archiveReportInJenkins(boolean archive, String reportFile) {
         String targetReport = "SCSR-${context.projectId}-${context.componentId}-${reportFile}"
         steps.sh(
             label: 'Create artifacts dir',
@@ -191,7 +141,6 @@ class ScanWithTrivyStage extends Stage {
         }
         String trivyScanStashPath = "scsr-report-${context.componentId}-${context.buildNumber}"
         context.addArtifactURI('trivyScanStashPath', trivyScanStashPath)
-
         steps.stash(
             name: "${trivyScanStashPath}",
             includes: 'artifacts/SCSR*',

--- a/src/org/ods/services/TrivyService.groovy
+++ b/src/org/ods/services/TrivyService.groovy
@@ -8,7 +8,7 @@ import org.ods.util.IPipelineSteps
 class TrivyService {
 
     static final int TRIVY_SUCCESS = 0
-    static final int TRIVY_OPERATIONAL_ERROR = 1
+    static final int TRIVY_FAIL = 1
 
     private final IPipelineSteps steps
     private final ILogger logger
@@ -19,11 +19,11 @@ class TrivyService {
     }
 
     @SuppressWarnings('ParameterCount')
-    int scanViaCli(String scanners, String pkgType, String format, String flags,
-        String reportFile, String nexusRepository, String openshiftDomain ) {
+    int scan(String resourceName, String scanners, String pkgType, String format, String flags,
+        String reportFile, String nexusRepository, String openshiftDomain) {
+        logger.startClocked(resourceName)
         logger.info "Starting to scan via Trivy CLI..."
-        int status = TRIVY_SUCCESS
-        status = steps.sh(
+        int returnCode = steps.sh(
             label: 'Scan via Trivy CLI',
             returnStatus: true,
             script: """
@@ -53,8 +53,22 @@ class TrivyService {
                 set -e
             """
         )
-
-        return status
+        switch (returnCode) {
+            case TRIVY_SUCCESS:
+                logger.info "Finished scan via Trivy CLI successfully!"
+                break
+            case TRIVY_FAIL:
+                logger.info(
+                    "An error occurred while processing the Trivy scan request " +
+                    "(e.g. invalid command line options, operational error, or " +
+                    "severity threshold exceeded when using the --exit-code flag)."
+                )
+                break
+            default:
+                logger.info "An unknown return code was returned: ${returnCode}"
+        }
+        logger.infoClocked(resourceName, "Trivy scan (via CLI)")
+        return returnCode
     }
 
 }

--- a/test/groovy/org/ods/component/ScanWithTrivyStageSpec.groovy
+++ b/test/groovy/org/ods/component/ScanWithTrivyStageSpec.groovy
@@ -4,7 +4,6 @@ import org.ods.services.TrivyService
 import org.ods.services.BitbucketService
 import org.ods.services.NexusService
 import org.ods.services.OpenShiftService
-import org.ods.services.ServiceRegistry
 import org.ods.util.Logger
 import vars.test_helper.PipelineSpockTestBase
 import util.PipelineSteps
@@ -32,6 +31,7 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
             logger))
         def nexus = Spy(new NexusService ("http://nexus", script, "foo-cd-cd-user-with-password"))
         def openShift = Spy(new OpenShiftService (script, logger))
+        openShift.getApplicationDomain() >> "openshift-domain.com"
         def stage = new ScanWithTrivyStage(
             script,
             context,
@@ -105,7 +105,7 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         def stage = createStage()
 
         when:
-        stage.archiveReportInNexus("trivy-sbom.json", "leva-documentation")
+        stage.archiveReportInNexus()
 
         then:
         1 * stage.script.readFile([file: "trivy-sbom.json"]) >> "Cool report"
@@ -133,7 +133,7 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         ]
 
         when:
-        stage.createBitbucketCodeInsightReport("http://nexus", 0, null)
+        stage.createBitbucketCodeInsightReport("http://nexus", 0)
 
         then:
         1 * stage.bitbucket.createCodeInsightReport(data, stage.context.repoName, stage.context.gitCommit)
@@ -158,13 +158,13 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         ]
 
         when:
-        stage.createBitbucketCodeInsightReport("http://nexus", 1, null)
+        stage.createBitbucketCodeInsightReport("http://nexus", 1)
 
         then:
         1 * stage.bitbucket.createCodeInsightReport(data, stage.context.repoName, stage.context.gitCommit)
     }
 
-    def "create Bitbucket Insight report - Messages"() {
+    def "create Bitbucket Insight report - Error Messages"() {
         given:
         def stage = createStage()
         def data = [
@@ -181,7 +181,7 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         ]
 
         when:
-        stage.createBitbucketCodeInsightReport('Message')
+        stage.createBitbucketCodeInsightErrorReport('Message')
 
         then:
         1 * stage.bitbucket.createCodeInsightReport(data, stage.context.repoName, stage.context.gitCommit)
@@ -192,12 +192,18 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         def stage = createStage()
 
         when:
-        def result = stage.scanViaCli("vuln,config,secret,license", "os,library", "cyclonedx",
-            [], "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
+        def result = stage.trivy.scan("component1", "vuln,misconfig,secret,license", "os,library",
+           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
 
         then:
-        1 * stage.trivy.scanViaCli("vuln,config,secret,license", "os,library",
-           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com") >> TrivyService.TRIVY_SUCCESS
+        1 * stage.script.sh(_) >> {
+            assert it.label == ['Scan via Trivy CLI']
+            return TrivyService.TRIVY_SUCCESS
+        }
+        1 * stage.script.sh(_) >> {
+            assert it.label == ['Read SBOM with Trivy CLI']
+            return 0
+        }
         1 * stage.logger.info("Finished scan via Trivy CLI successfully!")
         TrivyService.TRIVY_SUCCESS == result
     }
@@ -207,15 +213,24 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         def stage = createStage()
 
         when:
-        def result = stage.scanViaCli("vuln,config,secret,license", "os,library", "cyclonedx",
-            [], "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
+        def result = stage.trivy.scan("component1", "vuln,misconfig,secret,license", "os,library",
+           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
 
         then:
-        1 * stage.trivy.scanViaCli("vuln,config,secret,license", "os,library",
-           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com") >> TrivyService.TRIVY_OPERATIONAL_ERROR
-        1 * stage.logger.info("An error occurred in processing the scan request " +
-            "(e.g. invalid command line options, operational error).")
-        TrivyService.TRIVY_OPERATIONAL_ERROR == result
+        1 * stage.script.sh(_) >> {
+            assert it.label == ['Scan via Trivy CLI']
+            return TrivyService.TRIVY_FAIL
+        }
+        1 * stage.script.sh(_) >> {
+            assert it.label == ['Read SBOM with Trivy CLI']
+            return 0
+        }
+        1 * stage.logger.info(
+                  "An error occurred while processing the Trivy scan request " +
+                  "(e.g. invalid command line options, operational error, or " +
+                  "severity threshold exceeded when using the --exit-code flag)."
+        )
+        TrivyService.TRIVY_FAIL == result
     }
 
     def "scan with CLI - Error"() {
@@ -223,12 +238,18 @@ class ScanWithTrivyStageSpec extends PipelineSpockTestBase {
         def stage = createStage()
 
         when:
-        def result = stage.scanViaCli("vuln,config,secret,license", "os,library", "cyclonedx",
-            [], "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
+        def result = stage.trivy.scan("component1", "vuln,misconfig,secret,license", "os,library",
+           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
 
         then:
-        1 * stage.trivy.scanViaCli("vuln,config,secret,license", "os,library",
-           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com") >> 127
+        1 * stage.script.sh(_) >> {
+            assert it.label == ['Scan via Trivy CLI']
+            return 127
+        }
+        1 * stage.script.sh(_) >> {
+            assert it.label == ['Read SBOM with Trivy CLI']
+            return 0
+        }
         1 * stage.logger.info("An unknown return code was returned: 127")
         127 == result
     }

--- a/test/groovy/org/ods/services/TrivyServiceSpec.groovy
+++ b/test/groovy/org/ods/services/TrivyServiceSpec.groovy
@@ -5,16 +5,14 @@ import vars.test_helper.PipelineSpockTestBase
 
 class TrivyServiceSpec extends PipelineSpockTestBase {
 
-    def "invoke Trivy cli"() {
+    def "scan - SUCCESS"() {
         given:
         def steps = Spy(util.PipelineSteps)
-        def service = Spy(TrivyService, constructorArgs: [
-            steps,
-            new Logger(steps, false)
-        ])
+        def logger = Spy(new Logger(steps, false))
+        def service = Spy(TrivyService, constructorArgs: [steps, logger])
 
         when:
-        def result = service.scanViaCli("vuln,misconfig,secret,license", "os,library",
+        def result = service.scan("component1", "vuln,misconfig,secret,license", "os,library",
            "cyclonedx", "--debug --timeout=10m", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
 
         then:
@@ -47,9 +45,47 @@ class TrivyServiceSpec extends PipelineSpockTestBase {
             assert it.script.toString().contains('set -e')
 
             return 0
-        }    
-
+        }
+        1 * logger.info("Finished scan via Trivy CLI successfully!")
         0 == result
+    }
+
+    def "scan - Operational Error"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = Spy(new Logger(steps, false))
+        def service = Spy(TrivyService, constructorArgs: [steps, logger])
+
+        when:
+        def result = service.scan("component1", "vuln,misconfig,secret,license", "os,library",
+           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
+
+        then:
+        1 * steps.sh({ it.label == 'Scan via Trivy CLI' }) >> 1
+        1 * steps.sh({ it.label == 'Read SBOM with Trivy CLI' }) >> 0
+        1 * logger.info(
+                  "An error occurred while processing the Trivy scan request " +
+                  "(e.g. invalid command line options, operational error, or " +
+                  "severity threshold exceeded when using the --exit-code flag)."
+        )
+        1 == result
+    }
+
+    def "scan - Unknown return code"() {
+        given:
+        def steps = Spy(util.PipelineSteps)
+        def logger = Spy(new Logger(steps, false))
+        def service = Spy(TrivyService, constructorArgs: [steps, logger])
+
+        when:
+        def result = service.scan("component1", "vuln,misconfig,secret,license", "os,library",
+           "cyclonedx", "", "trivy-sbom.json", "docker-group-ods", "openshift-domain.com")
+
+        then:
+        1 * steps.sh({ it.label == 'Scan via Trivy CLI' }) >> 127
+        1 * steps.sh({ it.label == 'Read SBOM with Trivy CLI' }) >> 0
+        1 * logger.info("An unknown return code was returned: 127")
+        127 == result
     }
 
 }


### PR DESCRIPTION
 Closes #1260
 
 **Notable Changes:**
- Enables to use trivy's severity threshold with exit-code option while showing correct bitbucket code insight symbol and keeping report as requested in issue #1260
- Some refactoring including moving code that should be in service layer to TrivyService for better separation of concern
- Fixes bug that exceptions that happen while archiving report to nexus does just return null instead of exception
- Adds a couple of tests to the existing ones
- Renames return code int variable `TRIVY_OPERATIONAL_ERROR` into `TRIVY_FAIL` because the scan can now fail due to exceeding the severity threshold as well.