### PR TITLE
Fix branch mapping logic to ensure correct environment assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
+* Fix branch mapping logic to ensure correct environment assignment ([#1263](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1263))
 
 ## [4.12.0] - 2026-03-02
 ### Changed
@@ -23,7 +24,7 @@
 ## [4.11.2] - 2026-03-02
 ### Fixed
 * Fix SonarQube run enable/disable logic ([#1259](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1259))
-* Fix branch mapping logic to ensure correct environment assignment ([#1263](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1263))
+
 
 ## [4.11.1] - 2025-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ## [4.11.2] - 2026-03-02
 ### Fixed
 * Fix SonarQube run enable/disable logic ([#1259](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1259))
+* Fix branch mapping logic to ensure correct environment assignment ([#1263](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1263))
 
 ## [4.11.1] - 2025-12-19
 

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -495,7 +495,7 @@ class Context implements IContext {
         // https://issues.jenkins-ci.org/browse/JENKINS-27421 and
         // https://issues.jenkins-ci.org/browse/JENKINS-35191.
         for (def key : config.branchToEnvironmentMapping.keySet()) {
-           if (config.gitBranch.startsWith(key) && key.endsWith('/')) {
+            if (config.gitBranch.startsWith(key) && key.endsWith('/')) {
                 setMostSpecificEnvironment(
                     config.branchToEnvironmentMapping[key],
                     config.gitBranch.replace(key, '')

--- a/src/org/ods/component/Context.groovy
+++ b/src/org/ods/component/Context.groovy
@@ -495,7 +495,7 @@ class Context implements IContext {
         // https://issues.jenkins-ci.org/browse/JENKINS-27421 and
         // https://issues.jenkins-ci.org/browse/JENKINS-35191.
         for (def key : config.branchToEnvironmentMapping.keySet()) {
-            if (config.gitBranch.startsWith(key)) {
+           if (config.gitBranch.startsWith(key) && key.endsWith('/')) {
                 setMostSpecificEnvironment(
                     config.branchToEnvironmentMapping[key],
                     config.gitBranch.replace(key, '')


### PR DESCRIPTION
Shared library was not handling branchToMapping properly.  Branches whose name starts with branches defined in the  branchToEnvironmentMapping property AND where there was NO exact match listed in the branchToEnvironmentMapping property would attempt to deploy rather than skip deployment (as no environment mapped).  

The code change enforces that branches defined in the branchToEnvironmentMapping property that do not end with "/" should require an exact match before triggering a deployment

