### PR TITLE
fix: pass helmValues with global prefix in orchestration pipeline as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+* fix helm in orchestration pipeline not adding the helmValues with global prefix like in component pipeline ([#1295]https://github.com/opendevstack/ods-jenkins-shared-library/pull/1295)
 * Fix login/relogin to openshift cluster ([#1294](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1294))
 * Fix OCP Token exposure to ensure it is not shown within logs ([#1288](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1288))
 * Fix error when bug description exceeds 32Kb ([#1292](https://github.com/opendevstack/ods-jenkins-shared-library/pull/1292))

--- a/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
+++ b/src/org/ods/orchestration/phases/DeployOdsComponent.groovy
@@ -190,6 +190,11 @@ class DeployOdsComponent {
                     // take the persisted ones.
                     helmMergedValues << deploymentMean.helmValues
 
+                    // we add the global ones - this allows usage in subcharts
+                    deploymentMean.helmValues.each { key, value ->
+                        helmMergedValues["global.${key}"] = value
+                    }
+
                     // deal with dynamic value files - which are env dependent
                     deploymentMean.helmEnvBasedValuesFiles.each { envValueFile ->
                         helmValuesFiles << envValueFile.replace('.env',


### PR DESCRIPTION
this is needed to allow its usage in subcharts and is exactly the way it is implemented in the component pipeline

See implementation in component pipeline: https://github.com/opendevstack/ods-jenkins-shared-library/blob/aa664571069ea95cffe43d5fda4411a5af97db73/src/org/ods/component/HelmDeploymentStrategy.groovy#L98-L100