### PR TITLE
Fix Nexus not accepting npm artifacts when uploaded through odsComponentStageUploadToNexus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * Fix branch mapping logic to ensure correct environment assignment ([#1263](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1263))
+* Fix Nexus not accepting npm artifacts when uploaded through odsComponentStageUploadToNexus ([#3913](https://github.com/opendevstack/ods-jenkins-shared-library/pull/3913))
 
 ## [4.12.0] - 2026-03-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 * Fix Tailor deployment drifts for D, Q envs ([#1055](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1055))
 * Fix branch mapping logic to ensure correct environment assignment ([#1263](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1263))
-* Fix Nexus not accepting npm artifacts when uploaded through odsComponentStageUploadToNexus ([#3913](https://github.com/opendevstack/ods-jenkins-shared-library/pull/3913))
+* Fix Nexus not accepting npm artifacts when uploaded through odsComponentStageUploadToNexus ([#1268](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1268))
 
 ## [4.12.0] - 2026-03-02
 ### Changed

--- a/src/org/ods/component/UploadToNexusStage.groovy
+++ b/src/org/ods/component/UploadToNexusStage.groovy
@@ -55,6 +55,8 @@ class UploadToNexusStage extends Stage {
             nexusParams << ['raw.directory': (options.targetDirectory ?: context.projectId)]
         } else if (options.repositoryType == 'pypi') {
             nexusParams << ['pypi.asset': options.distributionFile]
+        } else if (options.repositoryType == 'npm') {
+            nexusParams << ['npm.asset': options.distributionFile]
         }
 
         def data = steps.readFile(file: options.distributionFile, encoding: 'Base64').toString().getBytes()

--- a/src/org/ods/services/NexusService.groovy
+++ b/src/org/ods/services/NexusService.groovy
@@ -146,8 +146,12 @@ class NexusService {
                 new ByteArrayInputStream(artifact),
                 ContentType.create(contentType),
                 nexusParams['pypi.asset'].substring( nexusParams['pypi.asset'].lastIndexOf("/") + 1 ))
-        }
-        else {
+        } else if (repositoryType == 'npm') {
+            restCall = restCall.field("npm.asset",
+                new ByteArrayInputStream(artifact),
+                ContentType.create(contentType),
+                nexusParams['npm.asset']) 
+        } else {
             restCall = restCall.field(
                 repositoryType == 'raw' || repositoryType == 'maven2' ? "${repositoryType}.asset1" : "${repositoryType}.asset",
                 new ByteArrayInputStream(artifact), contentType)

--- a/src/org/ods/services/NexusService.groovy
+++ b/src/org/ods/services/NexusService.groovy
@@ -150,7 +150,7 @@ class NexusService {
             restCall = restCall.field("npm.asset",
                 new ByteArrayInputStream(artifact),
                 ContentType.create(contentType),
-                nexusParams['npm.asset']) 
+                nexusParams['npm.asset'])
         } else {
             restCall = restCall.field(
                 repositoryType == 'raw' || repositoryType == 'maven2' ? "${repositoryType}.asset1" : "${repositoryType}.asset",

--- a/test/groovy/org/ods/services/NexusServiceSpec.groovy
+++ b/test/groovy/org/ods/services/NexusServiceSpec.groovy
@@ -128,6 +128,54 @@ class NexusServiceSpec extends SpecHelper {
         stopServer(server)
     }
 
+    Map storeNpmArtifactRequestData(Map mixins = [:]) {
+        def result = [
+            data: [
+                artifact: [0] as byte[],
+                contentType: "application/octet-stream",
+                name: "package.tgz",
+                repository: "npm-hosted",
+            ],
+            password: "password",
+            path: "/service/rest/v1/components",
+            username: "username"
+        ]
+    
+        result.multipartRequestBody = [
+            "npm.asset": result.data.artifact
+        ]
+    
+        result.queryParams = [
+            "repository": result.data.repository
+        ]
+    
+        return result << mixins
+    }
+    
+    def "store npm artifact"() {
+        given:
+        def request = storeNpmArtifactRequestData()
+        def response = storeArtifactResponseData()
+    
+        def server = createServer(WireMock.&post, request, response)
+        def service = createService(server.port(), "foo-cd-cd-user-with-password")
+    
+        when:
+        def result = service.storeComplextArtifact(
+            request.data.repository,
+            request.data.artifact,
+            request.data.contentType,
+            "npm",
+            ["npm.asset": request.data.name]
+        )
+    
+        then:
+        result == new URIBuilder("http://localhost:${server.port()}/repository/${request.data.repository}").build()
+    
+        cleanup:
+        stopServer(server)
+    }
+
     def "store artifact with HTTP 404 failure"() {
         given:
         def request = storeArtifactRequestData()


### PR DESCRIPTION
Issue caused by missing filename in multipart request.  
Added logic to capture the distribution filename for NPM and pass it in the call to Nexus 
